### PR TITLE
Adds s3-key-only style

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -445,7 +445,7 @@ upload:${style}:${local_path}
 upload:${style}:${region}:${local_path}
 ```
 
-There are three different styles that one could choose from.
+There are five different styles that one could choose from.
 
 * `path` style, as shown in the example above, will return the S3 path to the object as.
   This is referred to as the classic [Path Style method](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html).
@@ -464,6 +464,8 @@ There are three different styles that one could choose from.
 * `s3-uri` style, will return the S3 location using S3 URI without specifying a protocol.
   As an example, this style is required for [CodeBuild project source locations](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-source.html#cfn-codebuild-project-source-location).
   * It returns: `${bucket}/${key}`
+* `s3-key-only` style, similar to `s3-uri` but it will only return the `key` value.
+  * It returns: `${key}`
 
 The `region` is optional.
 This allows you to upload files to S3 Buckets within specific regions by

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
@@ -33,6 +33,10 @@ class S3:
                 bucket=self.bucket,
                 key=key
             )
+        if style == 's3-key-only':
+            return "{key}".format(
+                key=key
+            )
         s3_region_name = "s3"
         if self.region != 'us-east-1':
             s3_region_name = "s3-{region}".format(region=self.region)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_s3.py
@@ -57,6 +57,20 @@ def test_build_pathing_style_s3_uri_any_other_region(eu_west_1_cls):
             key=key,
         )
 
+def test_build_pathing_style_s3_key_only_us_east_1(us_east_1_cls):
+    key = 'some/key'
+    assert us_east_1_cls.build_pathing_style('s3-key-only', key) == \
+        "{key}".format(
+            key=key,
+        )
+
+def test_build_pathing_style_s3_key_only_any_other_region(eu_west_1_cls):
+    key = 'some/key'
+    assert eu_west_1_cls.build_pathing_style('s3-key-only', key) == \
+        "{key}".format(
+            key=key,
+        )
+
 def test_build_pathing_style_path_us_east_1(us_east_1_cls):
     key = 'some/key'
     assert us_east_1_cls.build_pathing_style('path', key) == \

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
@@ -84,7 +84,7 @@ class Resolver:
         return True
 
     def upload(self, value, key, file_name):
-        if not any(item in value for item in ['path', 'virtual-hosted']):
+        if not any(item in value for item in ['path', 'virtual-hosted', 's3-key-only']):
             raise Exception(
                 'When uploading to S3 you need to specify a '
                 'pathing style for the response either path or virtual-hosted, '


### PR DESCRIPTION
*Issue #, if available:*
No issue available

*Description of changes:*
Added a new Upload style called `aws-key-only`. This is very similar to `s3-uri`, but it only returns the Key value.

It's very useful in case you need to use CDK to declare a Lambda Function and want to use the `fromBucket` method for the source code. 

Since you can't use CDK `fromAsset` method with ADF, then you would have to find another way to upload your Lambda code using a native method like ADF Upload. `fromBucket` method  asks for Bucket Name and S3 Key to be provided, but you can't know those before running the ADF Build stage, so you need to find a way to declare this values using CloudFormation Parameters. Since `s3-uri` returns a String similar to `<bucketName>/adf-upload/<assetFolder>/<asset>` and that's kinda difficult to separate using native CloudFormation functions, an easier approach is to use two CloudFormation parameters:

```
Parameters:
  BucketName: 'resolve:/cross_region/s3_regional_bucket/<region>'
  BucketKey: 'upload:s3-key-only:lambda/code.zip'
```

Then you could use both to put into CDK's `lambda.Code.fromBucket` code declaration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
