### PR TITLE
Version lock missing CDK dependencies

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
@@ -50,4 +50,7 @@ aws_cdk.aws_cloudwatch==1.20
 aws_cdk.aws_kinesis==1.20
 aws_cdk.aws_s3_assets==1.20
 aws_cdk.aws_sns_subscriptions==1.20
+aws-cdk.aws-sam==1.20
+aws-cdk.cx-api==1.20
+aws-cdk.region-info==1.20
 aws-cdk.core==1.20


### PR DESCRIPTION
In the current release of ADF, the `shared/requirements.txt`
automatically includes three CDK modules with the latest version.

This commit will version-lock those modules to version `1.20` like all
other modules, such that it will not run into compatibility issues when
new versions of CDK are released.

The missing dependencies were:

- `aws-cdk.aws-sam`
- `aws-cdk.cx-api`
- `aws-cdk.region-info`

**References:**

- Fixes #223 (CodeBuild failure: Newer version of CDK is required issue)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
