### PR TITLE
Add S3-URI as upload path style

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -393,6 +393,8 @@ pipelines:
 
 Parameter injection solves problems that occur with Cross Account parameter access. This concept allows the resolution of values directly from SSM Parameter Store within the Deployment account into Parameter files *(eg global.json, account-name.json)* and also importing of exported values from CloudFormation stacks across accounts and regions.
 
+#### Retrieving parameter values
+
 If you wish to resolve values from Parameter Store on the Deployment Account directly into your parameter files you can do the the following:
 
 ```yaml
@@ -408,6 +410,8 @@ To highlight an example of how Parameter Injection can work well, think of the f
 
 There is also the concept of optionally resolving or importing values. This can be achieved by ending the import or resolve function with a **?**. For example, if you want to resolve a value from Parameter Store that might or might not yet exist you can use an optional resolve *(eg resolve:/my/path/to/myMagicKey?)*. If the key *myMagicKey* does not exist in Parameter Store then an empty string will be returned as the value.
 
+#### Importing exported values
+
 Parameter injection is also useful for importing exported values from CloudFormation stacks in other accounts or regions. Using the special **"import"** syntax you can access these values directly into your parameter files.
 
 ```yaml
@@ -417,17 +421,59 @@ Parameters:
 
 In the above example *123456789101* is the AWS Account Id in which we want to pull a value from, *eu-west-1* is the region, stack_name is the CloudFormation stack name and *export_key* is the output key name *(not export name)*. Again, this concept works with the optional style syntax *(eg, import:123456789101:eu-west-1:stack_name:export_key?)* if the key *export_key* does not exist at the point in time when this specific import is executed, it will return an empty string as the parameter value rather than an error since it is considered optional.
 
+#### Uploading assets
+
 Another built-in function is **upload**, You can use *upload* to perform an automated upload of a resource such as a template or file into Amazon S3 as part of the build process.
 Once the upload is complete, the Amazon S3 URL for the object will be put in place of the *upload* string in the parameter file.
 
-For example, If you are deploying products that will be made available via Service Catalog to many teams throughout your organization *(see samples)* you will need to reference the AWS CloudFormation template URL of the product as part of the template that creates the product definition. The problem that the **upload** function is solving in this case is that the template URL of the product cannot exist at this point since the file has not yet been uploaded to S3.
+For example, If you are deploying products that will be made available via Service Catalog to many teams throughout your organization *(see samples)* you will need to reference the AWS CloudFormation template URL of the product as part of the template that creates the product definition. The problem that the **upload** function is solving in this case is that the template URL of the product cannot exist at this point, since the file has not yet been uploaded to S3.
 
 ```yaml
 Parameters:
     ProductYTemplateURL: 'upload:path:productY/template.yml'
 ```
 
