### PR TITLE
Fix for AWS Account Ids prefixed with zeroes

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -64,6 +64,22 @@ The second pipeline (*vpc*) example deploys to an OU path `/banking/testing`. Yo
 
 By default, the above pipelines will be created to deploy CloudFormation using a change in two actions *(Create then Execute)*.
 
+### Important Notes
+
+#### Zero-prefixed AWS Account Ids
+
+In most cases, you can target accounts directly by passing the AWS Account Id
+as an integer, as shown in the example above. However, in case the AWS Account
+Id starts with a zero, for example `011112233332`, you will need to pass the
+AWS Account Id as a string instead.
+
+Due to the way the YAML file is read, it will automatically transform
+zero-leading numbers by removing the zero. Additionally, if the AWS Account Id
+starts with a zero and happens to include numbers between 0 and 7 only, for
+example `012345671234`, it will treat it as a octal number instead.
+Since this cannot be detected without making risky assumptions, the deployment
+will error to be on the safe side instead.
+
 ### Types
 
 The ADF comes with an extensive set of abstractions over CodePipeline providers that can be used to define pipelines. For example, see the below pipeline definition:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/target.py
@@ -10,8 +10,13 @@ require mutation depending on their structure.
 import re
 import os
 from errors import InvalidDeploymentMapError, NoAccountsFoundError
+from logger import configure_logger
+from schema_validation import AWS_ACCOUNT_ID_REGEX_STR
 
+
+LOGGER = configure_logger(__name__)
 ADF_DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]
+AWS_ACCOUNT_ID_REGEX = re.compile(AWS_ACCOUNT_ID_REGEX_STR)
 
 class TargetStructure:
     def __init__(self, target):
@@ -108,12 +113,33 @@ class Target():
     def fetch_accounts_for_target(self):
         if self.path == 'approval':
             return self._target_is_approval()
-        if (str(self.path)).startswith('ou-'):
+        if str(self.path).startswith('ou-'):
             return self._target_is_ou_id()
-        if (str(self.path).isnumeric() and len(str(self.path)) == 12):
+        if AWS_ACCOUNT_ID_REGEX.match(str(self.path)):
             return self._target_is_account_id()
-        if (str(self.path)).startswith('/'):
+        if str(self.path).isnumeric():
+            LOGGER.warning(
+                "The specified path is numeric, but is not 12 chars long. "
+                "This typically happens when you specify the account id as a "
+                "number, while the account id starts with a zero. If this is "
+                "the case, please wrap the account id in quotes to make it a "
+                "string. The current path is interpreted as '%s'. "
+                "It could be interpreted as an octal number due to the zero, "
+                "so it might not match the account id as specified in the "
+                "deployment map. Interpreted as an octal it would be '%s'. "
+                "This error is thrown to be on the safe side such that it "
+                "is not targeting the wrong account by accident.",
+                str(self.path),
+                # Optimistically convert the path from 10-base to octal 8-base
+                # Then remove the use of the 'o' char, as it will output
+                # in the correct way, starting with: 0o.
+                str(oct(int(self.path))).replace('o', ''),
+            )
+        if str(self.path).startswith('/'):
             return self._target_is_ou_path()
         if self.path is None:
-            return self._target_is_null_path() # No path/target has been passed, path will default to /deployment
-        raise InvalidDeploymentMapError("Unknown defintion for target: {0}".format(self.path))
+            # No path/target has been passed, path will default to /deployment
+            return self._target_is_null_path()
+        raise InvalidDeploymentMapError(
+            "Unknown definition for target: {0}".format(self.path)
+        )

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/stub_deployment_map.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/stub_deployment_map.yml
@@ -29,7 +29,7 @@ pipelines:
       source:
         provider: codecommit
         properties:
-          account_id: 111111111111
+          account_id: '011111111111'
       build:
         provider: codebuild
         properties:
@@ -66,7 +66,7 @@ pipelines:
       source:
         provider: codecommit
         properties:
-          account_id: 111111111111 # A different AccountId as this pipeline is owned by a different team
+          account_id: '012345678901' # A different AccountId as this pipeline is owned by a different team
       deploy:
         provider: codebuild
     targets: # targets looks for the deploy defaults above to determine parameters
@@ -87,6 +87,8 @@ pipelines:
           account_id: 111111111111 # A different AccountId as this pipeline is owned by a different team
     targets:
       - 162738475618
+      - '062738475618'
+      - '012733475612'
 
   - name: sample-ec2-java-app-codedeploy
     default_providers:


### PR DESCRIPTION
**Issue:** #75

When the deployment map would refer to a specific AWS Account Id that
has a zero as the first digit, the number would be interpreted
differently or would not be accepted by validation at all.

For example, `012345678901` would become `12345678901` (zero removed),
and `012345671234` would become `1402434204` (interpreted as octal).

**Fix:**

In this commit, the schema validation for AWS Account Ids allows the use
of strings to define the account id. Such that an account id that has a
zero at the start would not be changed.

Additionally, the logic has been changed to detect AWS Account Ids that
do not match the AWS Account Id regular expression. In case this
happens, the error message will instruct the user to define the account
id in a string. It will also show how the account id was interpreted by
ADF and what the possible non-octal version of that number could be,
such that the user is able to find the faulty definition quickly.

As a side benefit, the default provider types in the schema validation
would return an unrelated error message when one of the properties did
not match. All of a sudden it would report that `s3` does not match
`codecommit`, for example. This has been fixed by matching the right
properties schema to the defined properties, based on the supplied
provider value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
