### PR TITLE
v1.2.1

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -22,6 +22,7 @@
 - [Default Deployment Account Region](#default-deployment-account-region)
 - [Integrating Slack](#integrating-slack)
 - [Updating Between Versions](#updating-between-versions)
+- [Removing ADF](#removing-adf)
 
 ## Overview
 
@@ -48,7 +49,7 @@ The `src` folder contains a nesting of folders that go on to make two different 
 
 1. Ensure you have setup a new [AWS CloudTrail](https://aws.amazon.com/cloudtrail/) *(Not the default trail)* in your Master Account that spans all regions and that you are able to view trail information in the AWS CloudTrail console.
 
-2. In the AWS Console from your master account within us-east-1, head over to the Serverless Application Repository *(SAR)*. From there, search for aws-deployment-framework *(or "adf")*. If you are deploying ADF for the first time, fill in the required parameters for your specific use-case. For example, if you have no AWS Organization or dedicated deployment account already created, you can enter an account name and email address and ADF will create you an AWS Organization, the deployment OU, along with an AWS Account that will be used to house deployment pipelines throughout your Organization. If you already have an AWS Account you want to use as your deployment account you can specify its Account ID in the parameter *DeploymentAccountId* and leave the *DeploymentAccountName* and *DeploymentAccountEmail* empty. Next, specify the *DeploymentAccountMainRegion* parameter as the region that will host your deployment pipelines and would be considered your main AWS region. In the *InitialCommit* section of the parameters enter a list of AWS Regions that you might want to deploy your resources or applications into via AWS CodePipeline *(this can be updated whenever)*. Also specify a main notification endpoint *(email or slack (see docs))* to receive updates about the bootstrap process. When you have entered all required information press **'Deploy'**.
+2. In the AWS Console from your master account within us-east-1, head over to the Serverless Application Repository *(SAR)*. From there, search for aws-deployment-framework *(or "adf")* (ensure the checkbox "Show apps that create custom IAM roles or resource policies" is checked). If you are deploying ADF for the first time, fill in the required parameters for your specific use-case. For example, if you have no AWS Organization or dedicated deployment account already created, you can enter an account name and email address and ADF will create you an AWS Organization, the deployment OU, along with an AWS Account that will be used to house deployment pipelines throughout your Organization. If you already have an AWS Account you want to use as your deployment account you can specify its Account ID in the parameter *DeploymentAccountId* and leave the *DeploymentAccountName* and *DeploymentAccountEmail* empty. Next, specify the *DeploymentAccountMainRegion* parameter as the region that will host your deployment pipelines and would be considered your main AWS region. In the *InitialCommit* section of the parameters enter a list of AWS Regions that you might want to deploy your resources or applications into via AWS CodePipeline *(this can be updated whenever)*. Also specify a main notification endpoint *(email or slack (see docs))* to receive updates about the bootstrap process. When you have entered all required information press **'Deploy'**.
 
 3. As the stack *serverlessrepo-aws-deployment-framework* completes you can now open AWS CodePipeline from within the master account in us-east-1 and see that there is an initial pipeline execution that has been run. When ADF is deployed for the first time, it will make the initial commit with the skeleton structure of the *aws-deployment-framework-bootstrap* CodeCommit repository. From that initial commit you can clone the repository to your workstation and make the changes required to define your desired architectural landscape via AWS CloudFormation templates in regards to bootstrapping AWS Accounts within certain Organizational Unit's or apply SCP's from code *(see docs below)*.
 
@@ -79,8 +80,10 @@ config:
       action: safe
   protected: # Optional
     - ou-123
-  scp:
+  scp: # Service Control Policy
     keep-default-scp: enabled # Optional
+  scm: # Source Control Management
+    auto-create-repositories: enabled # Optional
 ```
 
 In the above example we have four main properties in `roles`, `regions` and `config`.
@@ -94,12 +97,13 @@ The Regions specification plays an important role in how ADF is laid out. You sh
 
 #### Config
 
-Config has four components in `main-notification-endpoint`, `scp`, `moves` and `protected`.
+Config has five components in `main-notification-endpoint`, `scp`, `scm`, `moves` and `protected`.
 
 - **main-notification-endpoint** is the main notification endpoint for the bootstrapping pipeline and deployment account pipeline creation pipeline. This value should be a valid email address or [slack](./admin-guide/#integrating-slack) channel that will receive updates about the status *(Success/Failure)* of CodePipeline that is associated with bootstrapping and creation/updating of all pipelines throughout your organization.
 - **moves** is configuration related to moving accounts within your AWS Organization. Currently the only configuration options for `moves` is named *to-root* and allows either `safe` or `remove_base`. If you specify *safe* you are telling the framework that when an AWS Account is moved from whichever OU it currently is in, back into the root of the Organization it will not make any direct changes to the account. It will however update any AWS CodePipeline pipelines that the account belonged to so that it is no longer a valid target. If you specify `remove_base` for this option and move an account to the root of your organization it will attempt to the base CloudFormation stacks *(regional and global)* from the account and then update any associated pipeline.
 - **protected** is a configuration that allows you to specify a list of OUs that are not configured by the AWS Deployment Framework bootstrapping process. You can move accounts to the protected OUs which will skip the standard bootstrapping process. This is useful for migrating existing accounts into being managed by The ADF.
 - **scp** allows the definition of configuration options that relate to Service Control Policies. Currently the only option for *scp* is *keep-default-scp* which can either be *enabled* or *disabled*. This option determines if the default FullAWSAccess Service Control Policy should stay attached to OUs that are managed by an *scp.json* or if it should be removed to make way for a more specific SCP, by default this is *enabled*. Its important to understand how SCPs work before setting this setting to disabled. Please read [How SCPs work](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_about-scps.html) for more information.
+- **scm** enables the automation aspect of creating AWS CodeCommit repositories automatically when creating a new Pipeline via ADF. This option is only relevant if you are using the *SourceAccountId* parameter in your Pipeline Parameters, if so, and this value is *enabled* ADF will automatically create the AWS CodeCommit Repository on the Source Account with the same name of the associated pipeline. If the Repository already exists on the source account this process will continue silently. If you wish to update/alter the CloudFormation template used to create this repository it can be found at */src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/repo_templates/codecommit.yml*.
 
 ## Accounts
 
@@ -317,6 +321,7 @@ Sometimes its a need to chain pipelines together, when one finishes you might wa
 pipelines:
   - name: sample-vpc
     type: cc-cloudformation
+    deployment_role: some_specific_role # <-- you can pass an optional IAM role of your choice that will be used as the deployment role for this pipeline
     completion_trigger: # <--- When this pipeline finishes it will automatically start sample-iam and sample-ecs-cluster at the same time
         pipelines:
           - sample-iam
@@ -398,3 +403,12 @@ As per the same as the `deployment_map.yml` style configuration, this would requ
 To update ADF between releases, open the Serverless Application Repository *(SAR)* on the master account in us-east-1. From here, search for *adf* and click deploy. During an update of ADF there is no need to pass in any parameters other than the defaults *(granted you used the defaults to deploy initially)*.
 
 This will cause your *serverlessrepo-aws-deployment-framework* stack to update with any new changes that were included in that release of ADF. However, we also might make changes to some of the foundational aspects of ADF and how it works, because of this, we might want to change files that live within the *bootstrap* or *pipelines* repository with AWS CodeCommit on your account. To do this, AWS CloudFormation will run the *InitialCommit* Custom CloudFormation resource when updating via the SAR, this resource will open a pull request against the current *master* branch on the respective repositories with a set of changes that you can optionally choose to merge. Initially when updating via the SAR a PR will be opened if there are any changes to make against the *bootstrap* repository, if those are merged the bootstrap pipeline will run and will update the deployment account base stack, which will in-turn make a PR against the deployment accounts *pipeline* repository with any changes from upstream.
+
+
+### Removing ADF
+
+If you wish to remove ADF you can delete the CloudFormation stack named *serverlessrepo-aws-deployment-framework* within on the master account in us-east-1. This will move into a DELETE_FAILED at some stage because there is an S3 Bucket that is created via a custom resource *(cross region)*. After it moves into DELETE_FAILED, you can right-click on the stack and hit delete again while selecting to skip the Bucket the stack will successfully delete, you can then manually delete the bucket and its contents. After the main stack has been removed you can remove the base stack in the deployment account *adf-global-base-deployment* and any associated regional deployment account base stacks. After you have deleted these stacks, you can manually remove any base stacks from accounts that were bootstrapped. Alternatively prior to removing the initial *serverlessrepo-aws-deployment-framework* stack, you can set the *moves* section of the *adfconfig.yml* file to *remove-base* which would automatically clean up the base stack when the account is moved to the Root of the AWS Organization.
+
+One thing to keep in mind if you are planning to re-install ADF is that you will want to clean up the parameter *deployment_account_id* within us-east-1 on the master account. AWS Step Functions uses this parameter to determine if ADF has already got a deployment account setup, if you re-install ADF with this parameter set with a value, ADF will attempt an assume role to the account to do some work, which will fail since that role will not be on the account at that point.
+
+There is also a CloudFormation stack named *adf-global-base-adf-build* which lives on the master account in your main deployment region. This stack creates two roles on the master account after the deployment account has been setup. These roles allow the deployment accounts CodeBuild role to assume a role back to the master account in order to query Organizations for AWS Accounts. This stack must be deleted manually also, if you do not remove this stack and then perform a fresh install of ADF, AWS CodeBuild on the deployment account will not be able to assume a role to the master account to query AWS Organizations. This is because this specific stack creates IAM roles with a strict trust relationship to the CodeBuild role on the deployment account, if that role gets deleted *(Which is will when you delete adf-global-base-deployment)* then this stack references invalid IAM roles that no longer exist. If you forget to remove this stack and notice the trust relationship of the IAM roles referenced in the stack are no longer valid, you can delete the stack and re-run the main bootstrap pipeline which will recreate it with valid roles and links to the correct roles.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -8,6 +8,8 @@
   - [Parameter Injection](#parameter-injection)
   - [Nested Stacks](#nested-stacks)
   - [Deploying Serverless Applications with SAM](#deploying-serverless-applications-with-sam)
+  - [Using Anchors and Alias](#using-anchors-and-alias)
+  - [One to many relationships](#one-to-many-relationships)
 
 ## Deployment Map
 
@@ -23,6 +25,7 @@ A basic example of a deployment_map.yml would look like the following *(assumes 
 pipelines:
   - name: iam
     type: cc-cloudformation
+    deployment_role: infrastructure_role # The role 'infrastructure_role' would need to exist on all target accounts with correct permissions, leaving blank defaults to the adf-cloudformation-deployment-role.
     params:
       - SourceAccountId: 111111222222
       - NotificationEndpoint: janes_team@doe.com # Optional
@@ -33,29 +36,27 @@ pipelines:
       - path: /banking/testing
         regions: eu-central-1
 
-
   - name: vpc
     type: github-cloudformation
-    regions: [ eu-west-1, eu-central-1 ]
     action: replace_on_failure
-    contains_transform: true
     params:
       - SourceAccountId: 8888877777777
       - NotificationEndpoint: channel1 # Slack Channel Example
     targets:
-      - ou-12341
+      - path: ou-12341
+        regions: [ eu-west-1, eu-central-1 ]
       - 22222222222
 ```
 
-In the above example we are creating two pipelines. The first one will deploy from a repository named **iam** that lives in the account **111111222222**. It will use the *cc-cloudformation* [type](#pipeline-types) and deploy in 3 steps. The first stage of the deployment will occur against all AWS Accounts that are in the `/security` Organization unit and be targeted to the `eu-west-1` region. After that, there is a manual approval phase which is denoted by the keyword `approval`. The next step will be the accounts within the `/banking/testing` OU for `eu-central-1` region. By providing a simple path or ou-id without a region definition it will default to the region chosen as the deployment account region in your [adfconfig](./admin-guide/adfconfig.yml). Any failure during the pipeline will cause it to halt.
+In the above example we are creating two pipelines. The first one will deploy from a repository named **iam** that lives in the account **111111222222**. This Repository will automatically be created for you by default if it does not exist. The pipeline will use the *cc-cloudformation* [type](#pipeline-types) and deploy in 3 steps. The first stage of the deployment will occur against all AWS Accounts that are in the `/security` Organization unit and be targeted to the `eu-west-1` region. After that, there is a manual approval phase which is denoted by the keyword `approval`. The next step will be the accounts within the `/banking/testing` OU for `eu-central-1` region. By providing a simple path or ou-id without a region definition it will default to the region chosen as the deployment account region in your [adfconfig](./admin-guide/adfconfig.yml). Any failure during the pipeline will cause it to halt. Also in this first pipeline we have decided we want to override the role that is used for the deployment of our CloudFormation on the target accounts. We don't simply want to use the default *adf-cloudformation-deployment-role* but rather a role named *infrastructure_role*. This role will need to exist on all target accounts with the correct permissions to deploy our IAM stack. As a streamlined way to get this role onto all target accounts, consider adding it to your bootstrap stacks. You can even pass separate roles for each stage of the pipelines using stage parameters if required.
 
 The second example is a simple example that deploys to an OU using its OU identifier number `ou-12341`. You can chose between a absolute path *(as in the first example)* in your AWS Organization or by specifying the OU ID. The second stage of this pipeline is simply an AWS Account ID. If you have a small amount of accounts or want to one of deploy to a specific account you can use an AWS Account Id if required.
 
-In this second example, we have defined a channel named `channel1` as the *NotificationEndpoint*. By doing this we will have events from this pipeline reported into the Slack channel named *channel1*. In order for this functionality to work as expected please see [Integrating Slack](./admin-guide/integrating-slack).
+In this second example, we have defined a channel named `channel1` as the *NotificationEndpoint*. By doing this we will have events from this pipeline reported into the Slack channel named *channel1*. In order for this functionality to work as expected please see [Integrating Slack](./admin-guide/integrating-slack). We also specify two regions we would like to use for the first stage of the pipeline.
 
 By default, the above pipelines will use a method of creating a change set and then executing the change set in two actions. Another top level option is to specify `action: replace_on_failure` on a specific pipeline. This changes the pipeline to no longer create a change set and then execute it but rather if the stack exists and is in a failed state *(reported as ROLLBACK_COMPLETE, ROLLBACK_FAILED, CREATE_FAILED, DELETE_FAILED, or UPDATE_ROLLBACK_FAILED)*, AWS CloudFormation deletes the stack and then creates a new stack. If the stack isn't in a failed state, AWS CloudFormation updates it. Use this action to automatically replace failed stacks without recovering or troubleshooting them. *You would typically choose this mode for testing.* You can use any of the action types such as *create_update* defined [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html).
 
-You can also run pipelines on a specific schedule, this is common for pipelines that produce some sort of output on a regular basis. For example, creating a new [AMI each week](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html). To do this specify the cron expression as the input for the *ScheduleExpression* parameter within the pipeline of your choice. You can choose between a *rate* expression or *cron* expression, [read more](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
+You can also run pipelines on a specific schedule, this is common for pipelines that produce some sort of output on a regular basis. For example, creating a new [AMI each week](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html). To do this specify the [cron](https://en.wikipedia.org/wiki/Cron) expression as the input for the *ScheduleExpression* parameter within the pipeline of your choice. You can choose between a *rate* expression or *cron* expression, [read more](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 
 ```yaml
   - name: ami-builder
@@ -68,7 +69,7 @@ You can also run pipelines on a specific schedule, this is common for pipelines 
         name: some-account
 ```
 
-If the template that is being deployed contains a Transform, such as a Serverless Transform it needs to be packaged and uploaded to S3 in every region where it will need to be deployed. This can be achieved by setting the `contains_transform: true` parameter and updating the buildspec for your pipeline to call the `bash adf-build/helpers/package_transform.sh` script. This script will package your lambda to each region and generate a region specific template.yml for the pipeline deploy stages.
+If the template that is being deployed contains a transform, such as a Serverless Transform it needs to be packaged and uploaded to S3 in every region where it will need to be deployed. This can be achieved by setting the `contains_transform: true` *(See samples folder)* parameter and updating the *buildspec.yml* for your pipeline to call the `bash adf-build/helpers/package_transform.sh` script. This script will package your lambda to each region and generate a region specific template.yml for the pipeline deploy stages.
 
 If you decide you no longer require a specific pipeline you can remove it from the deployment_map.yml file and commit those changes back to the *aws-deployment-framework-pipelines* repository *(on the deployment account)* in order for it to be cleaned up. The resources that were created as outputs from this pipeline will **not** be removed by this process.
 
@@ -90,11 +91,11 @@ targets:
 targets:
   - path: 9999999999
     regions: eu-west-1
-    name: my-special-account
+    name: my-special-account # Defaults to adf-cloudformation-deployment-role
     params:
       Foo: Bar
-  - path: /my_ou/production
-    regions: eu-central-1
+  - path: /my_ou/production # This can also be an array
+    regions: [eu-central-1, us-west-1]
     name: production_step
     params:
       Baz: Waffle
@@ -134,6 +135,8 @@ artifacts:
 In the example we have three steps to our install phase in our build, the remaining phases and steps you add are up to you. In the above steps we simply bring in the shared modules we will need to run our main function in *generate_params.py*. The $S3_BUCKET_NAME variable is available in AWS CodeBuild as we pass this in from our initial creation of the that defines the CodeBuild Project. You do not need to change this.
 
 Other packages such as [cfn-lint](https://github.com/awslabs/cfn-python-lint) can be installed in order to validate that our CloudFormation templates are up to standard and do not contain any obvious errors. If you wish to add in any extra packages you can add them to the *requirements.txt* in the `bootstrap_repository` which is brought down into AWS CodeBuild and installed. Otherwise you can add them into any pipelines specific buildspec.yml.
+
+If you wish to hide away the steps that can occur in AWS CodeBuild, you can move the *buildspec.yml* content itself into the pipeline type. By doing this, you can remove the option to have a buildspec.yml in the source repository at all. This is a potential way to enforce certain build steps for certain pipeline types. For an example of this, see the pipeline type for *s3-s3.yml.j2*.
 
 ### CloudFormation Parameters and Tagging
 
@@ -264,6 +267,8 @@ When you use the special keyword **"resolve:"**, the value in the specified path
 
 To highlight an example of how Parameter Injection can work well, think of the following scenario: You have some value that you wish to rotate on a monthly bases. You have some automation in place that updates the value of a Parameter store parameter to add in this new value. Each time this pipeline runs it will check for that value and update the resources accordingly, effectively detaching the parameters from the pipeline itself.
 
+There is also the concept of optionally resolving or importing values. This can be achieved by ending the import or resolve function with a **?**. For example, if you want to resolve a value from Parameter Store that might or might not yet exist you can use an optional resolve *(eg resolve:/my/path/to/myMagicKey?)*. If the key *myMagicKey* does not exist in Parameter Store then an empty string will be returned as the value.
+
 Parameter injection is also useful for importing exported values from CloudFormation stacks in other accounts or regions. Using the special **"import"** syntax you can access these values directly into your parameter files.
 
 ```json
@@ -274,7 +279,7 @@ Parameter injection is also useful for importing exported values from CloudForma
 }
 ```
 
-In the above example *123456789101* is the AWS Account Id in which we want to pull a value from, *eu-west-1* is the region, stack_name is the CloudFormation stack name and *export_key* is the output key name *(not export name)*.
+In the above example *123456789101* is the AWS Account Id in which we want to pull a value from, *eu-west-1* is the region, stack_name is the CloudFormation stack name and *export_key* is the output key name *(not export name)*. Again, this concept works with the optional style syntax *(eg, import:123456789101:eu-west-1:stack_name:export_key?)* if the key *export_key* does not exist at the point in time when this specific import is executed, it will return an empty string as the parameter value rather than an error since it is considered optional.
 
 Another built-in function is **upload**, You can use *upload* to perform an automated upload of a resource such as a template or file into Amazon S3 as part of the build process.
 Once the upload is complete, the Amazon S3 URL for the object will be put in place of the *upload* string in the parameter file.
@@ -284,12 +289,12 @@ For example, If you are deploying products that will be made available via Servi
 ```json
 {
     "Parameters": {
-        "ProductYTemplateURL": "upload:productY/template.yml"
+        "ProductYTemplateURL": "upload:path:productY/template.yml"
     }
 }
 ```
 
-In the above example, we are calling the **upload** function on a file called `template.yml` that lives in the *productY* folder within our repository. The string *"upload:productY/template.yml"* will be replaced by the URL of the object in S3 once it has been uploaded. You can also upload files to S3 Buckets within specific regions by adding in the region name as part of the string *(eg upload:us-west-1:productY/template.yml)*.
+In the above example, we are calling the **upload** function on a file called `template.yml` that lives in the *productY* folder within our repository and then returning the path style URL from S3 (indicated by the word *path* in the string). The string *"upload:path:productY/template.yml"* will be replaced by the URL of the object in S3 once it has been uploaded. You can optionally also upload files to S3 Buckets within specific regions by adding in the region name as part of the string *(eg upload:path:us-west-1:productY/template.yml)*. The upload function allows for two response types, to use the classic [Path Style method](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) use the keyword *path* in your upload string as per the example above. If you wish to use virtual-hosted style *(eg, http://johnsmith-bucket.s3-eu-west-1.amazonaws.com/homepage.html)* then define your upload string such as *upload:virtual-path:us-west-1:productY/template.yml*.
 
 The bucket being used to hold the uploaded object is the same Amazon S3 Bucket that holds deployment artifacts *(On the Deployment Account)* for the specific region which they are intended to be deployed to. Files that are uploaded using this functionality will receive a random name each time they are uploaded.
 
@@ -351,3 +356,60 @@ phases:
 artifacts:
   files: '**/*'
 ```
+
+### Using Anchors and Alias
+
+You can take advantage of YAML Anchors and Alias' in the deployment map files. As you can see from the example below, The &generic_params and &generic_targets are anchors. They can be added to any mapping, sequence or scalar. Once you create an anchor, you can reference it anywhere within the map again with its alias *(eg *generic_params)* to reproduce their values, similar to variables.
+
+```yaml
+pipelines:
+  - name: sample-vpc
+    type: cc-cloudformation
+    deployment_role: infra-deployment-role
+    params: &generic_params
+      - SourceAccountId: 111111111111
+    targets: &generic_targets
+      - /banking/testing
+      - approval
+      - path: /banking/production
+        regions: eu-west-1
+
+  - name: some-other-pipeline
+    type: cc-cloudformation
+    deployment_role: infra-deployment-role
+    params: *generic_params
+    targets: *generic_targets
+```
+
+For more advanced yaml usage, see [here](https://learnxinyminutes.com/docs/yaml/)
+
+### One to many relationships
+
+If required, it is possible to create multiple Pipelines that are tied to the same Repository.
+
+```yaml
+pipelines:
+  - name: sample-vpc-eu-west-1
+    type: cc-cloudformation
+    regions: eu-west-1
+    deployment_role: infra-deployment-role
+    params: &generic_params
+      - SourceAccountId: 111111111111
+      - RepositoryName: sample-vpc # Here we are inserting the RepositoryName as a Parameter
+    targets:
+      - /banking/testing
+      - approval
+      - /banking/production
+
+  - name: sample-vpc-us-east-1
+    type: cc-cloudformation
+    regions: us-east-1
+    deployment_role: infra-deployment-role
+    params: *generic_params # Using The YAML Anchors concept as mentioned above, we get those same values.
+    targets:
+      - /banking/testing
+      - approval
+      - /banking/production
+```
+
+By passing in the Repository name *(RepositoryName)* we are overriding the **name** property which normally is the name of our associated repository. This will tie both of these pipelines to the single *sample-vpc* repository on the *111111111111* AWS Account. When using this format the automatic repository creation will be skipped.

--- a/samples/sample-ec2-with-codedeploy/params/global.json
+++ b/samples/sample-ec2-with-codedeploy/params/global.json
@@ -6,8 +6,8 @@
         "InstanceMinSize": "1",
         "ImageId": "resolve:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
         "InstanceType": "t3.micro",
-        "CodeDeployAgentInstallScript": "upload:scripts/install-codedeploy.sh",
-        "JavaInstallScript": "upload:scripts/install-deps.sh",
+        "CodeDeployAgentInstallScript": "upload:path:scripts/install-codedeploy.sh",
+        "JavaInstallScript": "upload:path:scripts/install-deps.sh",
         "KeyPair": "some_key_pair"
     }
 }

--- a/samples/sample-ec2-with-codedeploy/template.yml
+++ b/samples/sample-ec2-with-codedeploy/template.yml
@@ -246,3 +246,9 @@ Resources:
       Cooldown: 300
       PolicyType: "SimpleScaling"
       ScalingAdjustment: 1
+Outputs:
+  ExternalUrl:
+    Description: The url of the external load balancer
+    Value: !Join ['', ['http://', !GetAtt 'PublicLoadBalancer.DNSName']]
+    Export:
+      Name: 'ExternalUrl'

--- a/src/lambda_codebase/account/handler.py
+++ b/src/lambda_codebase/account/handler.py
@@ -9,7 +9,7 @@ import os
 
 try:
     from main import lambda_handler # pylint: disable=unused-import
-except Exception as err:  # pylint: disable=broad-except
+except Exception as err: # pylint: disable=broad-except
     from urllib.request import Request, urlopen
     import json
 

--- a/src/lambda_codebase/account/main.py
+++ b/src/lambda_codebase/account/main.py
@@ -11,7 +11,7 @@ import logging
 import time
 import json
 import boto3
-from cfn_custom_resource import (  # pylint: disable=unused-import
+from cfn_custom_resource import ( # pylint: disable=unused-import
     lambda_handler,
     create,
     update,

--- a/src/lambda_codebase/cross_region_bucket/handler.py
+++ b/src/lambda_codebase/cross_region_bucket/handler.py
@@ -7,7 +7,7 @@ The Cross Region S3 Bucket Handler that is called when ADF is installed to creat
 
 try:
     from main import lambda_handler # pylint: disable=unused-import
-except Exception as err:  # pylint: disable=broad-except
+except Exception as err: # pylint: disable=broad-except
     from urllib.request import Request, urlopen
     import json
 

--- a/src/lambda_codebase/cross_region_bucket/main.py
+++ b/src/lambda_codebase/cross_region_bucket/main.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass, asdict
 import logging
 import json
 import secrets
-import string  # pylint: disable=deprecated-module # https://www.logilab.org/ticket/2481
+import string # pylint: disable=deprecated-module # https://www.logilab.org/ticket/2481
 import boto3
-from cfn_custom_resource import (  # pylint: disable=unused-import
+from cfn_custom_resource import ( # pylint: disable=unused-import
     lambda_handler,
     create,
     update,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -262,7 +262,7 @@ def main(): #pylint: disable=R0915
         # Updating the stack on the master account in deployment region
         cloudformation = CloudFormation(
             region=config.deployment_account_region,
-            deployment_account_region=config.deployment_account_region, # pylint: disable=R0801
+            deployment_account_region=config.deployment_account_region,
             role=boto3,
             wait=True,
             stack_name=None,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/scp.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/scp.py
@@ -12,7 +12,7 @@ from logger import configure_logger
 
 LOGGER = configure_logger(__name__)
 
-class SCP():
+class SCP:
     def __init__(self):
         pass
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
@@ -282,6 +282,7 @@ class CloudFormation(StackProperties):
 
     def get_stack_output(self, value):
         try:
+            LOGGER.debug("Retrieving value: %s", value)
             response = self.client.describe_stacks(
                 StackName=self.stack_name
             )

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -188,7 +188,7 @@ class Organizations: # pylint: disable=R0904
                 raise Exception(
                     "Path {0} failed to return a child OU at '{1}'".format(
                         path, p[0]))
-        else:  # pylint: disable=W0120
+        else: # pylint: disable=W0120
             return self.get_accounts_for_parent(ou_id)
 
     def build_account_path(self, ou_id, account_path, cache):

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
@@ -22,21 +22,38 @@ class S3:
         self.resource = boto3.resource('s3', region_name=region)
         self.bucket = bucket
 
-    def put_object(self, key, file_path):
+    def build_pathing_style(self, style, key):
+        if style == 'path':
+            if self.region == 'us-east-1':
+                return "https://s3.amazonaws.com/{bucket}/{key}".format(
+                    bucket=self.bucket,
+                    key=key
+                )
+            return "https://s3-{region}.amazonaws.com/{bucket}/{key}".format(
+                region=self.region,
+                bucket=self.bucket,
+                key=key
+            )
+        if style == 'virtual-hosted':
+            if self.region == 'us-east-1':
+                return "http://{bucket}.s3.amazonaws.com/{key}".format(
+                    bucket=self.bucket,
+                    key=key
+                )
+            return "http://{bucket}.s3-{region}.amazonaws.com/{key}".format(
+                region=self.region,
+                bucket=self.bucket,
+                key=key
+            )
+        raise Exception("Unknown upload style syntax, path or virtual-hosted must be specified.")
+
+
+    def put_object(self, key, file_path, style="path"):
         """
         Put the object into S3 and return the S3 URL of the object
         """
         self.resource.Object(self.bucket, key).put(Body=open(file_path, 'rb'))
-        if self.region == 'us-east-1':
-            return "https://s3.amazonaws.com/{bucket}/{key}".format(
-                bucket=self.bucket,
-                key=key
-            )
-        return "https://s3-{region}.amazonaws.com/{bucket}/{key}".format(
-            region=self.region,
-            bucket=self.bucket,
-            key=key
-        )
+        return self.build_pathing_style(style, key)
 
     def read_object(self, key):
         s3_object = self.resource.Object(self.bucket, key)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/account_name1_eu-central-1.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/account_name1_eu-central-1.yml
@@ -1,2 +1,3 @@
 Parameters:
     CostCenter: free
+    MySpecialValue: resolve:/values/some_value

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_deployment_map.py
@@ -23,27 +23,27 @@ def cls():
         )
     )
 
-def test_validate_deployment_map(cls):
-    assert cls._validate_deployment_map() == None
+def test_validate(cls):
+    assert cls._validate() == None
 
-def test_validate_deployment_map_invalid_no_content(cls):
+def test_validate_invalid_no_content(cls):
     cls.map_contents = {}
     with raises(InvalidDeploymentMapError):
-        cls._validate_deployment_map()
+        cls._validate()
 
 def test_validate_deployment_leading_zero(cls):
-    cls._validate_deployment_map()
+    cls._validate()
     target_pipeline = [i for i in cls.map_contents['pipelines'] if i.get('name') == 'some-thing'][0]['targets']
     assert '013456789101' in target_pipeline
 
-def test_validate_deployment_map_path_only(cls):
+def test_validate_path_only(cls):
     cls.map_contents = {"pipelines": [{"targets": [{"path": "/something"}]}]}
-    assert cls._validate_deployment_map() == None
+    assert cls._validate() == None
 
-def test_validate_deployment_map_invalid_paths(cls):
+def test_validate_invalid_paths(cls):
     cls.map_contents = {"pipelines": [{"targets": [{"paths": "/something", "regions": 'eu-west-1'}]}]}
     with raises(InvalidDeploymentMapError):
-        cls._validate_deployment_map()
+        cls._validate()
 
 def test_update_deployment_parameters(cls):
     cls.parameter_store = Mock()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_generate_params.py
@@ -9,9 +9,13 @@ import boto3
 import sys
 
 from pytest import fixture
-from mock import Mock
+from mock import Mock, patch
+from cache import Cache
 from generate_params import Parameters
-
+from parameter_store import ParameterStore
+from cloudformation import CloudFormation
+from sts import STS
+from resolver import Resolver
 
 @fixture
 def cls():
@@ -50,14 +54,13 @@ def test_parse_not_found(cls):
     assert parse == {'Parameters': {}, 'Tags': {}}
 
 
-def test_compare_cfn(cls):
+def test_param_updater(cls):
     parse = cls._parse(
         '{0}/stub_cfn_global'.format(cls.cwd)
     )
-    compare = cls._compare_cfn(
+    compare = cls._param_updater(
         parse,
-        {'Parameters': {}, 'Tags': {}},
-        'some_name'
+        {'Parameters': {}, 'Tags': {}}
     )
     assert compare == parse
 
@@ -94,14 +97,16 @@ def test_ensure_parameter_specific_contents(cls):
         "{0}/account_name1_eu-central-1.yml".format(cls.cwd),
         "{0}/params/account_name1_eu-central-1.yml".format(cls.cwd)
     )
-    cls.create_parameter_files()
 
-    parse_json = cls._parse(
-        "{0}/params/account_name1_eu-west-1".format(cls.cwd)
-    )
-    parse_yml = cls._parse(
-        "{0}/params/account_name1_eu-central-1".format(cls.cwd)
-    )
-
-    assert parse_json == {'Parameters': {'CostCenter': 'free', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}
-    assert parse_yml == {'Parameters': {'CostCenter': 'free', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}
+    with patch.object(ParameterStore, 'fetch_parameter', return_value='something') as ssm_mock:
+        with patch.object(CloudFormation, 'get_stack_output', return_value='something_else') as cfn_mock:
+            with patch.object(STS, 'assume_cross_account_role', return_value={}) as sts_mock:
+                cls.create_parameter_files()
+                parse_json = cls._parse(
+                    "{0}/params/account_name1_eu-west-1".format(cls.cwd)
+                )
+                parse_yml = cls._parse(
+                    "{0}/params/account_name1_eu-central-1".format(cls.cwd)
+                )
+                assert parse_json == {'Parameters': {'CostCenter': 'free', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}
+                assert parse_yml == {'Parameters': {'CostCenter': 'free', 'MySpecialValue': 'something', 'Environment': 'testing'}, 'Tags': {'TagKey': '123', 'MyKey': 'new_value'}}

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_pipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_pipeline.py
@@ -38,11 +38,11 @@ def test_pipeline_init_defaults(cls):
 def test_pipeline_replace_on_failure():
     assertion_pipeline = Pipeline(
         pipeline={
-        "name": "pipeline",
-        "params": [{"key": "value"}],
-        "targets": [],
-        "type": "cc-cloudformation",
-        "action": "replace_on_failure"
+            "name": "pipeline",
+            "params": [{"key": "value"}],
+            "targets": [],
+            "type": "cc-cloudformation",
+            "action": "replace_on_failure"
         }
     )
     assert assertion_pipeline.action == "REPLACE_ON_FAILURE"
@@ -51,11 +51,11 @@ def test_pipeline_replace_on_failure():
 def test_pipeline_contains_transform():
     assertion_pipeline = Pipeline(
         pipeline={
-        "name": "pipeline",
-        "params": [{"key": "value"}],
-        "targets": [],
-        "type": "cc-cloudformation",
-        "contains_transform": "true"
+            "name": "pipeline",
+            "params": [{"key": "value"}],
+            "targets": [],
+            "type": "cc-cloudformation",
+            "contains_transform": "true"
         }
     )
     assert assertion_pipeline.contains_transform == "true"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/handler.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/handler.py
@@ -4,7 +4,7 @@ The Initial Commit Handler that is called when ADF is installed to commit the in
 
 try:
     from initial_commit import lambda_handler # pylint: disable=unused-import
-except Exception as err:  # pylint: disable=broad-except
+except Exception as err: # pylint: disable=broad-except
     from urllib.request import Request, urlopen
     import json
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-buildonly.yml.j2
@@ -31,6 +31,10 @@ Parameters:
     Description: If the pipeline will automatically trigger based on update
     Type: String
     Default: False
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   SharedModulesBucket:
     Description: The S3 Bucket that holds shared modules between master and deployment account
     Type: AWS::SSM::Parameter::Value<String>
@@ -45,6 +49,7 @@ Parameters:
     Default: /cross_region/kms_arn/{{ deployment_account_region }}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
 Resources:
 {% if completion_trigger.get('pipelines', []) %}
   PipelineTriggerEventRule:
@@ -128,7 +133,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and CloudFormation Deployment Target
 Parameters:
+  RepositoryName:
+    Description: The Repository attached to this pipeline
+    Type: String
+    Default: ''
   ProjectName:
     Description: Name of the Project (This is automatically passed in by ADF)
     Type: String
@@ -35,6 +39,10 @@ Parameters:
     Description: If the pipeline will automatically trigger based on update
     Type: String
     Default: False
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   SharedModulesBucket:
     Description: The S3 Bucket that holds shared modules between master and deployment account
     Type: AWS::SSM::Parameter::Value<String>
@@ -51,6 +59,8 @@ Parameters:
 {% endfor %}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
+  HasCustomRepository: !Not [!Equals [!Ref RepositoryName, '']]
 Resources:
 {% if completion_trigger.get('pipelines', []) %}
   PipelineTriggerEventRule:
@@ -127,14 +137,14 @@ Resources:
       Targets:
         - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
           RoleArn: !GetAtt CronPipelineCloudWatchEventRole.Arn
-          Id: !Sub "adf-cron-${AWS::StackName}"
+          Id: !If [HasCustomRepository, !Sub "adf-cron-${ProjectName}", !Sub "adf-cron-${AWS::StackName}"]
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -176,7 +186,7 @@ Resources:
       State: "ENABLED"
       Targets:
         - Arn: !Ref PipelineSNSTopic
-          Id: !Sub "${AWS::StackName}-pipeline"
+          Id: !If [HasCustomRepository, !Sub "adf-pipeline-${ProjectName}", !Sub "adf-pipeline-${AWS::StackName}"]
 {% if "@" in notification_endpoint %}
           InputTransformer:
             InputTemplate: '"The pipeline <pipeline> from account <account> has <state> at <at>."'
@@ -238,7 +248,7 @@ Resources:
                 Version: 1
                 Provider: CodeCommit
               Configuration:
-                RepositoryName: !Ref ProjectName
+                RepositoryName: !If [HasCustomRepository, !Ref RepositoryName, !Ref ProjectName] 
                 BranchName: !Ref BranchName
               OutputArtifacts:
                 - Name: TemplateSource
@@ -290,7 +300,7 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 ActionMode: {{ action }}
-                StackName: !Sub "${StackPrefix}-${ProjectName}"
+                StackName: !If [HasCustomRepository, !Sub "${StackPrefix}-${RepositoryName}", !Sub "${StackPrefix}-${ProjectName}"]
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
 {% if contains_transform %}
                 TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
@@ -299,7 +309,11 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -314,7 +328,7 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 ActionMode: CHANGE_SET_REPLACE
-                StackName: !Sub "${StackPrefix}-${ProjectName}"
+                StackName: !If [HasCustomRepository, !Sub "${StackPrefix}-${RepositoryName}", !Sub "${StackPrefix}-${ProjectName}"]
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
 {% if contains_transform %}
                 TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
@@ -323,7 +337,11 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -338,8 +356,12 @@ Resources:
               Configuration:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
-                StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
+                StackName: !If [HasCustomRepository, !Sub "${StackPrefix}-${RepositoryName}", !Sub "${StackPrefix}-${ProjectName}"]
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               RunOrder: 2
               Region: {{ region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"
@@ -355,7 +377,7 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 ActionMode: CHANGE_SET_REPLACE
-                StackName: !Sub "${StackPrefix}-${ProjectName}"
+                StackName: !If [HasCustomRepository, !Sub "${StackPrefix}-${RepositoryName}", !Sub "${StackPrefix}-${ProjectName}"]
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
 {% if contains_transform %}
                 TemplatePath: !Sub "${ProjectName}-build::template_{{ region }}.yml"
@@ -364,8 +386,11 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ top_level_region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
-
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -380,9 +405,12 @@ Resources:
               Configuration:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
-                StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
-
+                StackName: !If [HasCustomRepository, !Sub "${StackPrefix}-${RepositoryName}", !Sub "${StackPrefix}-${ProjectName}"]
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               RunOrder: 2
               Region: {{ top_level_region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-codedeploy.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-codedeploy.yml.j2
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and CodeDeploy Target
 Parameters:
+  RepositoryName:
+    Description: The Repository attached to this pipeline
+    Type: String
+    Default: ''
   ProjectName:
     Description: Name of the Project (This is automatically passed in by ADF)
     Type: String
@@ -31,6 +35,10 @@ Parameters:
     Description: Name of the CodeCommit Branch you will use to trigger the pipeline
     Type: String
     Default: master
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   RestartExecutionOnUpdate:
     Description: If the pipeline will automatically trigger based on update
     Type: String
@@ -51,6 +59,8 @@ Parameters:
 {% endfor %}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
+  HasCustomRepository: !Not [!Equals [!Ref RepositoryName, '']]
 Resources:
 {% if completion_trigger.get('pipelines', []) %}
   PipelineTriggerEventRule:
@@ -134,7 +144,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -238,7 +248,7 @@ Resources:
                 Version: 1
                 Provider: CodeCommit
               Configuration:
-                RepositoryName: !Ref ProjectName
+                RepositoryName: !If [HasCustomRepository, !Ref RepositoryName, !Ref ProjectName]
                 BranchName: !Ref BranchName
               OutputArtifacts:
                 - Name: TemplateSource

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-customdeploy.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-customdeploy.yml.j2
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and CloudFormation Deployment Target
 Parameters:
+  RepositoryName:
+    Description: The Repository attached to this pipeline
+    Type: String
+    Default: ''
   ProjectName:
     Description: Name of the Project (This is automatically passed in by ADF)
     Type: String
@@ -31,11 +35,15 @@ Parameters:
     Description: Name of the CodeCommit Branch you will use to trigger the pipeline
     Type: String
     Default: master
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   RestartExecutionOnUpdate:
     Description: If the pipeline will automatically trigger based on update
     Type: String
     Default: False
-  SharedModulesBucket;
+  SharedModulesBucket:
     Description: The S3 Bucket that holds shared modules between master and deployment account
     Type: AWS::SSM::Parameter::Value<String>
     Default: deployment_account_bucket
@@ -51,6 +59,8 @@ Parameters:
 {% endfor %}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
+  HasCustomRepository: !Not [!Equals [!Ref RepositoryName, '']]
 Resources:
   CronCloudwatchEventsRule:
     Type: "AWS::Events::Rule"
@@ -135,7 +145,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -186,7 +196,7 @@ Resources:
           - Name: ACCOUNT_ID
             Value: !Ref AWS::AccountId
           - Name: DEPLOY_ROLE
-            Value: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+            Value: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
       Source:
         Type: CODEPIPELINE
         BuildSpec: {{ stage.get('params').get('Specfile') or 'deployspec.yml'}}
@@ -221,7 +231,7 @@ Resources:
           - Name: ACCOUNT_ID
             Value: !Ref AWS::AccountId
           - Name: DEPLOY_ROLE
-            Value: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+            Value: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
       Source:
         Type: CODEPIPELINE
         BuildSpec: {{  stage.get('params').get('Specfile') or 'deployspec.yml'}}
@@ -314,7 +324,7 @@ Resources:
                 Version: 1
                 Provider: CodeCommit
               Configuration:
-                RepositoryName: !Ref ProjectName
+                RepositoryName: !If [HasCustomRepository, !Ref RepositoryName, !Ref ProjectName ] 
                 BranchName: !Ref BranchName
               OutputArtifacts:
                 - Name: TemplateSource

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-s3.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-s3.yml.j2
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and S3 Deployment Target
 Parameters:
+  RepositoryName:
+    Description: The Repository attached to this pipeline
+    Type: String
+    Default: ''
   ProjectName:
     Description: Name of the Project
     Type: String
@@ -20,6 +24,10 @@ Parameters:
     Description: The Email Address / Slack channel notifications will go to for changes related to this pipeline
     Type: String
     Default: ''
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   ComputeType:
     Description: The ComputeType for CodeBuild
     Type: String
@@ -56,6 +64,8 @@ Parameters:
 {% endfor %}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
+  HasCustomRepository: !Not [!Equals [!Ref RepositoryName, '']]
 Resources:
 {% if completion_trigger.get('pipelines', []) %}
   PipelineTriggerEventRule:
@@ -139,7 +149,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -243,7 +253,7 @@ Resources:
                 Version: 1
                 Provider: CodeCommit
               Configuration:
-                RepositoryName: !Ref ProjectName
+                RepositoryName: !If [HasCustomRepository, !Ref RepositoryName, !Ref ProjectName] 
                 BranchName: !Ref BranchName
               OutputArtifacts:
                 - Name: TemplateSource

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-service-catalog.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-service-catalog.yml.j2
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Template For CodePipeline - AWS CodeCommit Source and Service Catalog Target
 Parameters:
+  RepositoryName:
+    Description: The Repository attached to this pipeline
+    Type: String
+    Default: ''
   ProjectName:
     Description: Name of the Project (This is automatically passed in by ADF)
     Type: String
@@ -34,6 +38,10 @@ Parameters:
     Description: Name of the CodeCommit Branch you will use to trigger the pipeline
     Type: String
     Default: master
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   RestartExecutionOnUpdate:
     Description: If the pipeline will automatically trigger based on update
     Type: String
@@ -54,6 +62,8 @@ Parameters:
 {% endfor %}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
+  HasCustomRepository: !Not [!Equals [!Ref RepositoryName, '']]
 Resources:
 {% if completion_trigger.get('pipelines', []) %}
   PipelineTriggerEventRule:
@@ -137,7 +147,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -241,7 +251,7 @@ Resources:
                 Version: 1
                 Provider: CodeCommit
               Configuration:
-                RepositoryName: !Ref ProjectName
+                RepositoryName: !If [HasCustomRepository, !Ref RepositoryName, !Ref ProjectName]
                 BranchName: !Ref BranchName
               OutputArtifacts:
                 - Name: TemplateSource

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/github-cloudformation.yml.j2
@@ -37,6 +37,10 @@ Parameters:
   Owner:
     Description: The owner of the github Repo
     Type: String
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   BranchName:
     Description: Branch to trigger the pipeline from
     Type: String
@@ -61,6 +65,7 @@ Parameters:
 {% endfor %}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
 Resources:
 {% if completion_trigger.get('pipelines', []) %}
   PipelineTriggerEventRule:
@@ -158,7 +163,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -325,8 +330,11 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
-
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -350,8 +358,11 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
-
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -367,8 +378,11 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
-
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               RunOrder: 2
               Region: {{ region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"
@@ -393,8 +407,11 @@ Resources:
 {% endif %}
                 TemplateConfiguration: !Sub "${ProjectName}-build::params/{{ stage.name }}_{{ top_level_region }}.json"
                 Capabilities: CAPABILITY_NAMED_IAM
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
-
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               InputArtifacts:
                 - Name: !Sub "${ProjectName}-build"
               RunOrder: 1
@@ -410,8 +427,11 @@ Resources:
                 ChangeSetName: !Sub "${StackPrefix}-${ProjectName}"
                 ActionMode: CHANGE_SET_EXECUTE
                 StackName: !Sub "${StackPrefix}-${ProjectName}"
-                RoleArn: "{{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeployRole')) if stage.get('params').get('DeployRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}"
-
+{% if deployment_role %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, deployment_role) }}
+{% else %}
+                RoleArn: {{ 'arn:aws:iam::{0}:role/{1}'.format(stage.id, stage.get('params').get('DeploymentRole')) if stage.get('params').get('DeploymentRole') else 'arn:aws:iam::{0}:role/adf-cloudformation-deployment-role'.format(stage.id) }}
+{% endif %}
               RunOrder: 2
               Region: {{ top_level_region }}
               RoleArn: "arn:aws:iam::{{ stage.id }}:role/adf-cloudformation-role"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/s3-s3.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/s3-s3.yml.j2
@@ -37,6 +37,10 @@ Parameters:
   SourceObjectKey:
     Description: The Source Object Key you wish to deploy into another S3 Bucket.
     Type: String
+  CustomBuildRole:
+    Description: If you wish to use a custom build role for CodeBuild
+    Type: String
+    Default: ""
   Extract:
     Description: If you want to extract the artifact in S3 (unzip)
     Type: String
@@ -58,6 +62,7 @@ Parameters:
 {% endfor %}
 Conditions:
   HasSchedule: !Not [!Equals [!Ref ScheduleExpression, '']]
+  HasCustomBuildRole: !Not [!Equals [!Ref CustomBuildRole, '']]
 Resources:
 {% if completion_trigger.get('pipelines', []) %}
   PipelineTriggerEventRule:
@@ -141,7 +146,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: !ImportValue CodeBuildRoleArn
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:

--- a/src/lambda_codebase/initial_commit/handler.py
+++ b/src/lambda_codebase/initial_commit/handler.py
@@ -4,7 +4,7 @@ The Initial Commit Handler that is called when ADF is installed to commit the in
 
 try:
     from initial_commit import lambda_handler # pylint: disable=unused-import
-except Exception as err:  # pylint: disable=broad-except
+except Exception as err: # pylint: disable=broad-except
     from urllib.request import Request, urlopen
     import json
 

--- a/src/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/initial_commit.py
@@ -9,13 +9,12 @@ from pathlib import Path
 import os
 import boto3
 import jinja2
-from cfn_custom_resource import (  # pylint: disable=unused-import
+from cfn_custom_resource import ( # pylint: disable=unused-import
     lambda_handler,
     create,
     update,
     delete,
 )
-
 
 PhysicalResourceId = str
 Data = Mapping[str, str]
@@ -67,7 +66,7 @@ class Event:
 
     def __post_init__(self):
         self.ResourceProperties = CustomResourceProperties(
-            **self.ResourceProperties  # pylint: disable=not-a-mapping
+            **self.ResourceProperties # pylint: disable=not-a-mapping
         )
 
 
@@ -103,7 +102,6 @@ class FileToDelete:
 class CreateEvent(Event):
     pass
 
-
 @dataclass
 class UpdateEvent(Event):
     PhysicalResourceId: str
@@ -111,22 +109,61 @@ class UpdateEvent(Event):
 
     def __post_init__(self):
         self.ResourceProperties = CustomResourceProperties(
-            **self.ResourceProperties  # pylint: disable=not-a-mapping
+            **self.ResourceProperties # pylint: disable=not-a-mapping
         )
         self.OldResourceProperties = CustomResourceProperties(
-            **self.OldResourceProperties  # pylint: disable=not-a-mapping
+            **self.OldResourceProperties # pylint: disable=not-a-mapping
         )
 
-def chunks(l, n):
-    n = max(1, n)
-    return (l[i:i+n] for i in range(0, len(l), n))
+def generate_create_branch_input(event, repo_name, commit_id):
+    return {
+        "repositoryName": repo_name,
+        "branchName": event.ResourceProperties.Version,
+        "commitId": commit_id
+    }
+
+def generate_delete_branch_input(event, repo_name):
+    return {
+        "repositoryName": repo_name,
+        "branchName": event.ResourceProperties.Version
+    }
+
+def chunks(list_to_chunk, number_to_chunk_into):
+    number_of_chunks = max(1, number_to_chunk_into)
+    return (list_to_chunk[item:item + number_of_chunks] for item in range(0, len(list_to_chunk), number_of_chunks))
+
+def generate_pull_request_input(event, repo_name):
+    return {
+        "title": 'ADF {0} Automated Update PR'.format(event.ResourceProperties.Version),
+        "description": PR_DESCRIPTION.format(event.ResourceProperties.Version),
+        "targets": [
+            {
+                'repositoryName': repo_name,
+                'sourceReference': event.ResourceProperties.Version,
+                'destinationReference': 'master'
+            },
+        ]
+    }
+
+def generate_commit_input(repo_name, index, branch="master", parent_commit_id=None, puts=None, deletes=None):
+    output = {
+        "repositoryName": repo_name,
+        "branchName": branch,
+        "authorName": "AWS ADF Builders Team",
+        "email": "adf-builders@amazon.com",
+        "commitMessage": "Automated Commit - {0} Part {1}".format("Delete" if deletes else "Create", index),
+        "putFiles": puts if puts else [],
+        "deleteFiles": deletes if deletes else []
+    }
+    if parent_commit_id:
+        output["parentCommitId"] = parent_commit_id
+    return output
 
 @create()
-def create_(event: Mapping[str, Any], _context: Any) -> Tuple[Union[None, PhysicalResourceId], Data]: #pylint: disable=R0912, R0915
+def create_(event: Mapping[str, Any], _context: Any) -> Tuple[Union[None, PhysicalResourceId], Data]:
     create_event = CreateEvent(**event)
     repo_name = repo_arn_to_name(create_event.ResourceProperties.RepositoryArn)
     directory = create_event.ResourceProperties.DirectoryName
-    files_to_commit = get_files_to_commit(directory)
     try:
         commit_id = CC_CLIENT.get_branch(
             repositoryName=repo_name,
@@ -137,145 +174,83 @@ def create_(event: Mapping[str, Any], _context: Any) -> Tuple[Union[None, Physic
             branchName=create_event.ResourceProperties.Version,
             commitId=commit_id
         )
-        for index, files in enumerate(chunks([f.as_dict() for f in files_to_commit], 99)):
-            commit_args = {
-                "repositoryName": repo_name,
-                "branchName": create_event.ResourceProperties.Version,
-                "authorName": "AWS ADF Builders Team",
-                "parentCommitId": commit_id,
-                "email": "adf-builders@amazon.com",
-                "commitMessage": "ADF {0} Automated Commit - Create Part {1}".format(create_event.ResourceProperties.Version, index),
-                "putFiles": files
-            }
+        # CodeCommit only allows 100 files per commit, so we chunk them up here
+        for index, files in enumerate(chunks([f.as_dict() for f in get_files_to_commit(directory)], 99)):
             if index == 0:
-                commit_response = CC_CLIENT.create_commit(**commit_args)
-                commit_id = commit_response["commitId"]
+                commit_id = CC_CLIENT.create_commit(
+                    **generate_commit_input(repo_name, index, puts=files)
+                )["commitId"]
             else:
-                commit_args["parentCommitId"] = commit_id
-                commit_response = CC_CLIENT.create_commit(**commit_args)
-                commit_id = commit_response["commitId"]
+                commit_id = CC_CLIENT.create_commit(
+                    **generate_commit_input(repo_name, index, puts=files, parent_commit_id=commit_id)
+                )["commitId"]
 
         CC_CLIENT.create_pull_request(
-            title='ADF {0} Automated Update PR'.format(create_event.ResourceProperties.Version),
-            description=PR_DESCRIPTION.format(create_event.ResourceProperties.Version),
-            targets=[
-                {
-                    'repositoryName': repo_name,
-                    'sourceReference': create_event.ResourceProperties.Version,
-                    'destinationReference': 'master'
-                },
-            ]
+            **generate_pull_request_input(create_event, repo_name)
         )
         return event.get("PhysicalResourceId"), {}
+
     except (CC_CLIENT.exceptions.FileEntryRequiredException, CC_CLIENT.exceptions.NoChangeException):
-        CC_CLIENT.delete_branch(
-            repositoryName=repo_name,
-            branchName=create_event.ResourceProperties.Version
-        )
+        CC_CLIENT.delete_branch(**generate_delete_branch_input(create_event, repo_name))
         return event.get("PhysicalResourceId"), {}
+
     except CC_CLIENT.exceptions.BranchDoesNotExistException:
         files_to_commit = get_files_to_commit(directory)
         if directory == "bootstrap_repository":
             adf_config = create_adf_config_file(create_event.ResourceProperties)
             files_to_commit.append(adf_config)
-        latest_commit_id = 0
-        for index, files in enumerate(chunks([f.as_dict() for f in files_to_commit], 99)):
-            commit_args = {
-                "repositoryName": repo_name,
-                "branchName": "master",
-                "authorName": "AWS ADF Builders Team",
-                "email": "adf-builders@amazon.com",
-                "commitMessage": "Initial Automated Commit - Create Part {0}".format(index),
-                "putFiles": files
-            }
-            if index == 0:
-                commit_response = CC_CLIENT.create_commit(**commit_args)
-                latest_commit_id = commit_response["commitId"]
-            else:
-                commit_args["parentCommitId"] = latest_commit_id
-                commit_response = CC_CLIENT.create_commit(**commit_args)
-                latest_commit_id = commit_response["commitId"]
 
-        return commit_response["commitId"], {}
+        for index, files in enumerate(chunks([f.as_dict() for f in files_to_commit], 99)):
+            if index == 0:
+                commit_id = CC_CLIENT.create_commit(
+                    **generate_commit_input(repo_name, index, puts=files)
+                )["commitId"]
+            else:
+                commit_id = CC_CLIENT.create_commit(
+                    **generate_commit_input(repo_name, index, puts=files, parent_commit_id=commit_id)
+                )["commitId"]
+
+        return commit_id, {}
 
 @update()
 def update_(event: Mapping[str, Any], _context: Any, create_pr=False) -> Tuple[PhysicalResourceId, Data]: #pylint: disable=R0912, R0915
     update_event = UpdateEvent(**event)
-    directory = update_event.ResourceProperties.DirectoryName
     repo_name = repo_arn_to_name(update_event.ResourceProperties.RepositoryArn)
     files_to_delete = get_files_to_delete(repo_name)
-    files_to_commit = get_files_to_commit(directory)
-
+    files_to_commit = get_files_to_commit(update_event.ResourceProperties.DirectoryName)
     commit_id = CC_CLIENT.get_branch(
         repositoryName=repo_name,
         branchName="master",
     )["branch"]["commitId"]
     CC_CLIENT.create_branch(
-        repositoryName=repo_name,
-        branchName=update_event.ResourceProperties.Version,
-        commitId=commit_id
+        **generate_create_branch_input(update_event, repo_name, commit_id)
     )
 
     if files_to_commit:
         try:
             for index, files in enumerate(chunks([f.as_dict() for f in files_to_commit], 99)):
-                commit_args = {
-                    "repositoryName": repo_name,
-                    "branchName": update_event.ResourceProperties.Version,
-                    "authorName": "AWS ADF Builders Team",
-                    "parentCommitId": commit_id,
-                    "email": "adf-builders@amazon.com",
-                    "commitMessage": "ADF {0} Automated Update PR - Create Part {1}".format(update_event.ResourceProperties.Version, index),
-                    "putFiles": files
-                }
-                if index == 0:
-                    commit_response = CC_CLIENT.create_commit(**commit_args)
-                    create_pr = True # pylint: disable=W0621
-                    commit_id = commit_response["commitId"]
-                else:
-                    commit_args["parentCommitId"] = commit_id
-                    commit_response = CC_CLIENT.create_commit(**commit_args)
-                    commit_id = commit_response["commitId"]
+                commit_id = CC_CLIENT.create_commit(**generate_commit_input(
+                    repo_name,
+                    index,
+                    parent_commit_id=commit_id,
+                    branch=update_event.ResourceProperties.Version,
+                    puts=files
+                ))["commitId"]
+                create_pr = True # If the commit above was able to be made, we want to create a PR afterwards
         except (CC_CLIENT.exceptions.FileEntryRequiredException, CC_CLIENT.exceptions.NoChangeException):
             pass
     if files_to_delete:
         try:
             for index, deletes in enumerate(chunks([f.as_dict() for f in files_to_delete], 99)):
-                commit_args = {
-                    "repositoryName": repo_name,
-                    "branchName": update_event.ResourceProperties.Version,
-                    "authorName": "AWS ADF Builders Team",
-                    "parentCommitId": commit_id,
-                    "email": "adf-builders@amazon.com",
-                    "commitMessage": "ADF {0} Automated Update PR - Delete Part {1}".format(update_event.ResourceProperties.Version, index),
-                    "deleteFiles": deletes
-                }
-                if index == 0:
-                    commit_response = CC_CLIENT.create_commit(**commit_args)
-                    commit_id = commit_response["commitId"]
-                else:
-                    commit_args["parentCommitId"] = commit_id
-                    commit_response = CC_CLIENT.create_commit(**commit_args)
-                    commit_id = commit_response["commitId"]
+                commit_id = CC_CLIENT.create_commit(**generate_commit_input(
+                    repo_name, index, parent_commit_id=commit_id, branch=update_event.ResourceProperties.Version, deletes=deletes
+                ))["commitId"]
         except (CC_CLIENT.exceptions.FileEntryRequiredException, CC_CLIENT.exceptions.NoChangeException):
             pass
     if create_pr or files_to_delete:
-        CC_CLIENT.create_pull_request(
-            title='ADF {0} Automated Update PR'.format(update_event.ResourceProperties.Version),
-            description=PR_DESCRIPTION.format(update_event.ResourceProperties.Version),
-            targets=[
-                {
-                    'repositoryName': repo_name,
-                    'sourceReference': update_event.ResourceProperties.Version,
-                    'destinationReference': 'master'
-                },
-            ]
-        )
+        CC_CLIENT.create_pull_request(**generate_pull_request_input(update_event, repo_name))
     else:
-        CC_CLIENT.delete_branch(
-            repositoryName=repo_name,
-            branchName=update_event.ResourceProperties.Version
-        )
+        CC_CLIENT.delete_branch(**generate_delete_branch_input(update_event, repo_name))
 
     return event["PhysicalResourceId"], {}
 
@@ -293,6 +268,7 @@ def get_files_to_delete(repo_name: str) -> List[FileToDelete]:
         afterCommitSpecifier='HEAD'
     )['differences']
 
+    # We never want to delete scp.json, global.yml, regional.yml or deployment_map.yml
     file_paths = [
         Path(file['afterBlob']['path'])
         for file in differences
@@ -301,6 +277,7 @@ def get_files_to_delete(repo_name: str) -> List[FileToDelete]:
         and 'global.yml' not in file['afterBlob']['path']
         and 'regional.yml' not in file['afterBlob']['path']
         and file['afterBlob']['path'] != 'deployment_map.yml'
+        and not file['afterBlob']['path'].startswith('deployment_maps')
     ]
 
     # 31: trimming off /var/task/bootstrap_repository so we can compare correctly
@@ -326,6 +303,8 @@ def get_files_to_commit(directoryName: str) -> List[FileToCommit]:
         )
         for entry in path.glob("**/*")
         if not entry.is_dir()
+        and entry.name != 'global.yml'
+        and entry.name != 'regional.yml'
     ]
 
 

--- a/src/lambda_codebase/organization/handler.py
+++ b/src/lambda_codebase/organization/handler.py
@@ -7,7 +7,7 @@ The Organization Handler that is called when ADF is installed to create the orga
 
 try:
     from main import lambda_handler # pylint: disable=unused-import
-except Exception as err:  # pylint: disable=broad-except
+except Exception as err: # pylint: disable=broad-except
     from urllib.request import Request, urlopen
     import json
 

--- a/src/lambda_codebase/organization/main.py
+++ b/src/lambda_codebase/organization/main.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, asdict
 import logging
 import json
 import boto3
-from cfn_custom_resource import (  # pylint: disable=unused-import
+from cfn_custom_resource import ( # pylint: disable=unused-import
     lambda_handler,
     create,
     update,

--- a/src/lambda_codebase/organization_unit/handler.py
+++ b/src/lambda_codebase/organization_unit/handler.py
@@ -7,7 +7,7 @@ The Organization Unit Handler that is called when ADF is installed to create the
 
 try:
     from main import lambda_handler # pylint: disable=unused-import
-except Exception as err:  # pylint: disable=broad-except
+except Exception as err: # pylint: disable=broad-except
     from urllib.request import Request, urlopen
     import json
 

--- a/src/lambda_codebase/organization_unit/main.py
+++ b/src/lambda_codebase/organization_unit/main.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, asdict
 import logging
 import json
 import boto3
-from cfn_custom_resource import (  # pylint: disable=unused-import
+from cfn_custom_resource import ( # pylint: disable=unused-import
     lambda_handler,
     create,
     update,

--- a/src/template.yml
+++ b/src/template.yml
@@ -14,7 +14,7 @@ Metadata:
     ReadmeUrl: ../README.md
     Labels: ['adf', 'aws-deployment-framework', 'multi-account', 'cicd', 'devops']
     HomePageUrl: https://github.com/awslabs/aws-deployment-framework
-    SemanticVersion: 1.2.0
+    SemanticVersion: 1.2.1
     SourceCodeUrl: https://github.com/awslabs/aws-deployment-framework
 Parameters:
   CommitInitialBootstrapContent:
@@ -187,7 +187,7 @@ Resources:
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 1.2.0
+          ADF_VERSION: 1.2.1
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: StackWaiter
       Role: !GetAtt LambdaRole.Arn
@@ -208,7 +208,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 1.2.0
+          ADF_VERSION: 1.2.1
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: DetermineEventFunction
       Role: !GetAtt LambdaRole.Arn
@@ -229,7 +229,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 1.2.0
+          ADF_VERSION: 1.2.1
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: CrossAccountExecuteFunction
       Role: !GetAtt LambdaRole.Arn
@@ -248,7 +248,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 1.2.0
+          ADF_VERSION: 1.2.1
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: RoleStackDeploymentFunction
       Role: !GetAtt LambdaRole.Arn
@@ -267,7 +267,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 1.2.0
+          ADF_VERSION: 1.2.1
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: MovedToRootActionFunction
       Role: !GetAtt LambdaRole.Arn
@@ -286,7 +286,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: !Ref TerminationProtection
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 1.2.0
+          ADF_VERSION: 1.2.1
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: UpdateResourcePoliciesFunction
       Role: !GetAtt LambdaRole.Arn
@@ -425,7 +425,7 @@ Resources:
         Image: "aws/codebuild/standard:2.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
-            Value: 1.2.0
+            Value: 1.2.1
           - Name: TERMINATION_PROTECTION
             Value: !Ref TerminationProtection
           - Name: PYTHONPATH
@@ -664,7 +664,7 @@ Resources:
     Condition: ShouldCommitInitialBootstrapContent
     Properties:
       ServiceToken: !GetAtt InitialCommitHandler.Arn
-      Version: 1.2.0
+      Version: 1.2.1
       RepositoryArn: !GetAtt CodeCommitRepository.Arn
       DirectoryName: bootstrap_repository
       DeploymentAccountRegion: !Ref DeploymentAccountMainRegion
@@ -837,7 +837,7 @@ Resources:
       Timeout: 300
 Outputs:
   ADFVersionNumber:
-    Value: 1.2.0
+    Value: 1.2.1
     Export:
       Name: "ADFVersionNumber"
   LayerArn:


### PR DESCRIPTION
# v1.2.1 🚀 

- Resolves #105 - You can now pass in custom deployment roles for an entire pipeline or for specific steps in a pipeline, for the docs for more information on the deployment_role key within deployment map files.
- Resolves #104 - You can now choose the type of url path that is returned when using the upload: intrinsic function. This can be either 'path' or 'virtual-hosted'. See the docs for the upload intrinsic function for more details.
- Resolves #103 - You can now attach multiple pipelines to a single repository by passing in a RepositoryName parameter.
- Resolves #85 - changes should not be made to global.yml or regional.yml between version upgrades. Unless there is some major changes to the deployment/global.yml, we will not suggest changes to this file in automated pull requests when deploying via the SAR.
- Resolves #84 - We have now documented the delete scenario for ADF.
- Resolves #77 - Pipelines are now generated in their own thread, making this process much faster.

#### Other Changes:
- Updated user-guide and admin-guide accordingly *(Highlighting YAML Anchors etc)*
- Allowing the ability to pass in a custom build role

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
