### PR TITLE
use default_providers:source:properties:branch when defined instead master

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -361,7 +361,8 @@ class Pipeline(core.Construct):
             "source": {
                 "provider": map_params.get('default_providers', {}).get('source', {}).get('provider'),
                 "account_id": map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('account_id'),
-                "repo_name": map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('repository') or map_params['name']
+                "repo_name": map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('repository') or map_params['name'],
+                "branch": map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('branch', 'master')
             }
         })
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
@@ -47,7 +47,7 @@ class Events(core.Construct):
                             "branch"
                         ],
                         "referenceName": [
-                            "master"
+                            params['source']['branch']
                         ]
                     }
                 )


### PR DESCRIPTION
*Issue #, if available:*
#188 Pipeline is not triggered by CodeCommit repositories changes if pipeline uses branch different from master
*Description of changes:*
use **default_providers:source:properties:branch** when defined instead of hard-coded master

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
