### PR TITLE
Mono repo support

### DIFF
--- a/samples/sample-mono-repo/README.md
+++ b/samples/sample-mono-repo/README.md
@@ -1,0 +1,89 @@
+# Sample Mono Repo showcasing ADF Pipelines
+
+This pipeline will demonstrate how to setup multiple
+pipelines that use a mono repo to host the code for two sample applications.
+
+Both applications deploy a simple S3 bucket without granting any permissions.
+The point of this sample is to demonstrate how different build and deployment
+stages can use the same repository as its source.
+
+Create a new repository that will host the files that are contained inside
+this sample folder. In the sample deployment map, the mono repo is named
+sample-mono-repo. Whereas the name of the deployment map block refers to the
+pipeline name. The later should be unique in order to perform.
+
+In the sample below, we prefixed the name of the mono repo at the start of the
+pipeline such that it is easy to determine where the pipeline is defined.
+
+You can extend the deployment map example code depicted below with samples
+from the other sample ADF deployments. Although the sample below shows two,
+you could use the same technique to create tens of pipelines from the same
+repository.
+
+### Deployment Map example
+
+```yaml
+  - name: sample-mono-repo-alpha
+    default_providers:
+      source:
+        provider: codecommit
+        properties:
+          account_id: 111111111111
+          repository: sample-mono-repo
+      build:
+        provider: codebuild
+        properties:
+          spec_filename: apps/alpha/buildspec.yml
+      deploy:
+        provider: cloudformation
+        properties:
+          root_dir: apps/alpha
+    targets:
+      - /banking/testing
+      - /banking/production
+
+  - name: sample-mono-repo-beta
+    default_providers:
+      source:
+        provider: codecommit
+        properties:
+          account_id: 111111111111
+          repository: sample-mono-repo
+      build:
+        provider: codebuild
+        properties:
+          spec_filename: apps/beta/buildspec.yml
+      deploy:
+        provider: cloudformation
+        properties:
+          root_dir: apps/beta
+    targets:
+      - /banking/testing
+      - /banking/production
+```
+
+## Separate deployment map
+
+Considering that all pipelines will be related to the same repository:
+If you are going to define a couple of pipelines, it could be
+worthwhile to define these pipelines in a separate deployment map.
+
+This can be achieved by creating a new deployment map file in the
+`deployment_maps` folder. If this folder does not exist in the
+`aws-deployment-framework-pipelines` repository, you can create one.
+
+The name of the deployment map inside this folder can be anything, as long as
+the file extension is `.yml`. For example, you could define a new deployment
+map in the file: `deployment_maps/sample-mono-repo.yml`
+
+Make sure that the deployment map file has the same syntax as the
+default `deployment_map.yml`. In other words, the array of pipelines should
+be stored inside the `pipelines` key.
+
+For example, `deployment_maps/sample-mono-repo.yml` inside the pipelines repo:
+
+```yaml
+pipelines:
+  - name: sample-mono-repo-alpha
+    # The rest of the sample pipeline definition above can be copied here.
+```

--- a/samples/sample-mono-repo/apps/alpha/README.md
+++ b/samples/sample-mono-repo/apps/alpha/README.md
@@ -1,0 +1,5 @@
+# Sample App A
+
+This app is part of the mono repo sample.
+As part of the deployment it will create a simple S3 bucket to host
+application assets.

--- a/samples/sample-mono-repo/apps/alpha/buildspec.yml
+++ b/samples/sample-mono-repo/apps/alpha/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+
+env:
+  variables:
+    INFRASTRUCTURE_ROOT_DIR: 'apps/alpha'
+
+phases:
+  install:
+    commands:
+      - cd $INFRASTRUCTURE_ROOT_DIR
+      - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet
+      - pip install -r adf-build/requirements.txt -q
+
+  build:
+    commands:
+      - python adf-build/generate_params.py
+
+artifacts:
+  files:
+    - '$INFRASTRUCTURE_ROOT_DIR/template.yml'
+    - '$INFRASTRUCTURE_ROOT_DIR/params/*.json'
+    - '$INFRASTRUCTURE_ROOT_DIR/params/*.yml"'

