### PR TITLE
Added cc-buildonly pipeline type

### DIFF
--- a/src/pipelines_repository/adf-build/deployment_map.py
+++ b/src/pipelines_repository/adf-build/deployment_map.py
@@ -63,7 +63,7 @@ class DeploymentMap:
                 for target in pipeline["targets"]:
                     if isinstance(target, dict):
                         # Prescriptive information on the error should be raised
-                        assert target["regions"] and target["path"]
+                        assert target["regions"]
         except KeyError:
             raise InvalidDeploymentMapError(
                 "Deployment Map target or regions specification is invalid"

--- a/src/pipelines_repository/adf-build/target.py
+++ b/src/pipelines_repository/adf-build/target.py
@@ -102,6 +102,9 @@ class Target():
         responses = self.organizations.dir_to_ou(self.path)
         self._create_response_object(responses)
 
+    def _target_is_region_only(self):
+        pass
+
     def fetch_accounts_for_target(self):
         if self.path == 'approval':
             return self._target_is_approval()
@@ -114,5 +117,8 @@ class Target():
 
         if (str(self.path)).startswith('/'):
             return self._target_is_ou_path()
+
+        if self.path is None:
+            return self._target_is_region_only()
 
         raise InvalidDeploymentMapError("Unknown defintion for target: {0}".format(self.path))

--- a/src/pipelines_repository/adf-build/tests/stubs/stub_deployment_map.yml
+++ b/src/pipelines_repository/adf-build/tests/stubs/stub_deployment_map.yml
@@ -27,3 +27,12 @@ pipelines:
       - NotificationEndpoint: my_email@email.com
     targets:
       - 123456789
+
+  - name: buildonly
+    type: cc-buildonly
+    params:
+      - SourceAccountId: 11111233321
+      - NotificationEndpoint: my_email@email.com
+    targets:
+      - regions: eu-west-1
+

--- a/src/pipelines_repository/adf-build/tests/test_deployment_map.py
+++ b/src/pipelines_repository/adf-build/tests/test_deployment_map.py
@@ -32,13 +32,8 @@ def test_validate_deployment_map_invalid_no_content(cls):
     with raises(InvalidDeploymentMapError):
         cls._validate_deployment_map()
 
-def test_validate_deployment_map_invalid_target(cls):
-    cls.map_contents = {"pipelines": [{"targets": [{"path": "/something", "region": 'eu-west-1'}]}]}
-    with raises(InvalidDeploymentMapError):
-        cls._validate_deployment_map()
-
 def test_validate_deployment_map_invalid_regions(cls):
-    cls.map_contents = {"pipelines": [{"targets": [{"regions": 'eu-west-1'}]}]}
+    cls.map_contents = {"pipelines": [{"targets": [{"region": 'eu-west-1'}]}]}
     with raises(InvalidDeploymentMapError):
         cls._validate_deployment_map()
 

--- a/src/pipelines_repository/adf-build/tests/test_deployment_map.py
+++ b/src/pipelines_repository/adf-build/tests/test_deployment_map.py
@@ -37,8 +37,8 @@ def test_validate_deployment_map_invalid_target(cls):
     with raises(InvalidDeploymentMapError):
         cls._validate_deployment_map()
 
-def test_validate_deployment_map_invalid_paths(cls):
-    cls.map_contents = {"pipelines": [{"targets": [{"paths": "/something", "regions": 'eu-west-1'}]}]}
+def test_validate_deployment_map_invalid_regions(cls):
+    cls.map_contents = {"pipelines": [{"targets": [{"regions": 'eu-west-1'}]}]}
     with raises(InvalidDeploymentMapError):
         cls._validate_deployment_map()
 

--- a/src/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
+++ b/src/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
@@ -1,0 +1,185 @@
+WSTemplateFormatVersion: '2010-09-09'
+Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and CloudFormation Deployment Target
+Parameters:
+  ProjectName:
+    Description: Name of the Project (This is automatically passed in by ADF)
+    Type: String
+  StackPrefix:
+    Description: Prefix to prepend to the stackname when deployed
+    Type: String
+    Default: adf
+  Image:
+    Description: The Image for CodeBuild to use
+    Type: String
+    Default: "aws/codebuild/python:3.7.1"
+  NotificationEndpoint:
+    Description: The Email Address / Slack channel notifications will go to for changes related to this pipeline
+    Type: String
+    Default: ''
+  ComputeType:
+    Description: The ComputeType for CodeBuild
+    Type: String
+    Default: "BUILD_GENERAL1_SMALL"
+  SourceAccountId:
+    Description: The ID of the Source Account that will hold the CodeCommit Repo
+    Type: String
+  BranchName:
+    Description: Name of the CodeCommit Branch you will use to trigger the pipeline
+    Type: String
+    Default: master
+  RestartExecutionOnUpdate:
+    Description: If the pipeline will automatically trigger based on update
+    Type: String
+    Default: False
+{% for region in regions %}
+  S3Bucket{{ region|replace("-", "") }}:
+    Description: The S3 Bucket for Cross region deployment for {{ region }}
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /cross_region/s3_regional_bucket/{{ region }}
+  KMSKey{{ region|replace("-", "") }}:
+    Description: The KMSKey Arn for Cross region deployment for {{ region }}
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /cross_region/kms_arn/{{ region }}
+{% endfor %}
+Resources:
+  BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "adf-build-${ProjectName}"
+      Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
+      EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
+      ServiceRole: !ImportValue CodeBuildRoleArn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: linuxContainer
+        ComputeType: !Ref ComputeType
+        Image: !Ref Image
+        EnvironmentVariables:
+          - Name: PROJECT_NAME
+            Value: !Ref ProjectName
+          - Name: S3_BUCKET_NAME
+            Value: !ImportValue S3Bucket-{{ deployment_account_region }}
+          - Name: ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+      Source:
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 20
+      Tags:
+        - Key: Name
+          Value: !Ref ProjectName
+{% if notification_endpoint %}
+  PipelineEventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Description: "Trigger notifications based on pipeline state changes"
+      EventPattern:
+        source:
+          - "aws.codepipeline"
+        detail-type:
+          - "CodePipeline Pipeline Execution State Change"
+        detail:
+          state:
+            - "FAILED"
+            - "SUCCEEDED"
+          pipeline:
+            - !Ref Pipeline
+      State: "ENABLED"
+      Targets:
+        - Arn: !Ref PipelineSNSTopic
+          Id: !Sub "${AWS::StackName}-pipeline"
+{% if "@" in notification_endpoint %}
+          InputTransformer:
+            InputTemplate: '"The pipeline <pipeline> from account <account> has <state> at <at>."'
+            InputPathsMap:
+              pipeline: "$.detail.pipeline"
+              state: "$.detail.state"
+              at: "$.time"
+              account: "$.account"
+{% endif %}
+  PipelineSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+{% if "@" in notification_endpoint %}
+        - Endpoint: !Ref NotificationEndpoint
+          Protocol: email
+{% else %}
+        - Endpoint: !ImportValue SendSlackNotificationLambdaArn
+          Protocol: lambda
+{% endif %}
+  PipelineSNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Id: !Sub "${AWS::StackName}"
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - events.amazonaws.com
+              - codecommit.amazonaws.com
+              - sns.amazonaws.com
+          Action: sns:Publish
+          Resource: "*"
+      Topics:
+      - !Ref PipelineSNSTopic
+  LambdaInvokePermission: 
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref PipelineSNSTopic
+      FunctionName: 'SendSlackNotification'
+{% endif %}
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn: !ImportValue CodePipelineRoleArn
+      Name: !Ref AWS::StackName
+      RestartExecutionOnUpdate: !Ref RestartExecutionOnUpdate
+      Stages:
+        - Name: !Sub Source-${SourceAccountId}
+          Actions:
+            - Name: CodeCommit
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: 1
+                Provider: CodeCommit
+              Configuration:
+                RepositoryName: !Ref ProjectName
+                BranchName: !Ref BranchName
+              OutputArtifacts:
+                - Name: TemplateSource
+              RunOrder: 1
+              RoleArn: !Sub "arn:aws:iam::${SourceAccountId}:role/adf-codecommit-role" #Source Account
+        - Name: Build
+          Actions:
+          - Name: Build
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Sub "adf-build-${ProjectName}"
+            RunOrder: 1
+            InputArtifacts:
+              - Name: TemplateSource
+            OutputArtifacts:
+              - Name: !Sub "${ProjectName}-build"
+      ArtifactStores:
+{% for region in regions %}
+        - Region: {{ region }}
+          ArtifactStore:
+            EncryptionKey:
+              Id: !Ref KMSKey{{ region|replace("-", "") }}
+              Type: KMS
+            Location: !Ref S3Bucket{{ region|replace("-", "") }}
+            Type: S3
+{% endfor %}
+Outputs:
+  PipelineUrl:
+    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}


### PR DESCRIPTION
*Issue #27

*Description of changes:*
Added new cc-buildonly pipeline type template. When using this template the pipeline will only contain the build stage. The cc-buildonly.yml.j2 template is based on the cc-cloudformation.yml.j2 template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
