### PR TITLE
changed name label of deployment stages to be deployment-{name_of_ou}

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-cloudformation.yml.j2
@@ -271,7 +271,7 @@ Resources:
               - Name: !Sub "${ProjectName}-build"
 {% for target in environments['targets'] %}
 {% if target|length > 0 and target[0].get('name') == "approval" %}
-        - Name: {{ target[0].get('step_name') or "approval-stage-" ~ loop.index }}
+        - Name: {{ target[0].get('step_name') or "deployment-{0}".format(target[0].get('name')) }}
           Actions:
             - Name: {{ target[0].get('step_name') or "Approval"}}
               ActionTypeId:


### PR DESCRIPTION
*Issue #139:*

*Description of changes:*

Using name instead of index to generate deploy stage name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
