### PR TITLE
Fixing support for Transforms when using the replace_on_failure option

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,6 +42,7 @@ pipelines:
   - name: vpc
     type: github-cloudformation
     regions: [ eu-west-1, eu-central-1 ]
+    replace_on_failure: true
     params:
       - SourceAccountId: 8888877777777
       - NotificationEndpoint: channel1

--- a/src/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
+++ b/src/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
@@ -206,7 +206,7 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
-                Capabilities: CAPABILITY_NAMED_IAM
+                Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
                 {% if stage.imports  %}
                 ParameterOverrides: !Sub | 

--- a/src/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
+++ b/src/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
@@ -232,7 +232,7 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
-                Capabilities: CAPABILITY_NAMED_IAM
+                Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
                 {% if stage.imports  %}
                 ParameterOverrides: !Sub | 


### PR DESCRIPTION
*Description of changes:*

While trying out the `replace_on_failure` option I noticed that the current pipeline types do not support the `CAPABILITY_AUTO_EXPAND` capability which is required when creating a stack that contains Transforms such as SAM.

I have added this capability to both cloudformation pipeline types as well as including an example of the usage of `replace_on_failure` parameter into the user-guide.md file.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
