### PR TITLE
Adding support for multi-region transform templates

### DIFF
--- a/src/pipelines_repository/adf-build/helpers/package_lambda.sh
+++ b/src/pipelines_repository/adf-build/helpers/package_lambda.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e # Exit on Error
+
+######
+#
+# This script will package all source code and send it to an S3 bucket in each region
+# where the lambda needs to be deployed to.
+#
+# PROJECT_NAME is an environment variable that is passed to the CodeBuild Project
+# CODEBUILD_SRC_DIR is an environment variable provided by CodeBuild
+#
+######
+
+# Get list of regions supported by this application
+app_regions=`aws ssm get-parameters --names /deployment/$PROJECT_NAME/regions --with-decryption --output=text --query='Parameters[0].Value'`
+# Convert json list to bash list (space delimited regions)
+regions="`echo $app_regions | sed  -e 's/\[\([^]]*\)\]/\1/g' | sed 's/,/ /g' | sed "s/'//g"`"
+
+# Loop through regions
+for region in $regions
+do
+    # Check if the package command actually needs to be run, only needed if there is a Transform
+    if grep -q Transform: "$CODEBUILD_SRC_DIR/template.yml"; then
+        ssm_bucket_name="/cross_region/s3_regional_bucket/$region"
+        bucket=`aws ssm get-parameters --names $ssm_bucket_name --with-decryption --output=text --query='Parameters[0].Value'`
+
+        aws cloudformation package --template-file $CODEBUILD_SRC_DIR/template.yml --output-template-file $CODEBUILD_SRC_DIR/template_$region.yml --s3-prefix $PROJECT_NAME --s3-bucket $bucket
+    else
+        # If package is not needed, just copy the file for each region
+        cp $CODEBUILD_SRC_DIR/template.yml $CODEBUILD_SRC_DIR/template_$region.yml
+    fi
+done

--- a/src/pipelines_repository/adf-build/pipeline.py
+++ b/src/pipelines_repository/adf-build/pipeline.py
@@ -22,6 +22,7 @@ class Pipeline:
         self.pipeline_type = pipeline.get('type', None)
         self.replace_on_failure = pipeline.get('replace_on_failure', '') # Legacy, and will be replaced in 1.0.0 in favour of below 'action'
         self.action = pipeline.get('action', '').upper()
+        self.contains_transform = pipeline.get('contains_transform', '')
 
         if not isinstance(self.top_level_regions, list):
             self.top_level_regions = [self.top_level_regions]
@@ -80,7 +81,8 @@ class Pipeline:
             top_level_regions=sorted(self.flatten_list(list(set(self.top_level_regions)))),
             regions=sorted(list(set(self.flatten_list(self.stage_regions)))),
             deployment_account_region=DEPLOYMENT_ACCOUNT_REGION,
-            action=self.action or self.replace_on_failure
+            action=self.action or self.replace_on_failure,
+            contains_transform=self.contains_transform
         )
 
         self._create_pipelines_folder()

--- a/src/pipelines_repository/adf-build/tests/test_pipeline.py
+++ b/src/pipelines_repository/adf-build/tests/test_pipeline.py
@@ -32,6 +32,7 @@ def test_flatten_list():
 def test_pipeline_init_defaults(cls):
     assert cls.action == ''
     assert cls.notification_endpoint is None
+    assert cls.contains_transform == ''
 
 
 def test_pipeline_replace_on_failure():
@@ -45,6 +46,19 @@ def test_pipeline_replace_on_failure():
         }
     )
     assert assertion_pipeline.action == "REPLACE_ON_FAILURE"
+
+
+def test_pipeline_contains_transform():
+    assertion_pipeline = Pipeline(
+        pipeline={
+        "name": "pipeline",
+        "params": [{"key": "value"}],
+        "targets": [],
+        "type": "cc-cloudformation",
+        "contains_transform": "true"
+        }
+    )
+    assert assertion_pipeline.contains_transform == "true"
 
 def test_generate_parameters(cls):
     parameters = cls.generate_parameters()

--- a/src/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
+++ b/src/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
@@ -204,7 +204,11 @@ Resources:
                 OutputFileName: !Sub "${AWS::AccountId}-${StackPrefix}-${ProjectName}-{{ region }}.json"
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
+{% if contains_transform %}
+                TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
+{% else %}
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
+{% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
@@ -224,7 +228,11 @@ Resources:
                 ActionMode: CHANGE_SET_REPLACE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
+{% if contains_transform %}
+                TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
+{% else %}
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
+{% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
@@ -262,7 +270,11 @@ Resources:
                 ActionMode: CHANGE_SET_REPLACE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
+{% if contains_transform %}
+                TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
+{% else %}
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
+{% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ top_level_region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"

--- a/src/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
+++ b/src/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
@@ -230,7 +230,11 @@ Resources:
                 OutputFileName: !Sub "${AWS::AccountId}-${StackPrefix}-${ProjectName}-{{ region }}.json"
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
+{% if contains_transform %}
+                TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
+{% else %}
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
+{% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
@@ -250,7 +254,11 @@ Resources:
                 ActionMode: CHANGE_SET_REPLACE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
+{% if contains_transform %}
+                TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
+{% else %}
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
+{% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
@@ -288,7 +296,11 @@ Resources:
                 ActionMode: CHANGE_SET_REPLACE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
+{% if contains_transform %}
+                TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
+{% else %}
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
+{% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ top_level_region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
                 RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"


### PR DESCRIPTION
*Description of changes:*

When deploying a template that contains a transform such as a Serverless Transform the samples state to use the `aws cloudformation package` command to package the lambda source code and upload it to S3. Unfortunately this will only work if the template is being deployed to a single region, as the subsequent pipeline stages will accept a single template.yml.

This change allows the user to specify a template as containing a transform, in which case the pipeline deploy stage will expect a region specific template.yml. This region specific template.yml can then be created as part of the buildspec by executing the package command for each region.

To simplify the above process of packaging for each region a helper script has also been added which loops through all regions where the particular pipeline has been configured to deploy to and runs the `aws cloudformation package` against that region.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
