### PR TITLE
Fix CodeBuild assume role to generate parameters

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -298,9 +298,6 @@ Resources:
                 - !Sub arn:aws:iam::${DeploymentAccountId}:role/adf-codebuild-role
             Action:
               - sts:AssumeRole
-            Condition:
-                ArnEquals:
-                    'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${DeploymentAccountId}:project/*'
       Path: /
   ReadOnlyAutomationRolePolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
**In short:**

The `aws:SourceArn` condition is missing in the STS Assume Role context.
This prevents the `generate_params.py` script from assuming into
accounts to get the parameters and outputs from the target accounts.

**In more detail:**

Context when it runs `generate_params.py`:

* CodeBuild will be operating on STS credentials that it gathered when
  the service assumed into the `adf-codebuild-role` in the Deployment
  account.

* When executing the `adf-build/generate_params.py` script, it will perform
  an STS Assume Role operation into the `adf-readonly-automation-role` in the
  target accounts that it needs to fetch parameters or outputs from.

As the latter operation is using an IAM Role to assume into another IAM Role,
we cannot use the `aws:SourceArn` condition as that is no longer available.
This was only available when it assumed into the `adf-codebuild-role` by the
AWS CodeBuild service.

The CloudTrail event of the STS Assume Role operation to show the
current details that are available:

```json
{
    "eventVersion": "1.05",
    "userIdentity": {
        "type": "AWSAccount",
        "principalId": "xxxxxxxxxxxxxxxxxxxxx:AWSCodeBuild-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
        "accountId": "000000000000"
    },
    "eventTime": "2020-03-04T13:58:22Z",
    "eventSource": "sts.amazonaws.com",
    "eventName": "AssumeRole",
    "awsRegion": "us-east-1",
    "sourceIPAddress": "codebuild.amazonaws.com",
    "userAgent": "codebuild.amazonaws.com",
    "requestParameters": {
        "roleArn": "arn:aws:iam::111111111111:role/adf-readonly-automation-role",
        "roleSessionName": "importer"
    },
    "responseElements": {
        "credentials": {
            "accessKeyId": "xxxxxxxxxxxxxxxxxxxx",
            "expiration": "Mar 4, 2020 2:58:22 PM",
            "sessionToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=="
        },
        "assumedRoleUser": {
            "assumedRoleId": "xxxxxxxxxxxxxxxxxxxxx:importer",
            "arn": "arn:aws:sts::111111111111:assumed-role/adf-readonly-automation-role/importer"
        }
    },
    "requestID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    "eventID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    "resources": [
        {
            "ARN": "arn:aws:iam::111111111111:role/adf-readonly-automation-role",
            "accountId": "111111111111",
            "type": "AWS::IAM::Role"
        }
    ],
    "eventType": "AwsApiCall",
    "recipientAccountId": "111111111111",
    "sharedEventID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
}
```

References:
* Fixes #230 - Cross-account role assumption to generate params

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
