### PR TITLE
Added root_dir attribute of CloudFormation to Types Guide

### DIFF
--- a/docs/types-guide.md
+++ b/docs/types-guide.md
@@ -112,6 +112,8 @@ default_providers:
       > The name of the CloudFormation Stack.
   - template_filename - *(String)*
       > The name of the CloudFormation Template to execute. Defaults to template.yml.
+  - root_dir - *(String)*
+      > The root directory in which the CloudFormation template and params directory reside. Example, when the CloudFormation template is stored in 'infra/custom_template.yml' and parameter files in the 'infra/params' directory, set template_filename to 'custom_template.yml' and root_dir to 'infra'. Defaults to '' (empty string), root of source repository or input artifact.
   - role - *(String)*
       > The role you would like to use on the target AWS account to execute the CloudFormtion action.
   - action - *(String)*
@@ -126,7 +128,7 @@ default_providers:
     - param *(String)*
       > The name of the Parameter you want to override in the specific stage.
     - key_name *(String)*
-      > The Key name from the stack output you wish to use as input in this stage.s
+      > The Key name from the stack output you wish to use as input in this stage.
 
 
 - **codedeploy**

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cloudformation.py
@@ -6,7 +6,6 @@
 import os
 import boto3
 from pytest import fixture
-from unittest.mock import patch
 from stubs import stub_cloudformation
 from mock import Mock
 


### PR DESCRIPTION
* Added root_dir to the CloudFormation deployment definition in the
Types Guide documentation.
* Fixed small typo of floating `s` after a period in Types Guide.
* Removed unnecessary import as discussed in #156.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
