### PR TITLE
Adding in an error handling path for bootstrapping base stacks

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -16,8 +16,6 @@
 - [Pipelines](#pipelines)
   - [Pipeline Parameters](#pipeline-parameters)
   - [Pipeline Types](#pipeline-types)
-  - [Creating Pipeline Templates Locally](#creating-pipeline-templates-locally)
-  - [Creating Pipeline Parameter Files Locally](#creating-pipeline-parameter-files-locally)
 - [Default Deployment Account Region](#default-deployment-account-region)
 - [Integrating Slack](#integrating-slack)
 - [Updating Between Versions](#updating-between-versions)

--- a/src/bootstrap_repository/adf-build/shared/python/stepfunctions.py
+++ b/src/bootstrap_repository/adf-build/shared/python/stepfunctions.py
@@ -24,7 +24,8 @@ class StepFunctions:
             regions,
             account_ids=None,
             full_path=None,
-            update_pipelines_only=0
+            update_pipelines_only=0,
+            error=0
         ):
         self.deployment_account_region = deployment_account_region
         self.client = role.client(
@@ -38,6 +39,7 @@ class StepFunctions:
         self.execution_arn = None
         self.full_path = full_path
         self.execution_status = None
+        self.error = error
 
     def execute_statemachine(self):
         """
@@ -61,6 +63,7 @@ class StepFunctions:
                 "regions": self.regions,
                 "full_path": self.full_path,
                 "update_only": self.update_pipelines_only,
+                "error": self.error
             })
         ).get('executionArn')
 

--- a/src/bootstrap_repository/deployment/global.yml
+++ b/src/bootstrap_repository/deployment/global.yml
@@ -769,53 +769,74 @@ Resources:
       StateMachineName: "EnableCrossAccountAccess"
       DefinitionString: !Sub |-
             {
-              "Comment": "Enable Cross Account Access from Deployment Account",
-              "StartAt": "UpdatePipelinesOnly?",
-              "States": {
-                "UpdatePipelinesOnly?": {
-                  "Type": "Choice",
-                  "Choices": [{
-                    "Variable": "$.update_only",
-                    "NumericEquals": 1,
-                    "Next": "UpdatePipelines"
-                  }],
-                  "Default": "EnableCrossAccountAccess"
-                },
-                "EnableCrossAccountAccess": {
-                  "Type": "Task",
-                  "Resource": "${EnableCrossAccountAccess.Arn}",
-                  "Next": "UpdatePipelines",
-                  "TimeoutSeconds": 60
-                },
-                "UpdatePipelines": {
-                  "Type": "Task",
-                  "Resource": "${CheckPipelineStatus.Arn}",
-                  "TimeoutSeconds": 60,
-                  "Next": "NeedToNotify?"
-                },
-                "NeedToNotify?": {
-                  "Type": "Choice",
-                  "Choices": [{
-                    "Variable": "$.update_only",
-                    "NumericEquals": 1,
-                    "Next": "Success"
-                  }],
-                  "Default": "Notify"
-                },
-                "Success": {
-                  "Type": "Succeed"
-                },
-                "Notify": {
-                  "Type": "Task",
-                  "Resource": "arn:aws:states:::sns:publish",
-                  "Parameters": {
-                    "TopicArn": "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${PipelineSNSTopic.TopicName}",
-                    "Message.$": "$.message",
-                    "Subject": "AWS Deployment Framework Bootstrap"
-                  },
-                  "End": true
-                  }
-              }
+                "Comment": "Enable Cross Account Access from Deployment Account",
+                "StartAt": "DetermineEvent",
+                "States": {
+                    "DetermineEvent": {
+                        "Type": "Choice",
+                        "Choices": [{
+                                "Variable": "$.update_only",
+                                "NumericEquals": 1,
+                                "Next": "UpdateDeploymentPipelines"
+                            },
+                            {
+                                "Not": {
+                                    "Variable": "$.error",
+                                    "NumericEquals": 0
+                                },
+                                "Next": "NotifyFailure"
+                            }
+                        ],
+                        "Default": "EnableCrossAccountAccess"
+                    },
+                    "EnableCrossAccountAccess": {
+                        "Type": "Task",
+                        "Resource": "${EnableCrossAccountAccess.Arn}",
+                        "Next": "UpdateDeploymentPipelines",
+                        "TimeoutSeconds": 60
+                    },
+                    "UpdateDeploymentPipelines": {
+                        "Type": "Task",
+                        "Resource": "${CheckPipelineStatus.Arn}",
+                        "TimeoutSeconds": 60,
+                        "Next": "NeedToNotifySuccess?"
+                    },
+                    "NeedToNotifySuccess?": {
+                        "Type": "Choice",
+                        "Choices": [{
+                            "Variable": "$.update_only",
+                            "NumericEquals": 1,
+                            "Next": "Success"
+                        }],
+                        "Default": "NotifySuccess"
+                    },
+                    "Success": {
+                        "Type": "Succeed"
+                    },
+                    "Failure": {
+                        "Type": "Fail"
+                    },
+                    "NotifySuccess": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:::sns:publish",
+                        "Parameters": {
+                            "TopicArn": "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${PipelineSNSTopic.TopicName}",
+                            "Message.$": "$.message",
+                            "Subject": "Success - AWS Deployment Framework Bootstrap"
+                        },
+                        "Next": "Success"
+                    },
+                    "NotifyFailure": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:::sns:publish",
+                        "Parameters": {
+                            "TopicArn": "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${PipelineSNSTopic.TopicName}",
+                            "Message.$": "$.error",
+                            "Subject": "Failure - AWS Deployment Framework Bootstrap"
+                        },
+                        "Next": "Failure"
+                    }
+                }
             }
       RoleArn: !GetAtt StatesExecutionRole.Arn
 Outputs:

--- a/src/initial/lambda_codebase/account_bootstrap.py
+++ b/src/initial/lambda_codebase/account_bootstrap.py
@@ -13,10 +13,7 @@ import boto3
 
 from logger import configure_logger
 from parameter_store import ParameterStore
-from cache import Cache
-from event import Event
 from cloudformation import CloudFormation
-from organizations import Organizations
 from s3 import S3
 from sts import STS
 
@@ -26,7 +23,7 @@ REGION_DEFAULT = os.environ["AWS_REGION"]
 LOGGER = configure_logger(__name__)
 
 
-def configure_generic_account(sts, parsed_event, region, role):
+def configure_generic_account(sts, event, region, role):
     """
     Fetches the kms_arn from the deployment account main region
     and adds the it plus the deployment_account_id parameter to the
@@ -35,40 +32,40 @@ def configure_generic_account(sts, parsed_event, region, role):
     """
     deployment_role = sts.assume_cross_account_role(
         'arn:aws:iam::{0}:role/{1}'.format(
-            parsed_event.deployment_account_id,
-            parsed_event.cross_account_access_role
+            event['deployment_account_id'],
+            event['cross_account_iam_role']
         ), 'configure_generic'
     )
 
     kms_arn = ParameterStore(
-        parsed_event.deployment_account_region,
+        event['deployment_account_region'],
         deployment_role
     ).fetch_parameter('/cross_region/kms_arn/{0}'.format(region))
     parameters = ParameterStore(region, role)
     parameters.put_parameter('kms_arn', kms_arn)
     parameters.put_parameter(
         'deployment_account_id',
-        parsed_event.deployment_account_id)
+        event['deployment_account_id'])
 
-def update_master_account_parameters(parsed_event, parameter_store):
+def update_master_account_parameters(event, parameter_store):
     """
     Update the Master account parameter store in us-east-1 with the deployment_account_id
     then updates the main deployment region with that same value
     """
-    parameter_store.put_parameter('deployment_account_id', parsed_event.account_id)
-    parameter_store = ParameterStore(parsed_event.deployment_account_region, boto3)
-    parameter_store.put_parameter('deployment_account_id', parsed_event.account_id)
+    parameter_store.put_parameter('deployment_account_id', event['account_id'])
+    parameter_store = ParameterStore(event['deployment_account_region'], boto3)
+    parameter_store.put_parameter('deployment_account_id', event['account_id'])
 
-def configure_deployment_account(parsed_event, role):
+def configure_deployment_account(event, role):
     """
     Applies the Parameters from adfconfig plus other essential
     Parameters to the Deployment Account in each region as defined in
     adfconfig.yml
     """
-    for region in list(set([parsed_event.deployment_account_region] + parsed_event.regions)):
+    for region in list(set([event['deployment_account_region']] + event['regions'])):
         parameters = ParameterStore(region, role)
-        if region == parsed_event.deployment_account_region:
-            for key, value in parsed_event.create_deployment_account_parameters().items():
+        if region == event['deployment_account_region']:
+            for key, value in event['deployment_account_parameters'].items():
                 if value:
                     parameters.put_parameter(
                         key,
@@ -78,51 +75,32 @@ def configure_deployment_account(parsed_event, role):
         parameters.put_parameter('organization_id', os.environ["ORGANIZATION_ID"])
 
 def lambda_handler(event, _):
-    parameters = ParameterStore(REGION_DEFAULT, boto3)
-    account_id = event.get(
-        'detail').get(
-            'requestParameters').get('accountId')
-    organizations = Organizations(boto3, account_id)
-    parsed_event = Event(event, parameters, organizations, account_id)
-    cache = Cache()
-
-    if parsed_event.moved_to_root or parsed_event.moved_to_protected:
-        return parsed_event.create_output_object(cache)
-
-    parsed_event.set_destination_ou_name()
-
     sts = STS(boto3)
     role = sts.assume_cross_account_role(
         'arn:aws:iam::{0}:role/{1}'.format(
-            parsed_event.account_id,
-            parsed_event.cross_account_access_role
+            event["account_id"],
+            event["cross_account_iam_role"]
         ), 'master_lambda'
     )
 
-    if parsed_event.is_deployment_account:
-        update_master_account_parameters(parsed_event, parameters)
-        configure_deployment_account(parsed_event, role)
+    if event['is_deployment_account']:
+        update_master_account_parameters(event, ParameterStore(REGION_DEFAULT, boto3))
+        configure_deployment_account(event, role)
 
     s3 = S3(REGION_DEFAULT, boto3, S3_BUCKET)
 
-    account_path = parsed_event.organizations.build_account_path(
-        parsed_event.destination_ou_id,
-        [],  # Initial empty array to hold OU Path,
-        cache,
-    )
-
-    for region in list(set([parsed_event.deployment_account_region] + parsed_event.regions)):
-        if not parsed_event.is_deployment_account:
-            configure_generic_account(sts, parsed_event, region, role)
+    for region in list(set([event["deployment_account_region"]] + event["regions"])):
+        if not event["is_deployment_account"]:
+            configure_generic_account(sts, event, region, role)
         cloudformation = CloudFormation(
             region=region,
-            deployment_account_region=parsed_event.deployment_account_region,
+            deployment_account_region=event["deployment_account_region"],
             role=role,
             wait=False,
             stack_name=None,
             s3=s3,
-            s3_key_path=account_path
+            s3_key_path=event["full_path"]
         )
         cloudformation.create_stack()
 
-    return parsed_event.create_output_object(cache)
+    return event

--- a/src/initial/lambda_codebase/deployment_account_config.py
+++ b/src/initial/lambda_codebase/deployment_account_config.py
@@ -26,8 +26,8 @@ def lambda_handler(event, _):
     s3 = S3(REGION_DEFAULT, boto3, S3_BUCKET)
 
     cloudformation = CloudFormation(
-        region=event.get('deployment_account_region'),
-        deployment_account_region=event.get('deployment_account_region'),
+        region=event['deployment_account_region'],
+        deployment_account_region=event['deployment_account_region'],
         role=boto3,
         wait=True,
         stack_name=None,

--- a/src/initial/lambda_codebase/determine_event.py
+++ b/src/initial/lambda_codebase/determine_event.py
@@ -1,0 +1,38 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+The Initial event object determination function
+"""
+
+import os
+import boto3
+
+from parameter_store import ParameterStore
+from cache import Cache
+from event import Event
+from organizations import Organizations
+
+REGION_DEFAULT = os.environ["AWS_REGION"]
+
+def lambda_handler(event, _):
+    parameters = ParameterStore(REGION_DEFAULT, boto3)
+    account_id = event.get(
+        'detail').get(
+            'requestParameters').get('accountId')
+    organizations = Organizations(boto3, account_id)
+    parsed_event = Event(event, parameters, organizations, account_id)
+    cache = Cache()
+
+    account_path = "ROOT" if parsed_event.moved_to_root else parsed_event.organizations.build_account_path(
+        parsed_event.destination_ou_id,
+        [],  # Initial empty array to hold OU Path,
+        cache
+    )
+
+    if parsed_event.moved_to_root or parsed_event.moved_to_protected:
+        return parsed_event.create_output_object(account_path)
+
+    parsed_event.set_destination_ou_name()
+
+    return parsed_event.create_output_object(account_path)

--- a/src/initial/lambda_codebase/event.py
+++ b/src/initial/lambda_codebase/event.py
@@ -81,31 +81,13 @@ class Event:
         finally:
             self._determine_if_deployment_account()
 
-    def create_deployment_account_parameters(self):
-        """
-        Fetches Organization information and returns parameters required
-        for the deployment account to function as intended.
-        """
-        organization_information = self.organizations.get_organization_info()
-        return {
-            'deployment_account_id': self.account_id,
-            'cross_account_access_role': self.cross_account_access_role,
-            'organization_id': organization_information.get(
-                "organization_id"
-            ),
-            'master_account_id': organization_information.get(
-                "organization_master_account_id"
-            ),
-            'notification_endpoint': self.main_notification_endpoint,
-            'notification_type': self.notification_type,
-            'deployment_account_bucket': DEPLOYMENT_ACCOUNT_S3_BUCKET
-        }
-
-    def create_output_object(self, cache):
+    def create_output_object(self, account_path):
         """
         Creates the output object to be passed to the next step
         of the Step Function
         """
+        organization_information = self.organizations.get_organization_info()
+
         return {
             'account_id': self.account_id,
             'cross_account_iam_role': self.cross_account_access_role,
@@ -116,9 +98,16 @@ class Event:
             'moved_to_protected': self.moved_to_protected,
             'is_deployment_account': self.is_deployment_account,
             'ou_name': self.destination_ou_name,
-            'full_path': "ROOT" if self.moved_to_root else self.organizations.build_account_path(
-                self.destination_ou_id,
-                [],  # Initial empty array to hold OU Path
-                cache
-            )
+            'full_path': "ROOT" if self.moved_to_root else account_path,
+            'deployment_account_parameters' : {
+                'organization_id': organization_information.get(
+                    "organization_id"
+                ),
+                'master_account_id': organization_information.get(
+                    "organization_master_account_id"
+                ),
+                'notification_endpoint': self.main_notification_endpoint,
+                'notification_type': self.notification_type,
+                'deployment_account_bucket': DEPLOYMENT_ACCOUNT_S3_BUCKET
+            }
         }

--- a/src/initial/lambda_codebase/generic_account_config.py
+++ b/src/initial/lambda_codebase/generic_account_config.py
@@ -25,18 +25,19 @@ def lambda_handler(event, _):
 
     role = sts.assume_cross_account_role(
         'arn:aws:iam::{0}:role/{1}'.format(
-            event.get('deployment_account_id'),
-            event.get('cross_account_iam_role')),
+            event['deployment_account_id'],
+            event['cross_account_iam_role']),
         'step_function')
 
     step_functions = StepFunctions(
         role=role,
-        deployment_account_id=event.get('deployment_account_id'),
-        deployment_account_region=event.get('deployment_account_region'),
-        full_path=event.get('full_path'),
-        regions=event.get('regions'),
-        account_ids=[event.get('account_id')],
-        update_pipelines_only=1 if event.get('moved_to_protected') or event.get('moved_to_root') else 0
+        deployment_account_id=event['deployment_account_id'],
+        deployment_account_region=event['deployment_account_region'],
+        full_path=event['full_path'],
+        regions=event['regions'],
+        account_ids=[event['account_id']],
+        update_pipelines_only=1 if event.get('moved_to_protected') or event.get('moved_to_root') else 0,
+        error=event.get('error', 0)
     )
     step_functions.execute_statemachine()
 

--- a/src/initial/lambda_codebase/tests/test_event.py
+++ b/src/initial/lambda_codebase/tests/test_event.py
@@ -60,13 +60,7 @@ def test_determine_if_deployment_account(cls):
     assert cls.is_deployment_account is 0
 
 
-def test_create_deployment_account_parameters(cls):
-    assertion = cls.create_deployment_account_parameters()
-    assert assertion.get('master_account_id') == '12345678910'
-    assert assertion.get('organization_id') == 'id-123'
-
-
 def test_create_output_object(cls):
-    assertion = cls.create_output_object({})
+    assertion = cls.create_output_object('/test')
     assert assertion.get('account_id') == 111111111111
     assert assertion.get('is_deployment_account') is 0

--- a/src/initial/template.yml
+++ b/src/initial/template.yml
@@ -124,6 +124,25 @@ Resources:
       Role: !GetAtt LambdaRole.Arn
       Runtime: python3.6
       Timeout: 300
+  DetermineEventFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: determine_event.lambda_handler
+      CodeUri: lambda_codebase/
+      Layers:
+          - !Ref LambdaLayerVersion
+      Description: "ADF Lambda Function - DetermineEvent"
+      Environment:
+        Variables:
+          S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
+          TERMINATION_PROTECTION: !Ref TerminationProtection
+          DEPLOYMENT_ACCOUNT_BUCKET: !Ref DeploymentAccountBucket
+          MASTER_ACCOUNT_ID: !Ref AWS::AccountId
+          ORGANIZATION_ID: !Ref OrganizationId
+      FunctionName: DetermineEventFunction
+      Role: !GetAtt LambdaRole.Arn
+      Runtime: python3.6
+      Timeout: 300
   CrossAccountExecuteFunction:
     Type: 'AWS::Serverless::Function'
     Properties:
@@ -441,86 +460,97 @@ Resources:
     Properties:
       DefinitionString: !Sub |-
             {
-              "Comment": "Execute Account provisioning",
-              "StartAt": "AccountBootstrap",
-              "States": {
-                "AccountBootstrap": {
-                  "Type": "Task",
-                  "Resource": "${CrossAccountExecuteFunction.Arn}",
-                  "Next": "MovedToRootOrProtected?",
-                  "TimeoutSeconds": 300
-                },
-                "MovedToRootOrProtected?": {
-                  "Type": "Choice",
-                  "Choices": [{
-                    "Variable": "$.moved_to_protected",
-                    "NumericEquals": 1,
-                    "Next": "UpdatePipelines"
-                  },
-                  {
-                    "Variable": "$.moved_to_root",
-                    "NumericEquals": 1,
-                    "Next": "MovedToRootAction"
-                  }],
-                  "Default": "WaitUntilComplete"
-                },
-                "MovedToRootAction": {
-                  "Type": "Task",
-                  "Resource": "${MovedToRootActionFunction.Arn}",
-                  "Retry": [ {
-                      "ErrorEquals": [ "RetryError" ],
-                      "IntervalSeconds": 10,
-                      "BackoffRate": 1.0,
-                      "MaxAttempts": 20
-                  } ],
-                  "Next": "UpdatePipelines",
-                  "TimeoutSeconds": 900
-                },
-                "UpdatePipelines": {
-                  "Type": "Task",
-                  "Resource": "${UpdateResourcePoliciesFunction.Arn}",
-                  "Retry": [ {
-                      "ErrorEquals": [ "RetryError" ],
-                      "IntervalSeconds": 10,
-                      "BackoffRate": 1.0,
-                      "MaxAttempts": 20
-                  } ],
-                  "End": true
-                },
-                "WaitUntilComplete": {
-                  "Type": "Task",
-                  "Resource": "${StackWaiterFunction.Arn}",
-                  "Retry": [ {
-                      "ErrorEquals": [ "RetryError" ],
-                      "IntervalSeconds": 10,
-                      "BackoffRate": 1.0,
-                      "MaxAttempts": 500
-                  } ],
-                  "Next": "DeploymentAccount?",
-                  "TimeoutSeconds": 900
-                },
-                "DeploymentAccount?": {
-                  "Type": "Choice",
-                  "Choices": [{
-                    "Variable": "$.is_deployment_account",
-                    "NumericEquals": 1,
-                    "Next": "DeploymentAccountConfig"
-                  }],
-                  "Default": "GenericAccountConfig"
-                },
-                "DeploymentAccountConfig": {
-                  "Type": "Task",
-                  "Resource": "${RoleStackDeploymentFunction.Arn}",
-                  "End": true,
-                  "TimeoutSeconds": 900
-                },
-                "GenericAccountConfig": {
-                  "Type": "Task",
-                  "Resource": "${UpdateResourcePoliciesFunction.Arn}",
-                  "End": true,
-                  "TimeoutSeconds": 900
+                "Comment": "ADF Account Bootstrapping Process",
+                "StartAt": "DetermineEvent",
+                "States": {
+                    "DetermineEvent": {
+                        "Type": "Task",
+                        "Resource": "${DetermineEventFunction.Arn}",
+                        "Next": "MovedToRootOrProtected?",
+                        "TimeoutSeconds": 300
+                    },
+                    "MovedToRootOrProtected?": {
+                        "Type": "Choice",
+                        "Choices": [{
+                                "Variable": "$.moved_to_protected",
+                                "NumericEquals": 1,
+                                "Next": "ExecuteDeploymentAccountStateMachine"
+                            },
+                            {
+                                "Variable": "$.moved_to_root",
+                                "NumericEquals": 1,
+                                "Next": "MovedToRootAction"
+                            }
+                        ],
+                        "Default": "CreateOrUpdateBaseStack"
+                    },
+                    "CreateOrUpdateBaseStack": {
+                        "Type": "Task",
+                        "Resource": "${CrossAccountExecuteFunction.Arn}",
+                        "Next": "WaitUntilBootstrapComplete",
+                        "Catch": [{
+                            "ErrorEquals": ["States.ALL"],
+                            "Next": "ExecuteDeploymentAccountStateMachine",
+                            "ResultPath": "$.error"
+                        }],
+                        "TimeoutSeconds": 300
+                    },
+                    "MovedToRootAction": {
+                        "Type": "Task",
+                        "Resource": "${MovedToRootActionFunction.Arn}",
+                        "Retry": [{
+                            "ErrorEquals": ["RetryError"],
+                            "IntervalSeconds": 10,
+                            "BackoffRate": 1.0,
+                            "MaxAttempts": 20
+                        }],
+                        "Catch": [{
+                            "ErrorEquals": ["States.ALL"],
+                            "Next": "ExecuteDeploymentAccountStateMachine",
+                            "ResultPath": "$.error"
+                        }],
+                        "Next": "ExecuteDeploymentAccountStateMachine",
+                        "TimeoutSeconds": 900
+                    },
+                    "WaitUntilBootstrapComplete": {
+                        "Type": "Task",
+                        "Resource": "${StackWaiterFunction.Arn}",
+                        "Retry": [{
+                            "ErrorEquals": ["RetryError"],
+                            "IntervalSeconds": 10,
+                            "BackoffRate": 1.0,
+                            "MaxAttempts": 500
+                        }],
+                        "Catch": [{
+                            "ErrorEquals": ["States.ALL"],
+                            "Next": "ExecuteDeploymentAccountStateMachine",
+                            "ResultPath": "$.error"
+                        }],
+                        "Next": "DeploymentAccount?",
+                        "TimeoutSeconds": 900
+                    },
+                    "DeploymentAccount?": {
+                        "Type": "Choice",
+                        "Choices": [{
+                            "Variable": "$.is_deployment_account",
+                            "NumericEquals": 1,
+                            "Next": "DeploymentAccountConfig"
+                        }],
+                        "Default": "ExecuteDeploymentAccountStateMachine"
+                    },
+                    "DeploymentAccountConfig": {
+                        "Type": "Task",
+                        "Resource": "${RoleStackDeploymentFunction.Arn}",
+                        "End": true,
+                        "TimeoutSeconds": 900
+                    },
+                    "ExecuteDeploymentAccountStateMachine": {
+                        "Type": "Task",
+                        "Resource": "${UpdateResourcePoliciesFunction.Arn}",
+                        "End": true,
+                        "TimeoutSeconds": 900
+                    }
                 }
-              }
             }
       RoleArn: !GetAtt StatesExecutionRole.Arn
 Outputs:


### PR DESCRIPTION
*Description of changes:*

Adding in more detailed error handling for bootstrapping process. Allows for notifications to be sent on failures of bootstrapping stacks and splits up the state machine (in root and deployment account) to be more straight forward and have a more accurate and readable flow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
