### PR TITLE
Increasing the power and timeout of the EnableCrossAccount Lambda

### DIFF
--- a/src/bootstrap_repository/deployment/global.yml
+++ b/src/bootstrap_repository/deployment/global.yml
@@ -639,6 +639,7 @@ Resources:
       Layers:
           - !Ref LambdaLayerVersion
       Description: "ADF Lambda Function - EnableCrossAccountAccess"
+      MemorySize: 1024
       Environment:
         Variables:
           KMS_KEY_ID: !Ref KMSKey
@@ -647,7 +648,7 @@ Resources:
       Handler: enable_cross_account_access.lambda_handler
       Role: !GetAtt LambdaRole.Arn
       Runtime: python3.6
-      Timeout: 300
+      Timeout: 900
   CheckPipelineStatus:
     Type: "AWS::Serverless::Function"
     Properties: 
@@ -795,7 +796,7 @@ Resources:
                         "Type": "Task",
                         "Resource": "${EnableCrossAccountAccess.Arn}",
                         "Next": "UpdateDeploymentPipelines",
-                        "TimeoutSeconds": 60
+                        "TimeoutSeconds": 900
                     },
                     "UpdateDeploymentPipelines": {
                         "Type": "Task",


### PR DESCRIPTION
*Description of changes:*

When working with more than 30 AWS Accounts in two regions the Lambda function on the Deployment Account *(EnableCrossAccountAccess)* can become slowed down as it updates/syncs policies across many accounts and regions and can ultimately timeout. This change takes it from 55 seconds execution time to 5 seconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
