### PR TITLE
Linting on global.yml of deployment

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -229,9 +229,6 @@ Resources:
             Resource: 
               - "*"
           - Effect: Allow
-            Condition:
-              StringEquals:
-                aws:PrincipalOrgID: !Ref OrganizationId
             Action:
               - "secretsmanager:Get*"
             Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/adf/*" # Only allow CodeBuild access to secrets that start with /adf/*


### PR DESCRIPTION
Fixed statement for adf-codebuild-policy in the deployment global yml definition. Double PrincipalOrgID condition was failing while linting. 