### PR TITLE
Custom Deploy pipe template

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
@@ -295,7 +295,7 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -319,7 +319,7 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -335,7 +335,7 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               RunOrder: 2
               Region: {{ region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"
@@ -360,7 +360,7 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ top_level_region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -376,7 +376,7 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               RunOrder: 2
               Region: {{ top_level_region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-customdeploy.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-customdeploy.yml.j2
@@ -1,0 +1,402 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and CloudFormation Deployment Target
+Parameters:
+  ProjectName:
+    Description: Name of the Project (This is automatically passed in by ADF)
+    Type: String
+  StackPrefix:
+    Description: Prefix to prepend to the stackname when deployed
+    Type: String
+    Default: adf
+  ScheduleExpression:
+    Description: The Schedule expression for this pipeline
+    Type: String
+    Default: ''
+  Image:
+    Description: The Image for CodeBuild to use
+    Type: String
+    Default: "aws/codebuild/python:3.7.1"
+  NotificationEndpoint:
+    Description: The Email Address / Slack channel notifications will go to for changes related to this pipeline
+    Type: String
+    Default: ''
+  ComputeType:
+    Description: The ComputeType for CodeBuild
+    Type: String
+    Default: "BUILD_GENERAL1_SMALL"
+  SourceAccountId:
+    Description: The ID of the Source Account that will hold the CodeCommit Repo
+    Type: String
+  BranchName:
+    Description: Name of the CodeCommit Branch you will use to trigger the pipeline
+    Type: String
+    Default: master
+  RestartExecutionOnUpdate:
+    Description: If the pipeline will automatically trigger based on update
+    Type: String
+    Default: False
+{% for region in regions %}
+  S3Bucket{{ region|replace("-", "") }}:
+    Description: The S3 Bucket for Cross region deployment for {{ region }}
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /cross_region/s3_regional_bucket/{{ region }}
+  KMSKey{{ region|replace("-", "") }}:
+    Description: The KMSKey Arn for Cross region deployment for {{ region }}
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /cross_region/kms_arn/{{ region }}
+{% endfor %}
+Conditions:
+  HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+Resources:
+  CronCloudwatchEventsRule:
+    Type: "AWS::Events::Rule"
+    Condition: HasSchedule
+    Properties: 
+      Description: !Sub Triggers ${AWS::StackName} on a Schedule
+      ScheduleExpression: !Ref ScheduleExpression
+      Targets:
+        - Arn: !GetAtt CronLambdaFunction.Arn
+          Id: !Sub "adf-cron-${AWS::StackName}"
+  CronLambdaFunction:
+    Type: 'AWS::Lambda::Function'
+    Condition: HasSchedule
+    Properties:
+      Code:
+        ZipFile: !Sub |
+          import boto3
+          def handler(event, _):
+            client = boto3.client('codepipeline', region_name="${AWS::Region}")
+            client.start_pipeline_execution(name="${AWS::StackName}")
+      Handler: 'index.handler'
+      FunctionName: !Sub "adf-cron-pipeline-${AWS::StackName}"
+      Description: !Sub "ADF Lambda Function - Cron ${AWS::StackName}"
+      MemorySize: 128
+      Role: !GetAtt CronLambdaRole.Arn
+      Runtime: 'python3.7'
+      Timeout: 60
+  CronPermissionForEventsToInvokeLambda: 
+    Type: AWS::Lambda::Permission
+    Condition: HasSchedule
+    Properties: 
+      FunctionName: !Ref CronLambdaFunction
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CronCloudwatchEventsRule.Arn
+  CronLambdaRole:
+    Type: "AWS::IAM::Role"
+    Condition: HasSchedule
+    Properties:
+      RoleName: !Sub "adf-cron-lambda-role-${AWS::StackName}"
+      AssumeRolePolicyDocument: 
+        Version: "2012-10-17"
+        Statement: 
+          - Effect: "Allow"
+            Principal: 
+              Service: 
+                - "lambda.amazonaws.com"
+            Action: 
+              - "sts:AssumeRole"
+      Path: "/"
+      Policies: 
+        - PolicyName: "adf-lambda-execution-role"
+          PolicyDocument: 
+            Version: "2012-10-17"
+            Statement: 
+              - Effect: "Allow"
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
+                Action: 
+                  - "codepipeline:StartPipelineExecution"
+              - Effect: "Allow"
+                Resource: "arn:aws:logs:*:*:*"
+                Action: "logs:*"
+              - Effect: "Allow"
+                Resource: "*"
+                Action: 
+                  - "lambda:GetAccountSettings"
+                  - "lambda:ListFunctions"
+                  - "lambda:ListTags"
+                  - "lambda:GetFunction"
+                  - "lambda:GetEventSourceMapping"
+                  - "lambda:ListEventSourceMappings"
+                  - "lambda:DeleteEventSourceMapping"
+                  - "lambda:UpdateEventSourceMapping"
+                  - "lambda:CreateEventSourceMapping"
+                  - "iam:ListRoles"
+                Condition:
+                  StringEquals:
+                    lambda:FunctionArn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:adf-cron-pipeline-${AWS::StackName}"
+  BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "adf-build-${ProjectName}"
+      Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
+      EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
+      ServiceRole: !ImportValue CodeBuildRoleArn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: linuxContainer
+        ComputeType: !Ref ComputeType
+        Image: !Ref Image
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: PYTHONPATH
+            Value: './adf-build/shared/python'
+          - Name: PROJECT_NAME
+            Value: !Ref ProjectName
+          - Name: S3_BUCKET_NAME
+            Value: !ImportValue S3Bucket-{{ deployment_account_region }}
+          - Name: ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+      Source:
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 20
+      Tags:
+        - Key: Name
+          Value: !Ref ProjectName
+{% for target in environments['targets'] %}    
+{% for stage in target %}
+{% if top_level_regions == [] %}
+{% for region in stage.regions %}
+  DeployProject{{ stage.name | replace("-","") }}{{ region | replace("-","") }}:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "adf-deploy-${ProjectName}-{{ stage.name }}-{{region}}"
+      Description: !Sub "CodeBuild Project ${ProjectName} to deploy in {{ stage.name }} {{ region }} created by ADF"
+      EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
+      ServiceRole: !ImportValue CodeBuildRoleArn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: linuxContainer
+        ComputeType: !Ref ComputeType
+        PrivilegedMode: true
+        Image: !Ref Image
+        EnvironmentVariables:
+          - Name: PYTHONPATH
+            Value: './adf-build/shared/python'
+          - Name: PROJECT_NAME
+            Value: !Ref ProjectName
+          - Name: S3_BUCKET_NAME
+            Value: !ImportValue S3Bucket-{{ deployment_account_region }}
+          - Name: ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+          - Name: DEPLOY_ROLE
+            Value: {{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: {{ stage.get('params').get('Specfile') or 'deployspec.yml'}}
+      TimeoutInMinutes: 20
+      Tags:
+        - Key: Name
+          Value: !Ref ProjectName
+{% endfor %}
+{% else %}
+{% for top_level_region in top_level_regions %}
+  DeployProject{{ stage.name | replace("-","") }}{{ top_level_region | replace("-","") }}:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "adf-deploy-${ProjectName}-{{ stage.name }}-{{top_level_region}}"
+      Description: !Sub "CodeBuild Project ${ProjectName} to deploy in {{ stage.name }} {{ top_level_region }} created by ADF"
+      EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
+      ServiceRole: !ImportValue CodeBuildRoleArn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: linuxContainer
+        ComputeType: !Ref ComputeType
+        Image: !Ref Image
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: PYTHONPATH
+            Value: './adf-build/shared/python'
+          - Name: PROJECT_NAME
+            Value: !Ref ProjectName
+          - Name: S3_BUCKET_NAME
+            Value: !ImportValue S3Bucket-{{ deployment_account_region }}
+          - Name: ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+          - Name: DEPLOY_ROLE
+            Value: {{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: {{  stage.get('params').get('Specfile') or 'deployspec.yml'}}
+      TimeoutInMinutes: 20
+      Tags:
+        - Key: Name
+          Value: !Ref ProjectName
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% if notification_endpoint %}
+  PipelineEventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Description: "Trigger notifications based on pipeline state changes"
+      EventPattern:
+        source:
+          - "aws.codepipeline"
+        detail-type:
+          - "CodePipeline Pipeline Execution State Change"
+        detail:
+          state:
+            - "FAILED"
+            - "SUCCEEDED"
+          pipeline:
+            - !Ref Pipeline
+      State: "ENABLED"
+      Targets:
+        - Arn: !Ref PipelineSNSTopic
+          Id: !Sub "${AWS::StackName}-pipeline"
+{% if "@" in notification_endpoint %}
+          InputTransformer:
+            InputTemplate: '"The pipeline <pipeline> from account <account> has <state> at <at>."'
+            InputPathsMap:
+              pipeline: "$.detail.pipeline"
+              state: "$.detail.state"
+              at: "$.time"
+              account: "$.account"
+{% endif %}
+  PipelineSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+{% if "@" in notification_endpoint %}
+        - Endpoint: !Ref NotificationEndpoint
+          Protocol: email
+{% else %}
+        - Endpoint: !ImportValue SendSlackNotificationLambdaArn
+          Protocol: lambda
+{% endif %}
+  PipelineSNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Id: !Sub "${AWS::StackName}"
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - events.amazonaws.com
+              - codecommit.amazonaws.com
+              - sns.amazonaws.com
+          Action: sns:Publish
+          Resource: "*"
+      Topics:
+      - !Ref PipelineSNSTopic
+  LambdaInvokePermission: 
+    Type: AWS::Lambda::Permission
+    Properties: 
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref PipelineSNSTopic
+      FunctionName: 'SendSlackNotification'
+{% endif %}
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn: !ImportValue CodePipelineRoleArn
+      Name: !Ref AWS::StackName
+      RestartExecutionOnUpdate: !Ref RestartExecutionOnUpdate
+      Stages:
+        - Name: !Sub Source-${SourceAccountId}
+          Actions:
+            - Name: CodeCommit
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: 1
+                Provider: CodeCommit
+              Configuration:
+                RepositoryName: !Ref ProjectName
+                BranchName: !Ref BranchName
+              OutputArtifacts:
+                - Name: TemplateSource
+              RunOrder: 1
+              RoleArn: !Sub "arn:aws:iam::${SourceAccountId}:role/adf-codecommit-role" #Source Account
+        - Name: Build
+          Actions:
+          - Name: Build
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Sub "adf-build-${ProjectName}"
+            RunOrder: 1
+            InputArtifacts:
+              - Name: TemplateSource
+            OutputArtifacts:
+              - Name: !Sub "${ProjectName}-build"
+{% for target in environments['targets'] %}
+{% if target|length > 0 and target[0].get('name') == "approval" %}
+        - Name: {{ target[0].get('step_name') or "approval-stage-" ~ loop.index }}
+          Actions:
+            - Name: {{ target[0].get('step_name') or "Approval"}}
+              ActionTypeId:
+                Category: Approval
+                Owner: AWS
+                Version: 1
+                Provider: Manual
+              Configuration:
+                {% if notification_endpoint %}
+                NotificationArn: !Ref PipelineSNSTopic
+                {% endif %}
+                CustomData: !Ref AWS::AccountId
+              RunOrder: 1
+{% else %}
+        - Name: {{ target[0].get('step_name') or "deployment-stage-" ~ loop.index }}
+          Actions:
+{% for stage in target %}
+{% if top_level_regions == [] %}
+{% for region in stage.regions %}
+          - Name: Deploy-{{ stage.name }}-{{ region }}
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Sub "adf-deploy-${ProjectName}-{{ stage.name }}-{{ region }}"
+            RunOrder: 1
+            InputArtifacts:
+              - Name: TemplateSource
+            OutputArtifacts:
+              - Name: !Sub "${ProjectName}-deploy"
+{% endfor %}
+{% else %}
+{% for top_level_region in top_level_regions %}
+          - Name: Deploy-{{ top_level_region }}-{{ stage.name }}
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Sub "adf-deploy-${ProjectName}-{{ stage.name }}-{{ top_level_region }}"
+            RunOrder: 1
+            InputArtifacts:
+              - Name: TemplateSource
+            OutputArtifacts:
+              - Name: !Sub "${ProjectName}-deploy"
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+      ArtifactStores:
+{% for region in regions %}
+        - Region: {{ region }}
+          ArtifactStore:
+            EncryptionKey:
+              Id: !Ref KMSKey{{ region|replace("-", "") }}
+              Type: KMS
+            Location: !Ref S3Bucket{{ region|replace("-", "") }}
+            Type: S3
+{% endfor %}
+Outputs:
+  PipelineUrl:
+    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
@@ -321,7 +321,7 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -345,7 +345,7 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -361,7 +361,7 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               RunOrder: 2
               Region: {{ region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"
@@ -386,7 +386,7 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ top_level_region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -402,7 +402,7 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-deployment-role"
+                RoleArn: "{{ stage.get('params').get('DeployRoleArn') or 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               RunOrder: 2
               Region: {{ top_level_region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"


### PR DESCRIPTION
*Issue #89*

*Description of changes:* Added a custom deployment template, cc-customdeploy. This creates a codebuild for each deploy stage. By default it uses the spec file deployspec.yml and the adf-cloudformation-deployment-role deployment role. But its possible to specify custom deploy spec and deploy role like this.

```
pipelines:
  - name: example-app
    type: cc-customdeploy
    params:
      - SourceAccountId: 01234567890
    targets:
      - path: 0987654321
        params:
            Specfile: deployspec-qa.yml
            DeployRoleArn: arn:aws:iam::0987654321:role/example-app-deploy-role
      - path: 8901234556
        params:
            Specfile: deployspec-prod.yml
            DeployRoleArn: arn:aws:iam::8901234556:role/example-app-deploy-role
```
I also added the ability to create a custom deploy role to the other CF based pipe templates where it was used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
