### PR TITLE
Add adf-codecommit-role to deployment account

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/global.yml
@@ -133,7 +133,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Ref AWS::AccountId
+              AWS: !GetAtt CodePipelineRole.Arn
             Action:
               - sts:AssumeRole
           - Effect: Allow

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/global.yml
@@ -124,6 +124,59 @@ Resources:
         ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
+  CodeCommitRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "adf-codecommit-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Ref AWS::AccountId
+            Action:
+              - sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+  CodeCommitPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "adf-codecommit-role-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "codecommit:BatchGetRepositories"
+              - "codecommit:CancelUploadArchive"
+              - "codecommit:Get*"
+              - "codecommit:GitPull"
+              - "codecommit:List*"
+              - "codecommit:UploadArchive"
+              - "codepipeline:StartPipelineExecution"
+              - "events:PutEvents"
+              - "s3:Get*"
+              - "s3:List*"
+              - "s3:Put*"
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - "kms:Decrypt"
+              - "kms:Describe*"
+              - "kms:DescribeKey"
+              - "kms:Encrypt"
+              - "kms:GenerateDataKey*"
+              - "kms:Get*"
+              - "kms:List*"
+              - "kms:ReEncrypt*"
+            Resource: !GetAtt KMSKey.Arn
+      Roles:
+        - !Ref CodeCommitRole
   CodeBuildRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
*Description of changes:*
Add the `adf-codecommit-role` to the deployment account bootstrap template so that code repositories can also be stored in the deployment account. Currently the creation of pipelines fails when the codecommit repo is located in the deployment account.

deployment_map.yml:
```
pipelines:
  - name: sample-vpc  # The name of your pipeline (This will match the name of your repository)
    type: cc-cloudformation  # The pipeline_type you wish to use for this pipeline
    params:
      - SourceAccountId: 1111111111111  # The source account that will hold the codebase
pipeline
    targets:  # Deployment stages
      - /marketing/non-prod
```
Error in cloudformation template deployment:
```
arn:aws:iam::1111111111111:role/adf-codepipeline-role is not authorized to perform AssumeRole on role arn:aws:iam::2222222222:role/adf-codecommit-role (Service: AWSCodePipeline; Status Code: 400; Error Code: InvalidStructureException; Request ID: 99030bbe-56c4-46b1-aed7-d46c2c94e4f4)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
