### PR TITLE
updated docs to include minimum AWS CLI version required

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -34,7 +34,7 @@
 
 ## Pre-Requisites
 
-- [awscli](https://aws.amazon.com/cli/)
+- [awscli](https://aws.amazon.com/cli/) version 1.16.147 or up
 - [git](https://git-scm.com/)
   - [AWS CodeCommit Setup](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html) 
 - [AWS CloudTrail configured](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-create-and-update-a-trail.html) in the AWS Organizations Master account.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I have made a minor change to the docs to include a minimum version number for the AWS CLI. With older versions the cloudformation package and deploy commands fail due to the lack of Lambda layer support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
