### PR TITLE
Add ability to skip SAM build in package-transform

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/package_transform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/package_transform.sh
@@ -1,19 +1,41 @@
 #!/bin/bash
-
-set -e
-
+#
 # This script will package all source code and send it to an S3 bucket in each region
 # where the lambda needs to be deployed to.
 #
 # ADF_PROJECT_NAME is an environment variable that is passed to the CodeBuild Project
 # CODEBUILD_SRC_DIR is an environment variable provided by CodeBuild
 
+set -e
+
+SKIP_BUILD=0
+
+# Walk through the options passed to this script
+for i in "$@"
+do
+  case $i in
+    --no-build)
+      SKIP_BUILD=1
+      ;;
+    *)
+      echo "Unknown option: $i"
+      exit 1
+      ;;
+  esac
+done
+
 pip install --upgrade awscli aws-sam-cli -q
 
-# Build our template and its potential dependancies
-sam build
+if [[ $SKIP_BUILD == 0 ]]; then
+  echo "Perform build step"
+  # Build our template and its potential dependencies
+  sam build
+else
+  echo "Skip build step"
+fi
 
 # Get list of regions supported by this application
+echo "Determine which regions need to be prepared"
 app_regions=`aws ssm get-parameters --names /deployment/$ADF_PROJECT_NAME/regions --with-decryption --output=text --query='Parameters[0].Value'`
 # Convert json list to bash list (space delimited regions)
 regions="`echo $app_regions | sed  -e 's/\[\([^]]*\)\]/\1/g' | sed 's/,/ /g' | sed "s/'//g"`"


### PR DESCRIPTION
**Why:**

The AWS Serverless Application Model (SAM) build action tries to fetch
all requirements specified in the `requirements.txt`.

However, this does not work when you would like to use other sources to
host the python modules than the default public one.

**How:**

In order to skip the `sam build` step, specify the `--no-build` flag to
the `package_transform.sh` script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
