### PR TITLE
v1.1.0

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_main.py
@@ -71,6 +71,7 @@ def test_update_deployment_account_output_parameters(cls, sts):
             deployment_account_region='eu-central-1',
             region='eu-central-1',
             deployment_account_role=sts,
+            kms_dict={},
             cloudformation=cloudformation
         )
         assert 4 == mock.call_count

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/initial_commit.py
@@ -162,6 +162,9 @@ def update_(event: Mapping[str, Any], _context: Any) -> Tuple[PhysicalResourceId
         commitId=commit_id
     )
     try:
+        puts = [f.as_dict() for f in files_to_commit]
+        deletes = [f.as_dict() for f in files_to_delete]
+
         CC_CLIENT.create_commit(
             repositoryName=repo_name,
             branchName=update_event.ResourceProperties.Version,
@@ -169,8 +172,8 @@ def update_(event: Mapping[str, Any], _context: Any) -> Tuple[PhysicalResourceId
             authorName='ADF Update PR',
             email='adf-builders@amazon.com',
             commitMessage='ADF {0} Automated Update PR'.format(update_event.ResourceProperties.Version),
-            putFiles=[f.as_dict() for f in files_to_commit],
-            deleteFiles=[f.as_dict() for f in files_to_delete]
+            putFiles=puts,
+            deleteFiles=deletes
         )
         CC_CLIENT.create_pull_request(
             title='ADF {0} Automated Update PR'.format(update_event.ResourceProperties.Version),
@@ -184,7 +187,6 @@ def update_(event: Mapping[str, Any], _context: Any) -> Tuple[PhysicalResourceId
             ]
         )
     except (CC_CLIENT.exceptions.FileEntryRequiredException, CC_CLIENT.exceptions.NoChangeException):
-        print("No changes require commiting")
         CC_CLIENT.delete_branch(
             repositoryName=repo_name,
             branchName=update_event.ResourceProperties.Version

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/deployment_map.py
@@ -54,7 +54,7 @@ class DeploymentMap:
         if file_path is None:
             file_path = self.map_path
         try:
-            LOGGER.info('Load deployment_map file %s', file_path)
+            LOGGER.info('Loading deployment_map file %s', file_path)
             with open(file_path, 'r') as stream:
                 return yaml.load(stream, Loader=yaml.FullLoader)
         except FileNotFoundError:
@@ -66,7 +66,7 @@ class DeploymentMap:
     def _get_deployment_apps_from_dir(self):
         if os.path.isdir(self.map_dir_path):
             for file in os.listdir(self.map_dir_path):
-                if file.endswith(".yml"):
+                if file.endswith(".yml") and file != 'example-deployment_map.yml':
                     deployment_map = self._get_deployment_map('{}/{}'.format(self.map_dir_path, file))
                     if 'pipelines' not in self.map_contents:
                         self.map_contents['pipelines'] = []

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/pipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/pipeline.py
@@ -22,8 +22,10 @@ class Pipeline:
         self.pipeline_type = pipeline.get('type', None)
         self.replace_on_failure = pipeline.get('replace_on_failure', '') # Legacy, and will be replaced in 1.0.0 in favour of below 'action'
         self.action = pipeline.get('action', '').upper()
+        self.completion_trigger = pipeline.get('completion_trigger', {})
         self.contains_transform = pipeline.get('contains_transform', '')
-
+        if not isinstance(self.completion_trigger.get('pipelines', []), list):
+            self.completion_trigger['pipelines'] = [self.completion_trigger['pipelines']]
         if not isinstance(self.top_level_regions, list):
             self.top_level_regions = [self.top_level_regions]
 
@@ -82,7 +84,8 @@ class Pipeline:
             regions=sorted(list(set(self.flatten_list(self.stage_regions)))),
             deployment_account_region=DEPLOYMENT_ACCOUNT_REGION,
             action=self.action or self.replace_on_failure,
-            contains_transform=self.contains_transform
+            contains_transform=self.contains_transform,
+            completion_trigger=self.completion_trigger
         )
 
         self._create_pipelines_folder()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/resolver.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/resolver.py
@@ -125,6 +125,7 @@ class Resolver:
         if key not in self.stage_parameters[param]:
             self.stage_parameters[param][key] = self.comparison_parameters[param][key]
 
+
     def update_sc(self, key):
         if key not in self.stage_parameters:
             self.stage_parameters[key] = self.comparison_parameters[key]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/tests/stubs/account_name1_eu-central-1.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/tests/stubs/account_name1_eu-central-1.yml
@@ -1,0 +1,2 @@
+Parameters:
+    CostCenter: free

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/tests/stubs/stub_cfn_global.json
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/tests/stubs/stub_cfn_global.json
@@ -6,5 +6,5 @@
     "Tags" : {
         "TagKey" : "123",
         "MyKey" : "new_value"
-      }
+    }
 }

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/tests/test_generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/adf-build/tests/test_generate_params.py
@@ -38,21 +38,21 @@ def test_params_folder_created(cls):
 
 def test_parse(cls):
     parse = cls._parse(
-        '{0}/stub_cfn_global.json'.format(cls.cwd)
+        '{0}/stub_cfn_global'.format(cls.cwd)
     )
     assert parse == {'Parameters': {'CostCenter': '123', 'Environment': 'testing'}, 'Tags': {'MyKey': 'new_value', 'TagKey': '123'}}
 
 
 def test_parse_not_found(cls):
     parse = cls._parse(
-        '{0}/nothing.json'.format(cls.cwd)
+        '{0}/nothing'.format(cls.cwd)
     )
     assert parse == {'Parameters': {}, 'Tags': {}}
 
 
 def test_compare_cfn(cls):
     parse = cls._parse(
-        '{0}/stub_cfn_global.json'.format(cls.cwd)
+        '{0}/stub_cfn_global'.format(cls.cwd)
     )
     compare = cls._compare_cfn(
         parse,
@@ -63,7 +63,7 @@ def test_compare_cfn(cls):
 
 
 def test_create_parameter_files(cls):
-    cls.global_path = "{0}/stub_cfn_global.json".format(cls.cwd)
+    cls.global_path = "{0}/stub_cfn_global".format(cls.cwd)
     cls.create_parameter_files()
     assert os.path.exists("{0}/params/account_name1_eu-west-1.json".format(cls.cwd))
     assert os.path.exists("{0}/params/account_name1_eu-central-1.json".format(cls.cwd))
@@ -74,26 +74,34 @@ def test_create_parameter_files(cls):
 
 
 def test_ensure_parameter_default_contents(cls):
-    cls.global_path = "{0}/stub_cfn_global.json".format(cls.cwd)
+    cls.global_path = "{0}/stub_cfn_global".format(cls.cwd)
     cls.create_parameter_files()
 
     parse = cls._parse(
-        "{0}/params/account_name1_us-west-2.json".format(cls.cwd)
+        "{0}/params/account_name1_us-west-2".format(cls.cwd)
     )
 
     assert parse == {'Parameters': {'CostCenter': '123', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}
 
 
 def test_ensure_parameter_specific_contents(cls):
-    cls.global_path = "{0}/stub_cfn_global.json".format(cls.cwd)
+    cls.global_path = "{0}/stub_cfn_global".format(cls.cwd)
     shutil.copy(
         "{0}/account_name1_eu-west-1.json".format(cls.cwd),
         "{0}/params/account_name1_eu-west-1.json".format(cls.cwd)
     )
+    shutil.copy(
+        "{0}/account_name1_eu-central-1.yml".format(cls.cwd),
+        "{0}/params/account_name1_eu-central-1.yml".format(cls.cwd)
+    )
     cls.create_parameter_files()
 
-    parse = cls._parse(
-        "{0}/params/account_name1_eu-west-1.json".format(cls.cwd)
+    parse_json = cls._parse(
+        "{0}/params/account_name1_eu-west-1".format(cls.cwd)
+    )
+    parse_yml = cls._parse(
+        "{0}/params/account_name1_eu-central-1".format(cls.cwd)
     )
 
-    assert parse == {'Parameters': {'CostCenter': 'free', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}
+    assert parse_json == {'Parameters': {'CostCenter': 'free', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}
+    assert parse_yml == {'Parameters': {'CostCenter': 'free', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
@@ -42,6 +42,51 @@ Parameters:
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
 Resources:
+{% if completion_trigger.get('pipelines', []) %}
+  PipelineTriggerEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: !Sub "Triggers on completion of ${Pipeline}"
+        EventPattern:
+          source:
+            - "aws.codepipeline"
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+          detail:
+            state:
+              - "SUCCEEDED"
+            pipeline:
+              - !Ref Pipeline
+        State: "ENABLED"
+        Targets:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+          - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+            RoleArn: !GetAtt PipelineTriggerCloudWatchEventRole.Arn
+            Id: !Sub "adf-trigger-{{pipeline}}"
+{% endfor %}
+  PipelineTriggerCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'adf-trigger-${Pipeline}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+{% endfor %}
+{% endif %}
   PipelineCloudWatchEventRole:
     Condition: HasSchedule
     Type: AWS::IAM::Role

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
@@ -48,7 +48,52 @@ Parameters:
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
 Resources:
-  PipelineCloudWatchEventRole:
+{% if completion_trigger.get('pipelines', []) %}
+  PipelineTriggerEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: !Sub "Triggers on completion of ${Pipeline}"
+        EventPattern:
+          source:
+            - "aws.codepipeline"
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+          detail:
+            state:
+              - "SUCCEEDED"
+            pipeline:
+              - !Ref Pipeline
+        State: "ENABLED"
+        Targets:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+          - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+            RoleArn: !GetAtt PipelineTriggerCloudWatchEventRole.Arn
+            Id: !Sub "adf-trigger-{{pipeline}}"
+{% endfor %}
+  PipelineTriggerCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'adf-trigger-${Pipeline}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+{% endfor %}
+{% endif %}
+  CronPipelineCloudWatchEventRole:
     Condition: HasSchedule
     Type: AWS::IAM::Role
     Properties:
@@ -77,7 +122,7 @@ Resources:
       ScheduleExpression: !Ref ScheduleExpression
       Targets:
         - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
-          RoleArn: !GetAtt PipelineCloudWatchEventRole.Arn
+          RoleArn: !GetAtt CronPipelineCloudWatchEventRole.Arn
           Id: !Sub "adf-cron-${AWS::StackName}"
   BuildProject:
     Type: AWS::CodeBuild::Project

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-codedeploy.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-codedeploy.yml.j2
@@ -48,6 +48,51 @@ Parameters:
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
 Resources:
+{% if completion_trigger.get('pipelines', []) %}
+  PipelineTriggerEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: !Sub "Triggers on completion of ${Pipeline}"
+        EventPattern:
+          source:
+            - "aws.codepipeline"
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+          detail:
+            state:
+              - "SUCCEEDED"
+            pipeline:
+              - !Ref Pipeline
+        State: "ENABLED"
+        Targets:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+          - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+            RoleArn: !GetAtt PipelineTriggerCloudWatchEventRole.Arn
+            Id: !Sub "adf-trigger-{{pipeline}}"
+{% endfor %}
+  PipelineTriggerCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'adf-trigger-${Pipeline}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+{% endfor %}
+{% endif %}
   PipelineCloudWatchEventRole:
     Condition: HasSchedule
     Type: AWS::IAM::Role

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-s3.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-s3.yml.j2
@@ -53,6 +53,51 @@ Parameters:
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
 Resources:
+{% if completion_trigger.get('pipelines', []) %}
+  PipelineTriggerEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: !Sub "Triggers on completion of ${Pipeline}"
+        EventPattern:
+          source:
+            - "aws.codepipeline"
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+          detail:
+            state:
+              - "SUCCEEDED"
+            pipeline:
+              - !Ref Pipeline
+        State: "ENABLED"
+        Targets:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+          - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+            RoleArn: !GetAtt PipelineTriggerCloudWatchEventRole.Arn
+            Id: !Sub "adf-trigger-{{pipeline}}"
+{% endfor %}
+  PipelineTriggerCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'adf-trigger-${Pipeline}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+{% endfor %}
+{% endif %}
   PipelineCloudWatchEventRole:
     Condition: HasSchedule
     Type: AWS::IAM::Role

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-service-catalog.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-service-catalog.yml.j2
@@ -51,6 +51,51 @@ Parameters:
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
 Resources:
+{% if completion_trigger.get('pipelines', []) %}
+  PipelineTriggerEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: !Sub "Triggers on completion of ${Pipeline}"
+        EventPattern:
+          source:
+            - "aws.codepipeline"
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+          detail:
+            state:
+              - "SUCCEEDED"
+            pipeline:
+              - !Ref Pipeline
+        State: "ENABLED"
+        Targets:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+          - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+            RoleArn: !GetAtt PipelineTriggerCloudWatchEventRole.Arn
+            Id: !Sub "adf-trigger-{{pipeline}}"
+{% endfor %}
+  PipelineTriggerCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'adf-trigger-${Pipeline}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+{% endfor %}
+{% endif %}
   PipelineCloudWatchEventRole:
     Condition: HasSchedule
     Type: AWS::IAM::Role

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
@@ -58,6 +58,51 @@ Parameters:
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
 Resources:
+{% if completion_trigger.get('pipelines', []) %}
+  PipelineTriggerEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: !Sub "Triggers on completion of ${Pipeline}"
+        EventPattern:
+          source:
+            - "aws.codepipeline"
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+          detail:
+            state:
+              - "SUCCEEDED"
+            pipeline:
+              - !Ref Pipeline
+        State: "ENABLED"
+        Targets:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+          - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+            RoleArn: !GetAtt PipelineTriggerCloudWatchEventRole.Arn
+            Id: !Sub "adf-trigger-{{pipeline}}"
+{% endfor %}
+  PipelineTriggerCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'adf-trigger-${Pipeline}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+{% endfor %}
+{% endif %}
   PipelineCloudWatchEventRole:
     Condition: HasSchedule
     Type: AWS::IAM::Role

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/s3-s3.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/s3-s3.yml.j2
@@ -55,6 +55,51 @@ Parameters:
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
 Resources:
+{% if completion_trigger.get('pipelines', []) %}
+  PipelineTriggerEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: !Sub "Triggers on completion of ${Pipeline}"
+        EventPattern:
+          source:
+            - "aws.codepipeline"
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+          detail:
+            state:
+              - "SUCCEEDED"
+            pipeline:
+              - !Ref Pipeline
+        State: "ENABLED"
+        Targets:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+          - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+            RoleArn: !GetAtt PipelineTriggerCloudWatchEventRole.Arn
+            Id: !Sub "adf-trigger-{{pipeline}}"
+{% endfor %}
+  PipelineTriggerCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'adf-trigger-${Pipeline}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+{% for pipeline in completion_trigger.get('pipelines', []) %}
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${StackPrefix}-pipeline-{{pipeline}}"
+{% endfor %}
+{% endif %}
   PipelineCloudWatchEventRole:
     Condition: HasSchedule
     Type: AWS::IAM::Role

--- a/src/template.yml
+++ b/src/template.yml
@@ -14,7 +14,7 @@ Metadata:
     ReadmeUrl: ../README.md
     Labels: ['adf', 'aws-deployment-framework', 'multi-account', 'cicd', 'devops']
     HomePageUrl: https://github.com/awslabs/aws-deployment-framework
-    SemanticVersion: 1.0.5
+    SemanticVersion: 1.0.6
     SourceCodeUrl: https://github.com/awslabs/aws-deployment-framework
 Parameters:
   CommitInitialBootstrapContent:
@@ -187,7 +187,7 @@ Resources:
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 1.0.5
+          ADF_VERSION: 1.0.6
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: StackWaiter
       Role: !GetAtt LambdaRole.Arn
@@ -208,7 +208,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 1.0.5
+          ADF_VERSION: 1.0.6
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: DetermineEventFunction
       Role: !GetAtt LambdaRole.Arn
@@ -229,7 +229,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 1.0.5
+          ADF_VERSION: 1.0.6
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: CrossAccountExecuteFunction
       Role: !GetAtt LambdaRole.Arn
@@ -248,7 +248,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 1.0.5
+          ADF_VERSION: 1.0.6
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: RoleStackDeploymentFunction
       Role: !GetAtt LambdaRole.Arn
@@ -267,7 +267,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 1.0.5
+          ADF_VERSION: 1.0.6
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: MovedToRootActionFunction
       Role: !GetAtt LambdaRole.Arn
@@ -286,7 +286,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 1.0.5
+          ADF_VERSION: 1.0.6
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: UpdateResourcePoliciesFunction
       Role: !GetAtt LambdaRole.Arn
@@ -425,7 +425,7 @@ Resources:
         Image: "aws/codebuild/standard:2.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
-            Value: 1.0.5
+            Value: 1.0.6
           - Name: TERMINATION_PROTECTION
             Value: !Ref TerminationProtection
           - Name: PYTHONPATH
@@ -664,7 +664,7 @@ Resources:
     Condition: ShouldCommitInitialBootstrapContent
     Properties:
       ServiceToken: !GetAtt InitialCommitHandler.Arn
-      Version: 1.0.5
+      Version: 1.0.6
       RepositoryArn: !GetAtt CodeCommitRepository.Arn
       DirectoryName: bootstrap_repository
       DeploymentAccountRegion: !Ref DeploymentAccountMainRegion
@@ -837,7 +837,7 @@ Resources:
       Timeout: 300
 Outputs:
   ADFVersionNumber:
-    Value: 1.0.5
+    Value: 1.0.6
     Export:
       Name: "ADFVersionNumber"
   LayerArn:


### PR DESCRIPTION
# v1.1.0

Resolves #78 - Multiple Deployment Map files are now possible thanks to @triha74 - If you wish to split your map into multiple smaller maps based on teams, types or services you can create additional map files in a folder called 'deployment_maps' in the pipelines repository.

Resolves #82 - Pipeline completion triggers are now available. This allows you to trigger *(aka chaining)* other pipelines based on the completion of a pipeline. See the docs for examples.

Resolves #73 Parameter files for CloudFormation in CodePipeline can now be written in yml *(eg global.yml, account-blah.yml)*. this works in the same manner with inheritance as it does with json.

*Description of changes:*

New Functionality:

- Completion triggers on pipelines are a new feature that act as a way to chain pipelines together and start the execution of a certain pipeline(s) based on one finishing. 
- ADF now supports multiple deployment_map files that live in a folder called **deployment_maps** on the pipelines repository *(deployment account)* which can help separate an reduce complexity in large environments. These files can be named anything as long as they end with *.yml*.s
- CloudFormation parameter files can now be written in yml aswell as json.

 Other Changes:

- Deployment Account now has a CodeCommit role as part of its base stack. This allows the use of the deployment account as a Source account for pipelines.
- Automatic updating of the KMS key parameter store value on target accounts *(base stacks parameter)* if the key was to change on the deployment account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
