### PR TITLE
Fix: removing the duplicate DeletionPolicy Attribute

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/regional.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/regional.yml
@@ -18,7 +18,6 @@ Resources:
               SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
-    DeletionPolicy: Delete
   DeploymentFrameworkRegionalPipelineBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:


### PR DESCRIPTION
Fix: removed the duplicate DeletionPolicy Attribute in the initial commit for the regional deployment bucket, because it was taking precedence over the "Retain"

in src/lambda_codebase/initial_commit/bootstrap_repository/deployment/regional.yml
```
  DeploymentFrameworkRegionalS3Bucket:
    Type: AWS::S3::Bucket
    DeletionPolicy: Retain <=== added in June to "v1.0.0" 368ec00 
    Properties:
      ...
    DeletionPolicy: Delete <=== added in March to the "initial commit" 095185f
```



Explanation: 

This CF template ends with status `DELETE_SKIPPED` after stack deletion:
```  
Resources:
  DeploymentFrameworkRegionalS3Bucket:
    Type: AWS::S3::Bucket
    DeletionPolicy: Delete
    DeletionPolicy: Retain
```
    
This CF template ends with status `DELETE_COMPLETE` after stack deletion:
```
Resources:
  DeploymentFrameworkRegionalS3Bucket:
    Type: AWS::S3::Bucket
    DeletionPolicy: Retain
    DeletionPolicy: Delete
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
