### PR TITLE
fix reqs security alert -> jinja2 2.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ mock==2.0.0
 boto3~=1.9, >=1.9.56
 pyyaml>=4.2b1
 astroid==2.1.0
-jinja2==2.10
+jinja2>=2.10.1

--- a/src/bootstrap_repository/adf-build/requirements.txt
+++ b/src/bootstrap_repository/adf-build/requirements.txt
@@ -5,4 +5,4 @@ pytest==3.0.7
 mock==2.0.0
 pyyaml>=4.2b1
 astroid==2.1.0
-jinja2==2.10
+jinja2>=2.10.1

--- a/src/pipelines_repository/adf-build/requirements.txt
+++ b/src/pipelines_repository/adf-build/requirements.txt
@@ -3,4 +3,4 @@ pytest==3.0.7
 mock==2.0.0
 boto3==1.9.89
 pyyaml>=4.2b1
-jinja2==2.10
+jinja2>=2.10.1


### PR DESCRIPTION
*Description of changes:*

fix reqs security alert -> 2.10.1, str.format_map allows a sandbox escape.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
