### PR TITLE
v1.2.2

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_pipelines.py
@@ -122,8 +122,8 @@ def worker_thread(p, organizations, auto_create_repositories, s3, deployment_map
         pipeline.template_dictionary["targets"].append(
             target_structure.account_list)
 
-    if DEPLOYMENT_ACCOUNT_REGION not in regions:
-        pipeline.stage_regions.append(DEPLOYMENT_ACCOUNT_REGION)
+        if DEPLOYMENT_ACCOUNT_REGION not in regions:
+            pipeline.stage_regions.append(DEPLOYMENT_ACCOUNT_REGION)
 
     parameters = pipeline.generate_parameters()
     pipeline.generate()


### PR DESCRIPTION
# v1.2.2
#### Bug fix:

regions was incorrectly indented in this specific case causing build-only pipelines to fail since they do not specify regions and thus the variable was unassigned when referenced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
