### PR TITLE
Fix to replace spaces and other unaccepted chars from CFn stack names

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
@@ -21,6 +21,7 @@ CFN_CONFIG = Config(
         max_attempts=10
     )
 )
+CFN_UNACCEPTED_CHARS = re.compile(r"[^-a-zA-Z0-9:/._+]")
 
 class StackProperties:
     clean_stack_status = [
@@ -85,10 +86,11 @@ class StackProperties:
             return []
 
     def _get_stack_name(self):
-        return 'adf-{0}-base-{1}'.format(
+        raw_stack_name = 'adf-{0}-base-{1}'.format(
             self._get_geo_prefix(),
             self.ou_name
         )
+        return CFN_UNACCEPTED_CHARS.sub("-", raw_stack_name)
 
 
 class CloudFormation(StackProperties):


### PR DESCRIPTION
With this fix it replaces all unaccepted chars from the CloudFormation
(CFn) stack name with a dash.

For example, when the OU name would be 'IT Department', it would fail
setting up the base ADF resources as it would generate the following
stack name: 'adf-global-base-IT Department', which includes a space that
is not supported by CloudFormation.

With this fix, it will replace the space with a dash, the new name would
become: 'adf-global-base-IT-Department'. Any other unsupported character
is treated the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.