### PR TITLE
Fixes CodeBuild unique project name for deployment stages

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -63,6 +63,7 @@ class CodeBuild(core.Construct):
                 name="{0}".format(id),
                 provider="CodeBuild",
                 category="Build",
+                project_name="adf-deploy-{0}".format(id),
                 run_order=1,
                 target=target,
                 map_params=map_params,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -29,6 +29,7 @@ class Action:
         self.provider = kwargs.get('provider')
         self.category = kwargs.get('category')
         self.map_params = kwargs.get('map_params')
+        self.project_name = kwargs.get('project_name')
         self.owner = kwargs.get('owner') or 'AWS'
         self.run_order = kwargs.get('run_order')
         self.index = kwargs.get('index')
@@ -186,8 +187,10 @@ class Action:
                 "ProviderName": self.map_params['default_providers']['build'].get('properties', {}).get('provider_name') # Enter the provider name you configured in the Jenkins plugin
             }
         if self.provider == "CodeBuild":
+            if self.project_name is None:
+                self.project_name = "adf-build-{0}".format(self.map_params['name'])
             return {
-                "ProjectName": "adf-build-{0}".format(self.map_params['name'])
+                "ProjectName": self.project_name
             }
         if self.provider == "ServiceCatalog":
             return {

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/main.py
@@ -100,7 +100,13 @@ class PipelineStack(core.Stack):
                     _actions.extend([
                         adf_codebuild.CodeBuild(
                             self,
-                            '{0}-stage-{1}'.format(target['name'], index + 1),
+                            # Use the name of the pipeline for CodeBuild
+                            # instead of the target name as it will always
+                            # operate from the deployment account.
+                            "{pipeline_name}-stage-{index}".format(
+                                pipeline_name=stack_input['input']['name'],
+                                index=index + 1,
+                            ),
                             stack_input['ssm_params'][ADF_DEPLOYMENT_REGION]["modules"],
                             stack_input['ssm_params'][ADF_DEPLOYMENT_REGION]["kms"],
                             stack_input['input'],


### PR DESCRIPTION
*Note: Please merge #169 first. This PR builds upon that commit.*

## CodeBuild project name uniqueness

Use pipeline name for CodeBuild instead of target name

**Issue:**

Currently, the name of the CodeBuild project is determined based on the
name of the target it points too. In the case of CodeBuild this would
always be the name of the deployment account.

Having multiple pipelines that have a CodeBuild project with the same
stage index would clash though.

**Fix:**

Use the name of the pipeline for CodeBuild instead of the target name,
as it will always operate from the deployment account.

## Single region

Moved CodeBuild deployment action outside of region loop

**Issue:**

In the current format, one could think that CodeBuild supports being
deployed in a specific target region while this is not supported.

As written in #168, the name of the CodeBuild project would clash.

When CodeBuild steps are added as deployment actions, they should be
added as one per stage, not multiple in the same stage.

**Fix:**

Moved the CodeBuild deployment action outside of the region loop to
ensure that it will only create just one even though multiple regions
are configured as targets for this pipeline.

This would allow targeting multiple deployment regions for other
deployment steps, while only using one CodeBuild action as a deployment
stage.

**Why not adding multi-region support?**

The pipeline is deployed using CloudFormation in the main region.
Adding resources that get deployed in other regions from the same stack
would make things too complex to maintain in the long run.

## Additional fixes

* Refactored stage name code for improved readability


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.