### PR TITLE
Fix IAM for package transform helper to function

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -241,6 +241,7 @@ Resources:
           - Effect: Allow
             Action:
               - "ssm:GetParameter"
+              - "ssm:GetParameters"
             Resource:
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
               - !Sub arn:aws:ssm:${AWS::Region}::parameter/aws/service/*


### PR DESCRIPTION
The `adf-build/helpers/package_transform.sh` helper is not able to
operate without rights to perform `ssm:GetParameters`.

This commit will add it to the `adf-codebuild-role` in the `/deployment` OU.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
