### PR TITLE
Added CAPABILITY_AUTO_EXPAND to github and codecommit pipeline templates

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
@@ -322,7 +322,7 @@ Resources:
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
-                Capabilities: CAPABILITY_NAMED_IAM
+                Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
@@ -349,7 +349,7 @@ Resources:
                 TemplatePath: !Sub "${ProjectName}-build::template.yml"
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
-                Capabilities: CAPABILITY_NAMED_IAM
+                Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
 
               InputArtifacts:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-deployment-framework/issues/98

*Description of changes:*
Added CAPABILITY_AUTO_EXPAND to change_set_replace action in cc-cloudformation and github-cloudformation pipeline types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
