### PR TITLE
retry logic for DescribeRegions while creating new account, handling non-empty default vpc

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/main.py
@@ -97,8 +97,7 @@ def get_all_regions(ec2_client):
                         'Values': [
                             'opt-in-not-required',
                         ]
-                    }async def funcname(parameter_list):
-                        pass
+                    }
                 ]
             )['Regions']
         ]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/main.py
@@ -14,27 +14,35 @@ from organizations import Organizations
 from logger import configure_logger
 from parameter_store import ParameterStore
 from sts import STS
+import tenacity
 
 
 LOGGER = configure_logger(__name__)
-ACCOUNTS_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'adf-accounts'))
+ACCOUNTS_FOLDER = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'adf-accounts'))
+
 
 def main():
     accounts = read_config_files(ACCOUNTS_FOLDER)
     if not bool(accounts):
-        LOGGER.info(f"Found {len(accounts)} account(s) in configuration file(s). Account provisioning will not continue.")
+        LOGGER.info(
+            f"Found {len(accounts)} account(s) in configuration file(s). Account provisioning will not continue.")
         return
     LOGGER.info(f"Found {len(accounts)} account(s) in configuration file(s).")
     organizations = Organizations(boto3)
     all_accounts = organizations.get_accounts()
-    parameter_store = ParameterStore(os.environ.get('AWS_REGION', 'us-east-1'), boto3)
-    adf_role_name = parameter_store.fetch_parameter('cross_account_access_role')
+    parameter_store = ParameterStore(
+        os.environ.get('AWS_REGION', 'us-east-1'), boto3)
+    adf_role_name = parameter_store.fetch_parameter(
+        'cross_account_access_role')
     for account in accounts:
         try:
-            account_id = next(acc["Id"] for acc in all_accounts if acc["Name"] == account.full_name)
-        except StopIteration: # If the account does not exist yet..
+            account_id = next(
+                acc["Id"] for acc in all_accounts if acc["Name"] == account.full_name)
+        except StopIteration:  # If the account does not exist yet..
             account_id = None
-        create_or_update_account(organizations, account, adf_role_name, account_id)
+        create_or_update_account(
+            organizations, account, adf_role_name, account_id)
 
 
 def create_or_update_account(org_session, account, adf_role_name, account_id=None):
@@ -53,24 +61,12 @@ def create_or_update_account(org_session, account, adf_role_name, account_id=Non
         ), 'delete_default_vpc'
     )
 
-    LOGGER.info(f'Ensuring account {account_id} (alias {account.alias}) is in OU {account.ou_path}')
+    LOGGER.info(
+        f'Ensuring account {account_id} (alias {account.alias}) is in OU {account.ou_path}')
     org_session.move_account(account_id, account.ou_path)
     if account.delete_default_vpc:
         ec2_client = role.client('ec2')
-        all_regions = [
-            region['RegionName']
-            for region in ec2_client.describe_regions(
-                AllRegions=False,
-                Filters=[
-                    {
-                        'Name': 'opt-in-status',
-                        'Values': [
-                            'opt-in-not-required',
-                        ]
-                    }
-                ]
-            )['Regions']
-        ]
+        all_regions = get_all_regions(ec2_client)
         args = (
             (account_id, region, role)
             for region in all_regions
@@ -83,8 +79,35 @@ def create_or_update_account(org_session, account, adf_role_name, account_id=Non
     org_session.create_account_alias(account.alias, role)
 
     if account.tags:
-        LOGGER.info(f'Ensuring tags exist for account {account_id}: {account.tags}')
+        LOGGER.info(
+            f'Ensuring tags exist for account {account_id}: {account.tags}')
         org_session.create_account_tags(account_id, account.tags)
+
+
+@tenacity.retry(wait=tenacity.wait_fixed(5), stop=tenacity.stop_after_attempt(60))
+def get_all_regions(ec2_client):
+    try:
+        all_regions = [
+            region['RegionName']
+            for region in ec2_client.describe_regions(
+                AllRegions=False,
+                Filters=[
+                    {
+                        'Name': 'opt-in-status',
+                        'Values': [
+                            'opt-in-not-required',
+                        ]
+                    }async def funcname(parameter_list):
+                        pass
+                ]
+            )['Regions']
+        ]
+        LOGGER.info(f'Regions are: {all_regions}')
+        return all_regions
+    except Exception as ce:
+        print(ce)
+        LOGGER.info(f'I am going to retry')
+        raise
 
 
 def schedule_delete_default_vpc(account_id, region, role):
@@ -95,6 +118,7 @@ def schedule_delete_default_vpc(account_id, region, role):
     """
     ec2_client = role.client('ec2', region_name=region)
     delete_default_vpc(ec2_client, account_id, region, role)
+
 
 if __name__ == '__main__':
     main()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/requirements.txt
@@ -8,3 +8,4 @@ astroid~=2.1.0
 six~=1.11.0
 aws-sam-cli==0.22.0
 pip==19.1.1
+tenacity==6.0.0


### PR DESCRIPTION
*Issues:*
1) when creating a new account, AWS services are not available for some time and bootstrap pipeline and step function fail
2) when deleting default VPCs, pipeline fails if a VPC is non-empty and stops to delete default VPC in any other regions.


*Description of changes:*
1) This code enables ADF to wait for services enablement and retry.
2) This code handles exception on non-empty VPC and continues to delete VPCs in other regions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
