### PR TITLE
use default_providers:deploy:properties:stack_name if defined

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -133,7 +133,11 @@ class Action:
             )
             _props = {
                 "ActionMode": self.action_mode,
-                "StackName": self.target.get('properties', {}).get('stack_name') or "{0}{1}".format(ADF_STACK_PREFIX, self.map_params['name']),
+                "StackName": self.target.get(
+                    'properties', {}).get('stack_name') or self.map_params.get(
+                        'default_providers', {}).get(
+                            'deploy', {}).get(
+                                'properties', {}).get('stack_name')or "{0}{1}".format(ADF_STACK_PREFIX, self.map_params['name']),
                 "ChangeSetName": "{0}{1}".format(ADF_STACK_PREFIX, self.map_params['name']),
                 "TemplateConfiguration": "{input_artifact}::{path_prefix}params/{target_name}_{region}.json".format(
                     input_artifact=_input_artifact,


### PR DESCRIPTION
*Issue #, if available:*
#186 Explicitly defined stack_name in default_providers section is ignored
*Description of changes:*
use default_providers:deploy:properties:stack_name if defined

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