--- a/samples/sample-mono-repo/apps/alpha/params/global.yml
+++ b/samples/sample-mono-repo/apps/alpha/params/global.yml
@@ -1,0 +1,3 @@
+Tags:
+  Repository: sample-mono-repo
+  App: Sample Mono Repo Alpha

--- a/samples/sample-mono-repo/apps/alpha/template.yml
+++ b/samples/sample-mono-repo/apps/alpha/template.yml
@@ -1,0 +1,10 @@
+# // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ADF CloudFormation Sample Template (Mono Repo/App A)
+Metadata:
+  License: Apache-2.0
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket

--- a/samples/sample-mono-repo/apps/beta/README.md
+++ b/samples/sample-mono-repo/apps/beta/README.md
@@ -1,0 +1,5 @@
+# Sample App B
+
+This app is part of the mono repo sample.
+As part of the deployment it will create a simple S3 bucket to host
+application assets.

--- a/samples/sample-mono-repo/apps/beta/buildspec.yml
+++ b/samples/sample-mono-repo/apps/beta/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+
+env:
+  variables:
+    INFRASTRUCTURE_ROOT_DIR: 'apps/beta'
+
+phases:
+  install:
+    commands:
+      - cd $INFRASTRUCTURE_ROOT_DIR
+      - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet
+      - pip install -r adf-build/requirements.txt -q
+
+  build:
+    commands:
+      - python adf-build/generate_params.py
+
+artifacts:
+  files:
+    - '$INFRASTRUCTURE_ROOT_DIR/template.yml'
+    - '$INFRASTRUCTURE_ROOT_DIR/params/*.json'
+    - '$INFRASTRUCTURE_ROOT_DIR/params/*.yml"'

--- a/samples/sample-mono-repo/apps/beta/params/global.yml
+++ b/samples/sample-mono-repo/apps/beta/params/global.yml
@@ -1,0 +1,3 @@
+Tags:
+  Repository: sample-mono-repo
+  App: Sample Mono Repo Beta

--- a/samples/sample-mono-repo/apps/beta/template.yml
+++ b/samples/sample-mono-repo/apps/beta/template.yml
@@ -1,0 +1,10 @@
+# // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ADF CloudFormation Sample Template (Mono Repo/App B)
+Metadata:
+  License: Apache-2.0
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -51,7 +51,7 @@ class Action:
                 return 'arn:aws:iam::{0}:role/{1}'.format(self.account_id, self.map_params["default_providers"]["deploy"].get('properties', {}).get("role"))
         return None
 
-    def _generate_configuration(self): #pylint: disable=R0912, R0911
+    def _generate_configuration(self): #pylint: disable=R0912, R0911, R0915
         if self.provider == "Manual" and self.category == "Approval":
             _props = {
                 "CustomData": self.target.get('properties', {}).get('message') or "Approval stage for {0}".format(self.map_params['name'])
@@ -118,27 +118,55 @@ class Action:
                                     'input', ''))
             }
         if self.provider == "CloudFormation":
