### PR TITLE
Adding minor fix for SSM clean-up

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_pipelines.py
@@ -48,7 +48,7 @@ def clean(parameter_store, deployment_map):
     for parameter in current_pipeline_parameters:
         name = parameter.get('Name').split('/')[-2]
         if name not in [p.get('name') for p in deployment_map.map_contents['pipelines']]:
-            parameter_store.delete_parameter(name)
+            parameter_store.delete_parameter(parameter.get('Name'))
             stacks_to_remove.append(name)
 
     for stack in list(set(stacks_to_remove)):


### PR DESCRIPTION
*Issue #, if available:* #119 

*Description of changes:* Instead of using the split name (see: https://github.com/awslabs/aws-deployment-framework/blob/master/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_pipelines.py#L49), use the full name of the SSM parameter when calling SSM delete_parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
