### PR TITLE
showing and explaining the CodePipeline limits to early adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Launch ADF via the [Serverless Application Repository](https://console.aws.amazo
 - Refer to the [Admin Guide](/docs/admin-guide.md) for Installation steps and Administration.
 - Refer to the [User Guide](/docs/user-guide.md) for using ADF once it is setup.
 - Refer to the [Samples Guide](/docs/samples-guide.md) for a detailed walk through of the provided samples.
+- Refer to the [FAQ](docs/FAQ.md) for list of the frequently asked questions.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,7 +4,7 @@
 - > A: Organzations can only be accessed from the Master account of the Organization, read more about [AWS Organizations](https://docs.aws.amazon.com/organizations/latest/APIReference/Welcome.html).
 
 - Q: What are the limits of AWS CodePipeline?
-- > A: Please read [AWS CodePipeline Limits](https://docs.aws.amazon.com/codepipeline/latest/userguide/limits.html).
+- > A: Please read [AWS CodePipeline Limits](https://docs.aws.amazon.com/codepipeline/latest/userguide/limits.html). A single pipeline of type cloudformation can have maximum of 200 deployment targets distributed across 8 organization units.
 
 - Q: I cannot get CodeCommit working nicely with git or it stops working after a short period of time.
 - > A: Please read [Setting up CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up.html).


### PR DESCRIPTION
issue #128 

It's important that early adopters know and understand the CodePipeline limits.
Let's be honest and add URL to the FAQ document on our main README file and also have one line explanation what does the limit means for the most common ADF pipeline type.


------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
