### PR TITLE
fixing bug in event.py when setting up adf from scratch

### DIFF
--- a/src/bootstrap_repository/adf-build/main.py
+++ b/src/bootstrap_repository/adf-build/main.py
@@ -241,7 +241,7 @@ def main():
 
         threads = []
         account_ids = organizations.get_account_ids()
-        for account_id in account_ids:
+        for account_id in [account for account in account_ids if account != deployment_account_id]:
             t = PropagatingThread(target=worker_thread, args=(
                 account_id,
                 sts,
@@ -260,7 +260,7 @@ def main():
             deployment_account_id=deployment_account_id,
             deployment_account_region=config.deployment_account_region,
             regions=config.target_regions,
-            account_ids=[i for i in account_ids if i != config.deployment_account_region],
+            account_ids=account_ids,
             update_pipelines_only=0
         )
 

--- a/src/initial/lambda_codebase/account_bootstrap.py
+++ b/src/initial/lambda_codebase/account_bootstrap.py
@@ -72,8 +72,6 @@ def configure_deployment_account(event, role):
                         value
                     )
 
-        parameters.put_parameter('organization_id', os.environ["ORGANIZATION_ID"])
-
 def lambda_handler(event, _):
     sts = STS(boto3)
     role = sts.assume_cross_account_role(

--- a/src/initial/lambda_codebase/event.py
+++ b/src/initial/lambda_codebase/event.py
@@ -108,6 +108,7 @@ class Event:
                 ),
                 'notification_endpoint': self.main_notification_endpoint,
                 'notification_type': self.notification_type,
+                'cross_account_iam_role': self.cross_account_access_role,
                 'deployment_account_bucket': DEPLOYMENT_ACCOUNT_S3_BUCKET
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing issue that was not adding 'cross_account_iam_role' to the deployment account when setting up ADF from scratch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
