### PR TITLE
v1.2.6

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
@@ -77,7 +77,8 @@ class Resolver:
                 self.stage_parameters[parent_key][key] = stack_output
         except IndexError:
             if stack_output:
-                self.stage_parameters[key] = stack_output
+                if self.stage_parameters.get(key):
+                    self.stage_parameters[key] = stack_output
             else:
                 raise Exception("Could not determine the structure of the file in order to import from CloudFormation")
         return True
@@ -102,11 +103,12 @@ class Resolver:
         try:
             parent_key = list(Resolver.determine_parent_key(self.stage_parameters, key))[0]
         except IndexError:
-            self.stage_parameters[key] = client.put_object(
-                "adf-upload/{0}/{1}".format(value, file_name),
-                "{0}".format(value),
-                style
-            )
+            if self.stage_parameters.get(key):
+                self.stage_parameters[key] = client.put_object(
+                    "adf-upload/{0}/{1}".format(value, file_name),
+                    "{0}".format(value),
+                    style
+                )
             return True
         self.stage_parameters[parent_key][key] = client.put_object(
             "adf-upload/{0}/{1}".format(value, file_name),
@@ -135,7 +137,6 @@ class Resolver:
             region = DEFAULT_REGION
         value = value[:-1] if optional else value
         client = ParameterStore(region, boto3)
-        LOGGER.info("Fetching Parameter from %s", value)
         try:
             parameter = self.cache.check('{0}/{1}'.format(region, value)) or client.fetch_parameter(value)
         except ParameterNotFoundError:
@@ -151,7 +152,8 @@ class Resolver:
                 self.stage_parameters[parent_key][key] = parameter
         except IndexError as error:
             if parameter:
-                self.stage_parameters[key] = parameter
+                if self.stage_parameters.get(key):
+                    self.stage_parameters[key] = parameter
             else:
                 LOGGER.error("Parameter was not found, unable to fetch it from parameter store")
                 raise Exception("Parameter was not found, unable to fetch it from parameter store") from error
@@ -159,7 +161,7 @@ class Resolver:
 
     def update(self, key):
         for k, _ in self.comparison_parameters.items():
-            if not self.stage_parameters.get(k):
+            if not self.stage_parameters.get(k) and not self.stage_parameters.get(k, {}).get(key):
                 self.stage_parameters[k] = self.comparison_parameters[k]
             if key not in self.stage_parameters[k] and self.comparison_parameters.get(k, {}).get(key):
                 self.stage_parameters[k][key] = self.comparison_parameters[k][key]


### PR DESCRIPTION
# v1.2.6

Resolves #132 :bug: - import:, upload: and resolve: should now correctly merge into the parameter file as intended.
Resolves #116 - Thanks @javydekoning - Can now pass in a repository name for Github as opposed to relying on the pipeline name.
Resolves #119 - Thanks @javydekoning - Parameters for removed pipelines now clean up correctly.

