### PR TITLE
Allow OU targets in deployment_map.yml that does not contain accounts

### DIFF
--- a/src/pipelines_repository/adf-build/generate_pipelines.py
+++ b/src/pipelines_repository/adf-build/generate_pipelines.py
@@ -113,9 +113,6 @@ def main():
                         raise Exception(
                             "Failed to return accounts for {0}".format(path))
 
-            pipeline.template_dictionary["targets"].append(
-                target_structure.account_list)
-
             if target_structure.account_list:
                 pipeline.template_dictionary["targets"].append(
                     target_structure.account_list

--- a/src/pipelines_repository/adf-build/generate_pipelines.py
+++ b/src/pipelines_repository/adf-build/generate_pipelines.py
@@ -116,6 +116,14 @@ def main():
             pipeline.template_dictionary["targets"].append(
                 target_structure.account_list)
 
+            if target_structure.account_list:
+                pipeline.template_dictionary["targets"].append(
+                    target_structure.account_list
+                )
+
+        if not pipeline.template_dictionary["targets"]:
+            continue
+
         if DEPLOYMENT_ACCOUNT_REGION not in regions:
             pipeline.stage_regions.append(DEPLOYMENT_ACCOUNT_REGION)
 


### PR DESCRIPTION
*Issue #, if available:*
#15 

*Description of changes:*
Changes to pipeline_repository to check if a target provided in deployment_map.yml actually contains accounts. If not it will skip trying to create a CloudFormation stack. This should prevent the failure as described in #15 

I wan't sure how to tackle writing a proper test for this. If you have some guidance or suggestions on this please let me know so I can update the pull request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
