### PR TITLE
Fix to skip deletion of deployment_maps dir and other json/yaml files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 init:
 	pip install -r requirements.txt
+	pip install -r src/lambda_codebase/initial_commit/requirements.txt
 
 test:
 	# Run unit tests
 	pytest src/lambda_codebase/initial_commit/bootstrap_repository -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/pytest.ini																																
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/pytest.ini
 	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pytest.ini
 	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini
+	pytest src/lambda_codebase/initial_commit -vvv -s -c src/lambda_codebase/initial_commit/pytest.ini
 lint:
 	# Linter performs static analysis to catch latent bugs
-	find src/ -iname "*.py" | xargs pylint --rcfile .pylintrc 
+	find src/ -iname "*.py" | xargs pylint --rcfile .pylintrc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tox==2.2.1
 pylint==2.2.2
 pytest==3.0.7
 mock==2.0.0
-boto3~=1.9, >=1.9.56
+boto3~=1.9, >=1.9.89
 pyyaml>=5.1
 astroid==2.1.0
 schema==0.7.1

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/tests/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+__init__ for tests module
+"""
+
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/tests/test_initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/deployment/lambda_codebase/initial_commit/tests/test_initial_commit.py
@@ -1,0 +1,99 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file
+
+from mock import Mock, patch
+from initial_commit import (
+    FileToDelete,
+    get_files_to_delete,
+)
+
+
+FILES_IN_UPSTREAM_REPO = [
+    'some.yml',
+    'otherfile.txt',
+    'samples/python.py',
+]
+FILES_ADDED_BY_USER = [
+    'global.yml',
+    'REGIONAL.YML',
+    'regional.yml',
+    'scp.json',
+    'other.JSON',
+    'other.yaml',
+    'deployment_maps/test.yml',
+]
+SHOULD_NOT_DELETE_FILES = FILES_IN_UPSTREAM_REPO + FILES_ADDED_BY_USER
+SHOULD_NOT_DELETE_DIRS = [
+    'deployment_maps',
+    'deployment',
+]
+SHOULD_DELETE_PATHS = [
+    'other.txt',
+    'pipeline_types/cc-cloudformation.yml.j2',
+    'cc-cloudformation.yml.j2',
+]
+
+
+class GenericPathMocked():
+    def __init__(self, path):
+        self.path = path
+
+    def __repr__(self):
+        return self.path
+
+    def is_dir(self):
+        return self.path in SHOULD_NOT_DELETE_DIRS
+
+
+@patch('initial_commit.Path')
+@patch('initial_commit.CC_CLIENT')
+def test_get_files_to_delete(cc_client, path_cls):
+    repo_name = 'some-repo-name'
+    difference_paths = (
+        SHOULD_NOT_DELETE_FILES +
+        SHOULD_NOT_DELETE_DIRS +
+        SHOULD_DELETE_PATHS
+    )
+    differences = list(map(
+        lambda x: {'afterBlob': {'path': x}},
+        difference_paths,
+    ))
+    cc_client.get_differences.return_value = {
+        'differences': differences,
+    }
+    path_rglob_mock = Mock()
+    path_rglob_mock.rglob.return_value = list(map(
+        lambda path: "/var/task/pipelines_repository/{}".format(path),
+        FILES_IN_UPSTREAM_REPO,
+    ))
+    path_cls.side_effect = lambda path: (
+        path_rglob_mock if path == '/var/task/pipelines_repository/'
+        else GenericPathMocked(path)
+    )
+
+    result = get_files_to_delete(repo_name)
+
+    cc_client.get_differences.assert_called_once_with(
+        repositoryName=repo_name,
+        afterCommitSpecifier='HEAD',
+    )
+
+    path_cls.assert_called_with(
+        '/var/task/pipelines_repository/'
+    )
+    path_rglob_mock.rglob.assert_called_once_with('*')
+
+    assert all(isinstance(x, FileToDelete) for x in result)
+
+    # Extract paths from result FileToDelete objects to make querying easier
+    result_paths = list(map(lambda x: x.filePath, result))
+
+    # Should not delete JSON, YAML, and directories
+    assert all(x not in result_paths for x in SHOULD_NOT_DELETE_FILES)
+    assert all(x not in result_paths for x in SHOULD_NOT_DELETE_DIRS)
+
+    # Should delete all other
+    assert all(x in result_paths for x in SHOULD_DELETE_PATHS)
+    assert len(result_paths) == len(SHOULD_DELETE_PATHS)

--- a/src/lambda_codebase/initial_commit/pytest.ini
+++ b/src/lambda_codebase/initial_commit/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+norecursedirs = bootstrap_repository

--- a/src/lambda_codebase/initial_commit/requirements.txt
+++ b/src/lambda_codebase/initial_commit/requirements.txt
@@ -1,3 +1,3 @@
 Jinja2~=2.10.1
 cfn-custom-resource~=1.0.1
-boto3~=1.9.89
+boto3~=1.9, >=1.9.89

--- a/src/lambda_codebase/initial_commit/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/tests/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+__init__ for tests module
+"""
+
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/src/lambda_codebase/initial_commit/tests/test_initial_commit.py
+++ b/src/lambda_codebase/initial_commit/tests/test_initial_commit.py
@@ -1,0 +1,99 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file
+
+from mock import Mock, patch
+from initial_commit import (
+    FileToDelete,
+    get_files_to_delete,
+)
+
+
+FILES_IN_UPSTREAM_REPO = [
+    'some.yml',
+    'otherfile.txt',
+    'samples/python.py',
+]
+FILES_ADDED_BY_USER = [
+    'global.yml',
+    'REGIONAL.YML',
+    'regional.yml',
+    'scp.json',
+    'other.JSON',
+    'other.yaml',
+    'deployment_maps/test.yml',
+]
+SHOULD_NOT_DELETE_FILES = FILES_IN_UPSTREAM_REPO + FILES_ADDED_BY_USER
+SHOULD_NOT_DELETE_DIRS = [
+    'deployment_maps',
+    'deployment',
+]
+SHOULD_DELETE_PATHS = [
+    'other.txt',
+    'pipeline_types/cc-cloudformation.yml.j2',
+    'cc-cloudformation.yml.j2',
+]
+
+
+class GenericPathMocked():
+    def __init__(self, path):
+        self.path = path
+
+    def __repr__(self):
+        return self.path
+
+    def is_dir(self):
+        return self.path in SHOULD_NOT_DELETE_DIRS
+
+
+@patch('initial_commit.Path')
+@patch('initial_commit.CC_CLIENT')
+def test_get_files_to_delete(cc_client, path_cls):
+    repo_name = 'some-repo-name'
+    difference_paths = (
+        SHOULD_NOT_DELETE_FILES +
+        SHOULD_NOT_DELETE_DIRS +
+        SHOULD_DELETE_PATHS
+    )
+    differences = list(map(
+        lambda x: {'afterBlob': {'path': x}},
+        difference_paths,
+    ))
+    cc_client.get_differences.return_value = {
+        'differences': differences,
+    }
+    path_rglob_mock = Mock()
+    path_rglob_mock.rglob.return_value = list(map(
+        lambda path: "/var/task/bootstrap_repository/{}".format(path),
+        FILES_IN_UPSTREAM_REPO,
+    ))
+    path_cls.side_effect = lambda path: (
+        path_rglob_mock if path == '/var/task/bootstrap_repository/'
+        else GenericPathMocked(path)
+    )
+
+    result = get_files_to_delete(repo_name)
+
+    cc_client.get_differences.assert_called_once_with(
+        repositoryName=repo_name,
+        afterCommitSpecifier='HEAD',
+    )
+
+    path_cls.assert_called_with(
+        '/var/task/bootstrap_repository/'
+    )
+    path_rglob_mock.rglob.assert_called_once_with('*')
+
+    assert all(isinstance(x, FileToDelete) for x in result)
+
+    # Extract paths from result FileToDelete objects to make querying easier
+    result_paths = list(map(lambda x: x.filePath, result))
+
+    # Should not delete JSON, YAML, and directories
+    assert all(x not in result_paths for x in SHOULD_NOT_DELETE_FILES)
+    assert all(x not in result_paths for x in SHOULD_NOT_DELETE_DIRS)
+
+    # Should delete all other
+    assert all(x in result_paths for x in SHOULD_DELETE_PATHS)
+    assert len(result_paths) == len(SHOULD_DELETE_PATHS)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ setenv=
     PYTHONPATH={toxinidir}/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python
     ORGANIZATION_ID=o-123456789
     AWS_REGION=eu-central-1
+    AWS_DEFAULT_REGION=eu-central-1
     ADF_PIPELINE_PREFIX=adf-pipeline-
     S3_BUCKET=some_bucket
     S3_BUCKET_NAME=some_bucket
@@ -24,9 +25,9 @@ setenv=
     ACCOUNT_ID=111111111111
 
 whitelist_externals = make
-deps = 
-    -rrequirements.txt
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/src/lambda_codebase/initial_commit/requirements.txt
 commands =
     make test
     make lint
-    


### PR DESCRIPTION
**Issue:**

When upgrading ADF, it deletes the old files that have been removed
between versions. However, the way it performs this test contained an
issue where it deleted the `deployment_maps` directory and other json/yaml
files that were not specifically whitelisted to be kept.

**Fix:**

Checks the files that would be scheduled for deletion against a regular
expression. When the file ends with a `json`, `yaml`, `yml` file extension
it should be kept in the repo as is.

Unit tests have been added to ensure that it would work as intended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