+            _path_prefix = self.target.get(
+                'properties', {}).get(
+                    'root_dir') or self.map_params.get(
+                        'default_providers', {}).get(
+                            'deploy', {}).get(
+                                'properties', {}).get(
+                                    'root_dir') or ""
+            if _path_prefix and not _path_prefix.endswith('/'):
+                _path_prefix = "{}/".format(_path_prefix)
+            _input_artifact = "{map_name}-build".format(
+                map_name=self.map_params['name'],
+            )
             _props = {
                 "ActionMode": self.action_mode,
                 "StackName": self.target.get('properties', {}).get('stack_name') or "{0}{1}".format(ADF_STACK_PREFIX, self.map_params['name']),
                 "ChangeSetName": "{0}{1}".format(ADF_STACK_PREFIX, self.map_params['name']),
-                "TemplateConfiguration": "{0}-build::params/{1}_{2}.json".format(self.map_params['name'], self.target['name'], self.region),
+                "TemplateConfiguration": "{input_artifact}::{path_prefix}params/{target_name}_{region}.json".format(
+                    input_artifact=_input_artifact,
+                    path_prefix=_path_prefix,
+                    target_name=self.target['name'],
+                    region=self.region,
+                ),
                 "Capabilities": "CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND",
                 "RoleArn": "arn:aws:iam::{0}:role/adf-cloudformation-deployment-role".format(self.target['id']) if not self.role_arn else self.role_arn
             }
             if self.map_params.get('default_providers', {}).get('build', {}).get('properties', {}).get('environment_variables', {}).get('CONTAINS_TRANSFORM'):
-                _props["TemplatePath"] = "{0}-build::template_{1}.yml".format(self.map_params['name'], self.region)
+                _props["TemplatePath"] = "{input_artifact}::{path_prefix}template_{region}.yml".format(
+                    input_artifact=_input_artifact,
+                    path_prefix=_path_prefix,
+                    region=self.region,
+                )
             else:
-                _props["TemplatePath"] = self.target.get(
+                _template_filename = self.target.get(
                     'properties', {}).get(
                         'template_filename') or self.map_params.get(
                             'default_providers', {}).get(
                                 'deploy', {}).get(
                                     'properties', {}).get(
-                                        'template_filename') or "{0}-build::template.yml".format(
-                                            self.map_params['name'])
+                                        'template_filename') or "template.yml"
+                _props["TemplatePath"] = "{input_artifact}::{path_prefix}{filename}".format(
+                    input_artifact=_input_artifact,
+                    path_prefix=_path_prefix,
+                    filename=_template_filename,
+                )
             if self.target.get('properties', {}).get('outputs'):
-                _props['OutputFileName'] = '{0}.json'.format(self.target['properties']['outputs'])
+                _props['OutputFileName'] = '{path_prefix}{filename}.json'.format(
+                    path_prefix=_path_prefix,
+                    filename=self.target['properties']['outputs'],
+                )
             if self.target.get('properties', {}).get('param_overrides'):
                 _overrides = {}
                 for override in self.target.get('properties', {}).get('param_overrides', []):

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
@@ -135,6 +135,7 @@ CLOUDFORMATION_ACTIONS = Or(
 CLOUDFORMATION_PROPS = {
     Optional("stack_name"): str,
     Optional("template_filename"): str,
+    Optional("root_dir"): str,
     Optional("role"): str,
     Optional("action"): CLOUDFORMATION_ACTIONS,
     Optional("outputs"): str,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/stub_deployment_map.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/stub_deployment_map.yml
@@ -54,6 +54,8 @@ pipelines:
         provider: cloudformation
         properties:
           action: replace_on_failure
+          root_dir: infra
+          template_filename: my_template.yml
     params:
         notification_endpoint: jon@smith.com
     targets: # Long hand syntax including regions and names for stages


### PR DESCRIPTION
Adds the `root_dir` property to the `cloudformation` deployment
provider properties. This enables the user to define multiple pipelines
that target the same repository, where each application/pipeline could
use different directories to host the CloudFormation template and
parameters.

In terms of CodeBuild: make sure to `cd` into the correct directory as
shown in the mono-repo sample. This is required to generate the
parameter files in the correct directory as well.

No changes were required for CodeBuild mono-repo support, as you can
specify the location of the BuildSpec using the `spec_filename` property
of the `codebuild` provider properties.

**R0915:**

A note on the added `pylint: disable R0915`: intentionally the modifications
required to add mono repo support touch as little as possible.
However, by adding a four statements we crossed the limit of
max 30 statements per function. The code in this file needs to be
refactored.

I will refactor the code in this specific file in a separate PR later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.