### PR TITLE
bugfix #142 remove doubled keyword ServiceRole

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-customdeploy.yml.j2
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/pipelines_repository/pipeline_types/cc-customdeploy.yml.j2
@@ -145,7 +145,7 @@ Resources:
       Name: !Sub "adf-build-${ProjectName}"
       Description: !Sub "CodeBuild Project ${ProjectName} created by ADF"
       EncryptionKey: !ImportValue KMSArn-{{ deployment_account_region }}
-      ServiceRole: ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
+      ServiceRole: !If [HasCustomBuildRole, !Ref CustomBuildRole, !ImportValue CodeBuildRoleArn]
       Artifacts:
         Type: CODEPIPELINE
       Environment:


### PR DESCRIPTION
*Issue #, if available:* 142

*Description of changes:* remove doubled keyword ServiceRole in cc-customdeploy.yml.j2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
