### PR TITLE
Fix import references of export to output key

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -391,7 +391,7 @@ pipelines:
 
 ### Parameter Injection
 
-Parameter injection solves problems that occur with Cross Account parameter access. This concept allows the resolution of values directly from SSM Parameter Store within the Deployment account into Parameter files *(eg global.json, account-name.json)* and also importing of exported values from CloudFormation stacks across accounts and regions.
+Parameter injection solves problems that occur with Cross Account parameter access. This concept allows the resolution of values directly from SSM Parameter Store within the Deployment account into Parameter files *(eg global.json, account-name.json)* and also importing of output values from CloudFormation stacks across accounts and regions.
 
 #### Retrieving parameter values
 
@@ -410,16 +410,16 @@ To highlight an example of how Parameter Injection can work well, think of the f
 
 There is also the concept of optionally resolving or importing values. This can be achieved by ending the import or resolve function with a **?**. For example, if you want to resolve a value from Parameter Store that might or might not yet exist you can use an optional resolve *(eg resolve:/my/path/to/myMagicKey?)*. If the key *myMagicKey* does not exist in Parameter Store then an empty string will be returned as the value.
 
-#### Importing exported values
+#### Importing output values
 
-Parameter injection is also useful for importing exported values from CloudFormation stacks in other accounts or regions. Using the special **"import"** syntax you can access these values directly into your parameter files.
+Parameter injection is also useful for importing output values from CloudFormation stacks in other accounts or regions. Using the special **"import"** syntax you can access these values directly into your parameter files.
 
 ```yaml
 Parameters:
-    BucketInLoggingAccount: 'import:123456789101:eu-west-1:stack_name:export_key'
+    BucketInLoggingAccount: 'import:123456789101:eu-west-1:stack_name:output_key'
 ```
 
-In the above example *123456789101* is the AWS Account Id in which we want to pull a value from, *eu-west-1* is the region, stack_name is the CloudFormation stack name and *export_key* is the output key name *(not export name)*. Again, this concept works with the optional style syntax *(eg, import:123456789101:eu-west-1:stack_name:export_key?)* if the key *export_key* does not exist at the point in time when this specific import is executed, it will return an empty string as the parameter value rather than an error since it is considered optional.
+In the above example *123456789101* is the AWS Account Id in which we want to pull a value from, *eu-west-1* is the region, stack_name is the CloudFormation stack name and *output_key* is the output key name *(not export name)*. Again, this concept works with the optional style syntax *(eg, import:123456789101:eu-west-1:stack_name:output_key?)* if the key *output_key* does not exist at the point in time when this specific import is executed, it will return an empty string as the parameter value rather than an error since it is considered optional.
 
 #### Uploading assets
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
@@ -34,16 +34,16 @@ class Resolver:
 
     def fetch_stack_output(self, value, key, optional=False): # pylint: disable=too-many-statements
         try:
-            [_, account_id, region, stack_name, export] = str(value).split(':')
+            [_, account_id, region, stack_name, output_key] = str(value).split(':')
         except ValueError:
             raise ValueError(
                 "{0} is not a valid import string."
-                "syntax should be import:account_id:region:stack_name:export_key".format(str(value))
+                "syntax should be import:account_id:region:stack_name:output_key".format(str(value))
             )
-        if Resolver._is_optional(export):
-            LOGGER.info("Parameter %s is considered optional", export)
+        if Resolver._is_optional(output_key):
+            LOGGER.info("Parameter %s is considered optional", output_key)
             optional = True
-        export = export[:-1] if optional else export
+        output_key = output_key[:-1] if optional else output_key
         try:
             role = self.sts.assume_cross_account_role(
                 'arn:aws:iam::{0}:role/{1}'.format(
@@ -58,7 +58,7 @@ class Resolver:
                 stack_name=stack_name,
                 account_id=account_id
             )
-            stack_output = self.cache.check(value) or cloudformation.get_stack_output(export)
+            stack_output = self.cache.check(value) or cloudformation.get_stack_output(output_key)
             if stack_output:
                 LOGGER.info("Stack output value is %s", stack_output)
                 self.cache.add(value, stack_output)
@@ -73,7 +73,16 @@ class Resolver:
                 self.stage_parameters[parent_key][key] = stack_output
             else:
                 if not stack_output:
-                    raise Exception("No Stack Output found on %s in %s with stack name %s and output key %s" % account_id, region, stack_name, export)
+                    raise Exception(
+                        "No Stack Output found on {account_id} in {region} "
+                        "with stack name {stack} and output key "
+                        "{output_key}".format(
+                            account_id=account_id,
+                            region=region,
+                            stack=stack_name,
+                            output_key=output_key,
+                        )
+                    )
                 self.stage_parameters[parent_key][key] = stack_output
         except IndexError:
             if stack_output:


### PR DESCRIPTION
In the code and docs of the import statement, it was referring to the
`export_key`. However, in the fine print it stated that it is referring
to the `output_key` as part of the Stack outputs instead.

This was confusing people to create outputs with export ids, thinking
they had to. This update renames the usage to `output_key` instead such
that it is consistent in the docs and code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
