### PR TITLE
Adding in a Build Only style pipeline

### DIFF
--- a/src/pipelines_repository/adf-build/generate_pipelines.py
+++ b/src/pipelines_repository/adf-build/generate_pipelines.py
@@ -107,7 +107,7 @@ def main(): #pylint: disable=R0915
     for p in deployment_map.map_contents.get('pipelines'):
         pipeline = Pipeline(p)
 
-        for target in p['targets']:
+        for target in p.get('targets', []):
             target_structure = TargetStructure(target)
             for step in target_structure.target:
                 for path in step.get('path'):

--- a/src/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
+++ b/src/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
@@ -1,5 +1,5 @@
-WSTemplateFormatVersion: '2010-09-09'
-Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and CloudFormation Deployment Target
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and CodeBuild (No Deployment Steps)
 Parameters:
   ProjectName:
     Description: Name of the Project (This is automatically passed in by ADF)
@@ -31,16 +31,14 @@ Parameters:
     Description: If the pipeline will automatically trigger based on update
     Type: String
     Default: False
-{% for region in regions %}
-  S3Bucket{{ region|replace("-", "") }}:
-    Description: The S3 Bucket for Cross region deployment for {{ region }}
+  S3Bucket{{ deployment_account_region|replace("-", "") }}:
+    Description: The S3 Bucket for Cross region deployment for {{ deployment_account_region }}
     Type: AWS::SSM::Parameter::Value<String>
-    Default: /cross_region/s3_regional_bucket/{{ region }}
-  KMSKey{{ region|replace("-", "") }}:
-    Description: The KMSKey Arn for Cross region deployment for {{ region }}
+    Default: /cross_region/s3_regional_bucket/{{ deployment_account_region }}
+  KMSKey{{ deployment_account_region|replace("-", "") }}:
+    Description: The KMSKey Arn for Cross region deployment for {{ deployment_account_region }}
     Type: AWS::SSM::Parameter::Value<String>
-    Default: /cross_region/kms_arn/{{ region }}
-{% endfor %}
+    Default: /cross_region/kms_arn/{{ deployment_account_region }}
 Resources:
   BuildProject:
     Type: AWS::CodeBuild::Project
@@ -168,18 +166,14 @@ Resources:
             RunOrder: 1
             InputArtifacts:
               - Name: TemplateSource
-            OutputArtifacts:
-              - Name: !Sub "${ProjectName}-build"
       ArtifactStores:
-{% for region in regions %}
-        - Region: {{ region }}
+        - Region: {{ deployment_account_region }}
           ArtifactStore:
             EncryptionKey:
-              Id: !Ref KMSKey{{ region|replace("-", "") }}
+              Id: !Ref KMSKey{{ deployment_account_region|replace("-", "") }}
               Type: KMS
-            Location: !Ref S3Bucket{{ region|replace("-", "") }}
+            Location: !Ref S3Bucket{{ deployment_account_region|replace("-", "") }}
             Type: S3
-{% endfor %}
 Outputs:
   PipelineUrl:
     Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}


### PR DESCRIPTION
*Issue #, if available:*
#27 Allowing a build only pipeline - This PR builds on #31

*Description of changes:*
Allows for targets to be optional in the deployment map and returns an empty array from generate_pipelines if it is omitted. Creating a new pipeline type *cc-buildonly.yml.j2* (thanks @thiezn)

With this change you can now construct a pipeline like:

```
  - name: my-build
    type: cc-buildonly
    params:
      - SourceAccountId: 12345678910
```

If you wanted to access resources cross region you would do so in your code that is executed within CodeBuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
