### PR TITLE
slight fix on deployment_map.py to allow empty targets

### DIFF
--- a/src/pipelines_repository/adf-build/deployment_map.py
+++ b/src/pipelines_repository/adf-build/deployment_map.py
@@ -60,7 +60,7 @@ class DeploymentMap:
         """
         try:
             for pipeline in self.map_contents["pipelines"]:
-                for target in pipeline["targets"]:
+                for target in pipeline.get("targets", []):
                     if isinstance(target, dict):
                         # Prescriptive information on the error should be raised
                         assert target["regions"] and target["path"]

--- a/src/pipelines_repository/adf-build/tests/stubs/stub_deployment_map.yml
+++ b/src/pipelines_repository/adf-build/tests/stubs/stub_deployment_map.yml
@@ -27,3 +27,8 @@ pipelines:
       - NotificationEndpoint: my_email@email.com
     targets:
       - 123456789
+
+  - name: my-build
+    type: cc-buildonly
+    params:
+      - SourceAccountId: 123456789101


### PR DESCRIPTION
*Issue #, if available:*
#31 

*Description of changes:*
Fixing slight issue with optional targets key in deployment_map

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
