### PR TITLE
Fixes use of target spec_filename over default for CodeBuild deployments

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -47,7 +47,11 @@ class CodeBuild(core.Construct):
                 environment_variables=CodeBuild.generate_build_env_variables(_codebuild, shared_modules_bucket, map_params, target),
                 privileged=target.get('properties', {}).get('privileged', False) or map_params['default_providers']['build'].get('properties', {}).get('privileged', False)
             )
-            _spec = map_params['default_providers']['deploy'].get('properties', {}).get('spec_filename') or target.get('properties', {}).get('spec_filename') or 'deployspec.yml'
+            _spec_filename = (
+                target.get('properties', {}).get('spec_filename') or
+                map_params['default_providers']['deploy'].get('properties', {}).get('spec_filename') or
+                'deployspec.yml'
+            )
             _codebuild.PipelineProject(
                 self,
                 'project',
@@ -57,7 +61,7 @@ class CodeBuild(core.Construct):
                 project_name="adf-deploy-{0}".format(id),
                 timeout=core.Duration.minutes(_timeout),
                 role=_iam.Role.from_role_arn(self, 'build_role', role_arn=_build_role),
-                build_spec=_codebuild.BuildSpec.from_source_filename(_spec)
+                build_spec=_codebuild.BuildSpec.from_source_filename(_spec_filename)
             )
             self.deploy = Action(
                 name="{0}".format(id),


### PR DESCRIPTION
**Issue:**

When using CodeBuild for both deployment steps and integration tests, you would want to be able to specify the use of a specific `spec_filename` as shown in the third target stage below (named `integration-tests`).

```yaml
pipelines:
  - name: deploy-using-codebuild-pipeline
    default_providers:
      source:
        provider: codecommit
        properties:
          account_id: 111111111111
      build:
        provider: codebuild
        properties:
          image: STANDARD_2_0
      deploy:
        provider: codebuild
        properties:
          image: STANDARD_2_0
          spec_filename: different_deployspec.yml
    targets:
      - name: deploy-to-dev
        provider: codebuild
        properties:
          environment_variables:
            BUCKET_NAME: some-bucket-to-use-in-dev
      - name: deploy-to-test
        provider: codebuild
        properties:
          environment_variables:
            BUCKET_NAME: some-bucket-to-use-in-test
      - name: integration-tests
        provider: codebuild
        properties:
          spec_filename: testspec.yml
      - approval
      - name: deploy-to-prod
        provider: codebuild
        properties:
          environment_variables:
            BUCKET_NAME: some-bucket-to-use-in-prod
```

Instead of using the specific one, it uses the one specified in the default providers.
So is uses: `different_deployspec.yml` for all targets that have `codebuild` as its provider.
Whereas the third step (named `integration-tests`) should have used `testspec.yml` instead.

**Fix:**

The root cause of the issue is an incorrect ordering in the evaluation of which `spec_filename` to use.

Changed the order to use the target `spec_filename` if specified, otherwise it will try to use the one specified in the default providers list followed by the generic `deployspec.yml`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
