### PR TITLE
3.0.3

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -256,7 +256,7 @@ Resources:
               - "logs:CreateLogStream"
               - "logs:PutLogEvents"
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/adf-build-*
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*
           - Effect: Allow
             Action: # If you plan on building docker images in CodeBuild you need these
               - "ecr:GetAuthorizationToken"
@@ -572,6 +572,9 @@ Resources:
             Sid: "CodeCommit"
             Action:
               - "codecommit:CreateRepository"
+              - "codecommit:UpdateRepository"
+              - "codecommit:GetRepository"
+              - "codecommit:TagResource"
             Resource:
               - "*"
           - Effect: Allow

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -234,6 +234,7 @@ Resources:
             Action:
               - "codecommit:CreateRepository"
               - "codecommit:UpdateRepository"
+              - "codecommit:GetRepository"
               - "codecommit:TagResource"
             Resource:
               - "*"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -295,6 +295,12 @@ class Action:
                     name="{0}-build".format(self.map_params['name'])
                 )
             ]
+            if not self.map_params.get('default_providers', {}).get('build', {}).get('enabled', True):
+                action_props["input_artifacts"] = [
+                    _codepipeline.CfnPipeline.InputArtifactProperty(
+                        name="output-source"
+                    )
+                ]
         if self.category == 'Deploy':
             action_props["input_artifacts"] = [
                 _codepipeline.CfnPipeline.InputArtifactProperty(
@@ -305,12 +311,6 @@ class Action:
                 action_props["output_artifacts"] = [
                     _codepipeline.CfnPipeline.OutputArtifactProperty(
                         name=self.target.get('properties', {}).get('outputs')
-                    )
-                ]
-            if not self.map_params.get('default_providers', {}).get('build', {}).get('enabled', True):
-                action_props["input_artifacts"] = [
-                    _codepipeline.CfnPipeline.InputArtifactProperty(
-                        name="output-source"
                     )
                 ]
             for override in self.target.get('properties', {}).get('param_overrides', []):

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/repo.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/repo.py
@@ -71,9 +71,11 @@ class Repo:
             s3_key_path=None,
             account_id=DEPLOYMENT_ACCOUNT_ID,
         )
-
-        # Update the stack if the repo and the adf contolled stack exist
-        update_stack = (self.repo_exists() and cloudformation.get_stack_status())
-        if update_stack:
+        # Update the stack if the repo and the adf contolled stack exist, return if the repo exists but no stack (previously made)
+        _repo_exists = self.repo_exists()
+        _stack_exists = cloudformation.get_stack_status()
+        if _repo_exists and not _stack_exists:
+            return
+        if not _repo_exists and not _stack_exists:
             LOGGER.info('Ensuring State for Codecommit Repository Stack %s on Account %s', self.name, self.account_id)
             cloudformation.create_stack()

--- a/src/template.yml
+++ b/src/template.yml
@@ -14,7 +14,7 @@ Metadata:
     ReadmeUrl: ../docs/serverless-application-repo.md
     Labels: ['adf', 'aws-deployment-framework', 'multi-account', 'cicd', 'devops']
     HomePageUrl: https://github.com/awslabs/aws-deployment-framework
-    SemanticVersion: 3.0.1
+    SemanticVersion: 3.0.3
     SourceCodeUrl: https://github.com/awslabs/aws-deployment-framework
 Parameters:
   CrossAccountAccessRoleName:
@@ -172,7 +172,7 @@ Resources:
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 3.0.1
+          ADF_VERSION: 3.0.3
           ADF_LOG_LEVEL: INFO
       FunctionName: StackWaiter
       Role: !GetAtt LambdaRole.Arn
@@ -193,7 +193,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 3.0.1
+          ADF_VERSION: 3.0.3
           ADF_LOG_LEVEL: INFO
       FunctionName: DetermineEventFunction
       Role: !GetAtt LambdaRole.Arn
@@ -214,7 +214,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 3.0.1
+          ADF_VERSION: 3.0.3
           ADF_LOG_LEVEL: INFO
       FunctionName: CrossAccountExecuteFunction
       Role: !GetAtt LambdaRole.Arn
@@ -233,7 +233,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 3.0.1
+          ADF_VERSION: 3.0.3
           ADF_LOG_LEVEL: INFO
       FunctionName: RoleStackDeploymentFunction
       Role: !GetAtt LambdaRole.Arn
@@ -252,7 +252,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 3.0.1
+          ADF_VERSION: c
           ADF_LOG_LEVEL: INFO
       FunctionName: MovedToRootActionFunction
       Role: !GetAtt LambdaRole.Arn
@@ -271,7 +271,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 3.0.1
+          ADF_VERSION: 3.0.3
           ADF_LOG_LEVEL: INFO
       FunctionName: UpdateResourcePoliciesFunction
       Role: !GetAtt LambdaRole.Arn
@@ -449,7 +449,7 @@ Resources:
         Image: "aws/codebuild/standard:2.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
-            Value: 3.0.1
+            Value: 3.0.3
           - Name: TERMINATION_PROTECTION
             Value: false
           - Name: PYTHONPATH
@@ -714,7 +714,7 @@ Resources:
     Type: Custom::InitialCommit
     Properties:
       ServiceToken: !GetAtt InitialCommitHandler.Arn
-      Version: 3.0.1
+      Version: 3.0.3
       RepositoryArn: !GetAtt CodeCommitRepository.Arn
       DirectoryName: bootstrap_repository
       ExistingAccountId: !Ref DeploymentAccountId
@@ -935,7 +935,7 @@ Resources:
           Id: adf-codepipeline-trigger-bootstrap
 Outputs:
   ADFVersionNumber:
-    Value: 3.0.1
+    Value: 3.0.3
     Export:
       Name: "ADFVersionNumber"
   LayerArn:


### PR DESCRIPTION
# v3.0.3

Resolves #218 - codebuild role was missing permissions were missing to call get:repo on source accounts, also simplified the checking logic for if repo exists.
Resolves #217 - Thanks @eriklz for the suggestion, Mutable as False here works nicely.
Resolves #215 - Made these changes in 3.0.2 branch but officially adding them in here as 3.0.3
Resolves #194 - Can now use different images in deploy phase to those in build phase as expected.

Thank you all for being part of testing and helping 3.0 be an awesome release!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