-In the above example, we are calling the **upload** function on a file called `template.yml` that lives in the *productY* folder within our repository and then returning the path style URL from S3 (indicated by the word *path* in the string). The string *"upload:path:productY/template.yml"* will be replaced by the URL of the object in S3 once it has been uploaded. You can optionally also upload files to S3 Buckets within specific regions by adding in the region name as part of the string *(eg upload:path:us-west-1:productY/template.yml)*. The upload function allows for two response types, to use the classic [Path Style method](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) use the keyword *path* in your upload string as per the example above. If you wish to use virtual-hosted style *(eg, http://johnsmith-bucket.s3-eu-west-1.amazonaws.com/homepage.html)* then define your upload string such as *upload:virtual-path:us-west-1:productY/template.yml*.
+In the above example, we are calling the **upload** function on a file called `template.yml` that lives in the *productY* folder within our repository and then returning the path style URL from S3 (indicated by the word *path* in the string). The string *"upload:path:productY/template.yml"* will be replaced by the URL of the object in S3 once it has been uploaded.
+
+Syntax:
+
+```
+# Using the default region:
+upload:${style}:${local_path}
+
+# Or, when you would like to choose a specific region:
+upload:${style}:${region}:${local_path}
+```
+
+There are three different styles that one could choose from.
+
+* `path` style, as shown in the example above, will return the S3 path to the object as.
+  This is referred to as the classic [Path Style method](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html).
+  * In case the bucket is stored in us-east-1, it will return:
+    `https://s3.amazonaws.com/${bucket}/${key}`
+  * In case the bucket is stored in any other region, it will return:
+    `https://s3-${region}.amazonaws.com/${bucket}/${key}`
+* `virtual-hosted` style, will return the S3 location using the virtual hosted bucket domain.
+  * In case the bucket is stored in us-east-1, it will return:
+    `https://${bucket}.s3.amazonaws.com/${key}`
+  * In case the bucket is stored in any other region, it will return:
+    `https://${bucket}.s3-${region}.amazonaws.com/${key}`
+* `s3-url` style, will return the S3 location using S3 URL with the `s3://` protocol.
+  As an example, this style is required for [CloudFormation AWS::Include transform](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html). 
+  * It returns: `s3://${bucket}/${key}`
+* `s3-uri` style, will return the S3 location using S3 URI without specifying a protocol.
+  As an example, this style is required for [CodeBuild project source locations](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-source.html#cfn-codebuild-project-source-location).
+  * It returns: `${bucket}/${key}`
+
+The `region` is optional.
+This allows you to upload files to S3 Buckets within specific regions by
+adding in the region name as part of the string
+(eg. `upload:path:us-west-1:productY/template.yml`).
+
+The `local_path` references the files that you would like to be uploaded from
+the location where `adf-build/generate-params.py` scripts gets executed from.
+As shown in the example shared above, the file to upload would be the
+`productY/template.yml` file that is stored in the root of the repository.
 
 The bucket being used to hold the uploaded object is the same Amazon S3 Bucket that holds deployment artifacts *(On the Deployment Account)* for the specific region which they are intended to be deployed to. Files that are uploaded using this functionality will receive a random name each time they are uploaded.
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
@@ -23,29 +23,36 @@ class S3:
         self.bucket = bucket
 
     def build_pathing_style(self, style, key):
+        if style == 's3-url':
+            return "s3://{bucket}/{key}".format(
+                bucket=self.bucket,
+                key=key
+            )
+        if style == 's3-uri':
+            return "{bucket}/{key}".format(
+                bucket=self.bucket,
+                key=key
+            )
+        s3_region_name = "s3"
+        if self.region != 'us-east-1':
+            s3_region_name = "s3-{region}".format(region=self.region)
         if style == 'path':
-            if self.region == 'us-east-1':
-                return "https://s3.amazonaws.com/{bucket}/{key}".format(
-                    bucket=self.bucket,
-                    key=key
-                )
-            return "https://s3-{region}.amazonaws.com/{bucket}/{key}".format(
-                region=self.region,
+            return "https://{s3_region}.amazonaws.com/{bucket}/{key}".format(
+                s3_region=s3_region_name,
                 bucket=self.bucket,
                 key=key
             )
         if style == 'virtual-hosted':
-            if self.region == 'us-east-1':
-                return "http://{bucket}.s3.amazonaws.com/{key}".format(
-                    bucket=self.bucket,
-                    key=key
-                )
-            return "http://{bucket}.s3-{region}.amazonaws.com/{key}".format(
-                region=self.region,
+            return "https://{bucket}.{s3_region}.amazonaws.com/{key}".format(
+                s3_region=s3_region_name,
                 bucket=self.bucket,
                 key=key
             )
-        raise Exception("Unknown upload style syntax, path or virtual-hosted must be specified.")
+        raise Exception(
+            "Unknown upload style syntax: {style}. "
+            "Valid options include: s3-uri, path, or "
+            "virtual-hosted.".format(style=style)
+        )
 
 
     def put_object(self, key, file_path, style="path", pre_check=False):

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_s3.py
@@ -5,16 +5,101 @@
 
 import os
 import boto3
-from pytest import fixture
+from pytest import fixture, raises
 from stubs import stub_s3
 from mock import Mock
 from s3 import S3
 
-
 @fixture
-def cls():
-    cls = S3(
+def us_east_1_cls():
+    return S3(
         'us-east-1',
         'some_bucket'
     )
+
+@fixture
+def eu_west_1_cls():
+    cls = S3(
+        'eu-west-1',
+        'some_bucket'
+    )
     return cls
+
+def test_build_pathing_style_s3_url_us_east_1(us_east_1_cls):
+    key = 'some/key'
+    assert us_east_1_cls.build_pathing_style('s3-url', key) == \
+        "s3://{bucket}/{key}".format(
+            bucket=us_east_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_s3_url_any_other_region(eu_west_1_cls):
+    key = 'some/key'
+    assert eu_west_1_cls.build_pathing_style('s3-url', key) == \
+        "s3://{bucket}/{key}".format(
+            bucket=eu_west_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_s3_uri_us_east_1(us_east_1_cls):
+    key = 'some/key'
+    assert us_east_1_cls.build_pathing_style('s3-uri', key) == \
+        "{bucket}/{key}".format(
+            bucket=us_east_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_s3_uri_any_other_region(eu_west_1_cls):
+    key = 'some/key'
+    assert eu_west_1_cls.build_pathing_style('s3-uri', key) == \
+        "{bucket}/{key}".format(
+            bucket=eu_west_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_path_us_east_1(us_east_1_cls):
+    key = 'some/key'
+    assert us_east_1_cls.build_pathing_style('path', key) == \
+        "https://s3.amazonaws.com/{bucket}/{key}".format(
+            bucket=us_east_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_path_any_other_region(eu_west_1_cls):
+    key = 'some/key'
+    assert eu_west_1_cls.build_pathing_style('path', key) == \
+        "https://s3-{region}.amazonaws.com/{bucket}/{key}".format(
+            region=eu_west_1_cls.region,
+            bucket=eu_west_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_virtual_hosted_us_east_1(us_east_1_cls):
+    key = 'some/key'
+    assert us_east_1_cls.build_pathing_style('virtual-hosted', key) == \
+        "https://{bucket}.s3.amazonaws.com/{key}".format(
+            bucket=us_east_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_virtual_hosted_any_other_region(eu_west_1_cls):
+    key = 'some/key'
+    assert eu_west_1_cls.build_pathing_style('virtual-hosted', key) == \
+        "https://{bucket}.s3-{region}.amazonaws.com/{key}".format(
+            region=eu_west_1_cls.region,
+            bucket=eu_west_1_cls.bucket,
+            key=key,
+        )
+
+def test_build_pathing_style_unknown_style(us_east_1_cls):
+    key = 'some/key'
+    style = 'unknown'
+    correct_error_message = (
+        "Unknown upload style syntax: {style}. "
+        "Valid options include: s3-uri, path, or virtual-hosted."
+    ).format(style=style)
+    with raises(Exception) as excinfo:
+        us_east_1_cls.build_pathing_style(style, key)
+
+    error_message = str(excinfo.value)
+    assert error_message.find(correct_error_message) >= 0


### PR DESCRIPTION
In order to reference files from CloudFormation, like a Swagger
OpenAPI definition, you need to use the `s3://` format.

At the moment, the `upload:` helper is able to return `path` or
`virtual-hosted` urls. With this PR, it will get support to return
S3-URIs as well.

Modifications:

- Added S3-URI syntax support.
- Removed redundant code for `path` and `virtual-hosted`.
- Added tests to verify the styles and different region configs.
- Documentation has been updated to clearly distinguish the different
  output styles.

**References:**

- Fixes #197 (requests `s3://` as an output format for `upload:` helper).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
