### PR TITLE
Updating Slack notification to send error for failing bootstrap stacks

### DIFF
--- a/src/bootstrap_repository/deployment/lambda_codebase/tests/stubs/slack.py
+++ b/src/bootstrap_repository/deployment/lambda_codebase/tests/stubs/slack.py
@@ -66,3 +66,24 @@ stub_failed_pipeline_event = {
         }
     }]
 }
+
+stub_failed_bootstrap_event = {
+    'Records': [{
+        'EventSource': 'aws:sns',
+        'EventVersion': '1.0',
+        'EventSubscriptionArn': 'arn:aws:sns:eu-central-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+        'Sns': {
+            'Type': 'Notification',
+            'MessageId': '1',
+            'TopicArn': 'arn:aws:sns:eu-central-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+            'Subject': 'Failure - AWS Deployment Framework Bootstrap',
+            'Message': '{"Error":"Exception","Cause":"{\\"errorMessage\\": \\"CloudFormation Stack Failed - Account: 111 Region: eu-central-1 Status: ROLLBACK_IN_PROGRESS\\", \\"errorType\\": \\"Exception\\", \\"stackTrace\\": [[\\"/var/task/wait_until_complete.py\\", 99, \\"lambda_handler\\", \\"status))\\"]]}"}',
+            'Timestamp': '2019-03-10T11:09:49.953Z',
+            'SignatureVersion': '1',
+            'Signature': '2',
+            'SigningCertUrl': 'https://sns.eu-central-1.amazonaws.com/SimpleNotificationService',
+            'UnsubscribeUrl': 'https://sns.eu-central-1.amazonaws.com',
+            'MessageAttributes': {}
+        }
+    }]
+}

--- a/src/bootstrap_repository/deployment/lambda_codebase/tests/test_slack.py
+++ b/src/bootstrap_repository/deployment/lambda_codebase/tests/test_slack.py
@@ -5,7 +5,7 @@
 
 from pytest import fixture
 from ..slack import *
-from .stubs.slack import stub_approval_event, stub_failed_pipeline_event, stub_bootstrap_event
+from .stubs.slack import stub_approval_event, stub_failed_pipeline_event, stub_bootstrap_event, stub_failed_bootstrap_event
 
 @fixture
 def stubs():
@@ -56,5 +56,8 @@ def test_create_bootstrap_message_text(stubs):
     assert assertion["channel"] == 'some_channel'
     assert assertion["text"] == ':white_check_mark: Account 1111111 has now been bootstrapped into banking/production'
 
-# def test_send_message(stubs):
-#     pass
+def test_create_bootstrap_message_fail_text(stubs):
+    message = extract_message(stub_failed_bootstrap_event)
+    assertion = create_bootstrap_message_text('some_channel', message)
+    assert assertion["channel"] == 'some_channel'
+    assert assertion["text"] == ':red_circle: CloudFormation Stack Failed - Account: 111 Region: eu-central-1 Status: ROLLBACK_IN_PROGRESS'

--- a/src/initial/lambda_codebase/wait_until_complete.py
+++ b/src/initial/lambda_codebase/wait_until_complete.py
@@ -93,7 +93,7 @@ def lambda_handler(event, _):
                 'ROLLBACK_IN_PROGRESS',
                 'ROLLBACK_COMPLETE'
             ):
-            raise Exception("CloudFormation Stack Failed - Account: {0} Region: {1} Status: {2}".format(
+            raise Exception("Account Bootstrap Failed - Account: {0} Region: {1} Status: {2}".format(
                 event['account_id'],
                 region,
                 status))


### PR DESCRIPTION
*Description of changes:*
Updating the slack notification component to send notifications to slack correct on failed bootstrapping of accounts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
