### PR TITLE
Fixing Github Example in User Guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -41,7 +41,6 @@ pipelines:
     type: github-cloudformation
     action: replace_on_failure
     params:
-      - ProjectName: "vpc-example" # Name of the Github repository
       - Owner: "githubrepowner" # Repository owner user
       - OAuthToken: "/tokens/oauth/github" # Name of SSM Param Store object
       - WebhookSecret: "/tokens/webhooksecret/github"

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,14 +36,18 @@ pipelines:
       - path: /banking/testing
         regions: eu-central-1
 
-  - name: vpc
+  # Github source example
+  - name: vpc-example # Pipeline name MUST be equal to Github repository name.
     type: github-cloudformation
     action: replace_on_failure
     params:
-      - SourceAccountId: 8888877777777
+      - ProjectName: "vpc-example" # Name of the Github repository
+      - Owner: "githubrepowner" # Repository owner user
+      - OAuthToken: "/tokens/oauth/github" # Name of SSM Param Store object
+      - WebhookSecret: "/tokens/webhooksecret/github"
       - NotificationEndpoint: channel1 # Slack Channel Example
     targets:
-      - path: ou-12341
+      - path: ou-12341 # AWS Organizations OU ID
         regions: [ eu-west-1, eu-central-1 ]
       - 22222222222
 ```


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:** Fixed the Github example, the previous one listed a `SourceAccountId` which only applies to CodeCommit. It was also missing param's required for Github.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
