### PR TITLE
Added support for sub deployment_map files

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
@@ -6,6 +6,7 @@ Module used for working with the Deployment Map (yml) file.
 """
 
 import yaml
+import os
 
 from errors import InvalidDeploymentMapError
 from logger import configure_logger
@@ -20,8 +21,10 @@ class DeploymentMap:
             map_path=None
     ):
         self.map_path = map_path or 'deployment_map.yml'
+        self.map_dir_path = map_path or 'deployment_map'
         self.parameter_store = parameter_store
-        self.map_contents = self._get_deployment_map()
+        self.map_contents = self._get_deployment_map(self.map_path)
+        self.map_contents = self._get_deployment_apps_from_dir()
         self.pipeline_name_prefix = pipeline_name_prefix
         self.account_ou_names = {}
         self._validate_deployment_map()
@@ -47,9 +50,10 @@ class DeploymentMap:
                 str(pipeline.notification_endpoint)
             )
 
-    def _get_deployment_map(self):
+    def _get_deployment_map(self, file_path):
         try:
-            with open(self.map_path, 'r') as stream:
+            LOGGER.info('Load deployment_map file {}'.format(file_path))
+            with open(file_path, 'r') as stream:
                 return yaml.load(stream, Loader=yaml.FullLoader)
         except FileNotFoundError:
             LOGGER.error('Cannot Create Deployment Pipelines as there '
@@ -57,6 +61,17 @@ class DeploymentMap:
                          'If this is your first time using ADF please see read the user guide'
                          , exc_info=True)
 
+    def _get_deployment_apps_from_dir(self):
+        if os.path.isdir(self.map_dir_path):
+            for file in os.listdir(self.map_dir_path):
+                if file.endswith(".yml"): 
+                    deployment_map = self._get_deployment_map('{}/{}'.format(self.map_dir_path,file))
+                    if 'pipelines' not in self.map_contents:
+                        self.map_contents['pipelines'] = []
+                    if 'pipelines' in deployment_map:
+                        self.map_contents['pipelines'].extend(deployment_map['pipelines'])
+        return self.map_contents
+        
     def _validate_deployment_map(self):
         """
         Validates the deployment map contains valid configuration

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
@@ -65,7 +65,7 @@ class DeploymentMap:
         if os.path.isdir(self.map_dir_path):
             for file in os.listdir(self.map_dir_path):
                 if file.endswith(".yml"): 
-                    deployment_map = self._get_deployment_map('{}/{}'.format(self.map_dir_path,file))
+                    deployment_map = self._get_deployment_map('{}/{}'.format(self.map_dir_path, file))
                     if 'pipelines' not in self.map_contents:
                         self.map_contents['pipelines'] = []
                     if 'pipelines' in deployment_map:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
@@ -23,7 +23,7 @@ class DeploymentMap:
         self.map_path = map_path or 'deployment_map.yml'
         self.map_dir_path = map_path or 'deployment_map'
         self.parameter_store = parameter_store
-        self.map_contents = self._get_deployment_map(self.map_path)
+        self.map_contents = self._get_deployment_map()
         self.map_contents = self._get_deployment_apps_from_dir()
         self.pipeline_name_prefix = pipeline_name_prefix
         self.account_ou_names = {}
@@ -50,7 +50,9 @@ class DeploymentMap:
                 str(pipeline.notification_endpoint)
             )
 
-    def _get_deployment_map(self, file_path):
+    def _get_deployment_map(self, file_path=None):
+        if file_path is None:
+            file_path = self.map_path
         try:
             LOGGER.info('Load deployment_map file %s', file_path)
             with open(file_path, 'r') as stream:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
@@ -52,7 +52,7 @@ class DeploymentMap:
 
     def _get_deployment_map(self, file_path):
         try:
-            LOGGER.info('Load deployment_map file {}'.format(file_path))
+            LOGGER.info('Load deployment_map file %s', file_path)
             with open(file_path, 'r') as stream:
                 return yaml.load(stream, Loader=yaml.FullLoader)
         except FileNotFoundError:
@@ -64,14 +64,14 @@ class DeploymentMap:
     def _get_deployment_apps_from_dir(self):
         if os.path.isdir(self.map_dir_path):
             for file in os.listdir(self.map_dir_path):
-                if file.endswith(".yml"): 
+                if file.endswith(".yml"):
                     deployment_map = self._get_deployment_map('{}/{}'.format(self.map_dir_path, file))
                     if 'pipelines' not in self.map_contents:
                         self.map_contents['pipelines'] = []
                     if 'pipelines' in deployment_map:
                         self.map_contents['pipelines'].extend(deployment_map['pipelines'])
         return self.map_contents
-        
+
     def _validate_deployment_map(self):
         """
         Validates the deployment map contains valid configuration

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
@@ -21,7 +21,7 @@ class DeploymentMap:
             map_path=None
     ):
         self.map_path = map_path or 'deployment_map.yml'
-        self.map_dir_path = map_path or 'deployment_map'
+        self.map_dir_path = map_path or 'deployment_maps'
         self.parameter_store = parameter_store
         self.map_contents = self._get_deployment_map()
         self.map_contents = self._get_deployment_apps_from_dir()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
@@ -5,8 +5,8 @@
 Module used for working with the Deployment Map (yml) file.
 """
 
-import yaml
 import os
+import yaml
 
 from errors import InvalidDeploymentMapError
 from logger import configure_logger


### PR DESCRIPTION
*Issue #78:*

*Description of changes:* Added support for loading deployment_map files form a deployment_map dir.

The code loads deployment_map.yml then if there is a deployment_map dir and it has content it loads any yml files in there. The deployment_map/*.yml follow the exact same format as the deployment_map.yml. The loaded subfiles are merged with the pipelines list of the deployment_map.yml. If there was not deployment_map.yml it creates an empty pipelines array that it subsquently fills with content from subfiles. 

Example 1.
```
RihaDevTeam:~/environment/adf/deploy/aws-deployment-framework-pipelines (master) $ ls
adf-build  deployment_map  deployment_map.yml  pipeline_types  pytest.ini
RihaDevTeam:~/environment/adf/deploy/aws-deployment-framework-pipelines (master) $ 
RihaDevTeam:~/environment/adf/deploy/aws-deployment-framework-pipelines (master) $ ls deployment_map
example-lib-python.yml       example-service-authentication.yml
example-service-dynamo.yml   example-service-dynamo.yml
```

Example 2.
```
RihaDevTeam:~/environment/adf/deploy/aws-deployment-framework-pipelines (master) $ ls
adf-build  deployment_map  deployment_map.yml  pipeline_types  pytest.ini
RihaDevTeam:~/environment/adf/deploy/aws-deployment-framework-pipelines (master) $ 
RihaDevTeam:~/environment/adf/deploy/aws-deployment-framework-pipelines (master) $ ls deployment_map
team-alpha.yml             team-beta.yml
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
