### PR TITLE
Fix CodeBuild use specific image in target stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ init:
 test:
 	# Run unit tests
 	pytest src/lambda_codebase/initial_commit/bootstrap_repository -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pytest.ini																																
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pytest.ini
 	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pytest.ini
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/pytest.ini
 	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini
 lint:
 	# Linter performs static analysis to catch latent bugs
-	find src/ -iname "*.py" | xargs pylint --rcfile .pylintrc 
+	find src/ -iname "*.py" | xargs pylint --rcfile .pylintrc

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -20,6 +20,8 @@ ADF_DEPLOYMENT_REGION = os.environ["AWS_REGION"]
 ADF_DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]
 
 class CodeBuild(core.Construct):
+    # pylint: disable=no-value-for-parameter
+
     def __init__(self, scope: core.Construct, id: str, shared_modules_bucket: str, deployment_region_kms: str, map_params: dict, target, **kwargs): #pylint: disable=W0622
         super().__init__(scope, id, **kwargs)
         ADF_DEFAULT_BUILD_ROLE = 'arn:aws:iam::{0}:role/adf-codebuild-role'.format(ADF_DEPLOYMENT_ACCOUNT_ID)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -96,6 +96,7 @@ class Action:
                 "Owner": self.map_params.get('default_providers', {}).get('source').get('properties', {}).get('owner', {}),
                 "Repo": self.map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('repository', {}) or self.map_params['name'],
                 "Branch": self.map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('branch', {}) or 'master',
+                # pylint: disable=no-value-for-parameter
                 "OAuthToken": core.SecretValue.secrets_manager(
                     self.map_params['default_providers']['source'].get('properties', {}).get('oauth_token_path'),
                     json_field=self.map_params['default_providers']['source'].get('properties', {}).get('json_field')
@@ -394,5 +395,6 @@ class Pipeline(core.Construct):
     def import_required_arns():
         _output = []
         for arn in Pipeline._import_arns:
+            # pylint: disable=no-value-for-parameter
             _output.append(core.Fn.import_value(arn))
         return _output

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
@@ -22,6 +22,7 @@ ADF_PIPELINE_PREFIX = os.environ.get("ADF_PIPELINE_PREFIX", "")
 class Events(core.Construct):
     def __init__(self, scope: core.Construct, id: str, params: dict, **kwargs): #pylint: disable=W0622
         super().__init__(scope, id, **kwargs)
+        # pylint: disable=no-value-for-parameter
         _pipeline = _codepipeline.Pipeline.from_pipeline_arn(self, 'pipeline', params["pipeline"])
         _source_account = params.get('source', {}).get('account_id')
         _provider = params.get('source', {}).get('provider')
@@ -58,6 +59,7 @@ class Events(core.Construct):
                 )
             )
         if params.get('topic_arn'):
+            # pylint: disable=no-value-for-parameter
             _topic = _sns.Topic.from_topic_arn(self, 'topic_arn', params["topic_arn"])
             _event = _events.Rule(
                 self,
@@ -117,6 +119,7 @@ class Events(core.Construct):
                         source=["aws.codepipeline"]
                     )
                 )
+                # pylint: disable=no-value-for-parameter
                 _completion_pipeline = _codepipeline.Pipeline.from_pipeline_arn(
                     self,
                     'pipeline-{0}'.format(index),
@@ -135,6 +138,7 @@ class Events(core.Construct):
                 'schedule_{0}'.format(params['name']),
                 description="Triggers {0} on a schedule of {1}".format(params['name'], params['schedule']),
                 enabled=True,
+                # pylint: disable=no-value-for-parameter
                 schedule=_events.Schedule.expression(params['schedule'])
             )
             _target_pipeline = _targets.CodePipeline(

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_github.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_github.py
@@ -55,6 +55,7 @@ class GitHub(core.Construct):
             ],
             target_action="source",
             name="adf-webhook-{0}".format(map_params['name']),
+            # pylint: disable=no-value-for-parameter
             target_pipeline_version=core.Token.as_number(_version),
             register_with_third_party=True
         )

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
@@ -23,6 +23,7 @@ class Notifications(core.Construct):
     def __init__(self, scope: core.Construct, id: str, map_params: dict, **kwargs): #pylint: disable=W0622
         super().__init__(scope, id, **kwargs)
         LOGGER.debug('Notification configuration required for %s', map_params['name'])
+        # pylint: disable=no-value-for-parameter
         _slack_func = _lambda.Function.from_function_arn(
             self,
             'slack_lambda_function',

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Tests for cdk_constructs
+"""
+
+import sys
+import os
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__))))

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_determine_build_image.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_determine_build_image.py
@@ -1,0 +1,584 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file
+
+from copy import deepcopy
+from mock import patch
+from aws_cdk import (
+    aws_codebuild as _codebuild,
+    core,
+)
+from cdk_constructs.adf_codebuild import CodeBuild, DEFAULT_CODEBUILD_IMAGE
+
+SIMPLE_TARGET = {
+    'properties': {},
+}
+SPECIFIC_CODEBUILD_IMAGE_STR = 'STANDARD_3_0'
+SPECIFIC_CODEBUILD_IMAGE_ALT_STR = 'STANDARD_2_0'
+SPECIFIC_CODEBUILD_IMAGE_ALT2_STR = 'STANDARD_1_0'
+SPECIFIC_CODEBUILD_IMAGE_ECR = {
+    'repository_arn': 'arn:aws:ecr:region:012345678910:repository/test',
+    'tag': 'specific',
+}
+CODEBUILD_SPECIFIC_MAP_PARAMS_STR = {
+    'provider': 'codebuild',
+    'properties': {
+        'image': SPECIFIC_CODEBUILD_IMAGE_STR,
+    }
+}
+CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR = {
+    'provider': 'codebuild',
+    'properties': {
+        'image': SPECIFIC_CODEBUILD_IMAGE_ALT_STR,
+    }
+}
+CODEBUILD_SPECIFIC_MAP_PARAMS_ALT2_STR = {
+    'provider': 'codebuild',
+    'properties': {
+        'image': SPECIFIC_CODEBUILD_IMAGE_ALT2_STR,
+    }
+}
+CODEBUILD_SPECIFIC_MAP_PARAMS_ECR = {
+    'provider': 'codebuild',
+    'properties': {
+        'image': SPECIFIC_CODEBUILD_IMAGE_ECR,
+    }
+}
+
+CODEBUILD_BASE_MAP_PARAMS = {
+    'default_providers': {
+        'build': {},
+        'deploy': {},
+    },
+}
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_build_defaults(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Not set.
+        Build: No specifics, i.e. use defaults.
+        Deploy: Specific config set, as str.
+
+    Tests:
+        Since the target is not set, it will determine that it is a build
+        step. As no specific config for the default build provider is set
+        it should return the default config.
+    """
+    scope = core.Stack()
+    target = None
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    # Set deploy one to alternative, so we can test
+    # that it is not using this in build steps
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == getattr(
+        _codebuild.LinuxBuildImage,
+        DEFAULT_CODEBUILD_IMAGE,
+    )
+    ecr_repo.from_repository_arn.assert_not_called()
+    build_image.from_ecr_repository.assert_not_called()
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_build_str(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Not set.
+        Build: Specific config set, as str, should use this.
+        Deploy: Specific config set, as str.
+
+    Tests:
+        Since the target is not set, it will determine that it is a build
+        step. As specific config for the default build provider is set
+        it should use these, not the deploy specific config.
+    """
+    scope = core.Stack()
+    target = None
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_STR
+    # Set deploy one to alternative, so we can test
+    # that it is not using this in build steps
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == getattr(
+        _codebuild.LinuxBuildImage,
+        SPECIFIC_CODEBUILD_IMAGE_STR,
+    )
+    ecr_repo.from_repository_arn.assert_not_called()
+    build_image.from_ecr_repository.assert_not_called()
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_build_ecr(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Not set.
+        Build: Specific config set, as ECR dict, should use this.
+        Deploy: Specific config set, as str.
+
+    Tests:
+        Since the target is not set, it will determine that it is a build
+        step. As specific config for the default build provider is set
+        it should use these with ECR, not the deploy specific config.
+        Plus setting the 'specific' tag, as that is specified.
+    """
+    scope = core.Stack()
+    target = None
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ECR
+    # Set deploy one to alternative, so we can test
+    # that it is not using this in build steps
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    from_repo_arn_return_value = {'Some': 'Value'}
+    ecr_repo.from_repository_arn.return_value = from_repo_arn_return_value
+
+    from_ecr_repo_return_value = {'Another': 'Object'}
+    build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == from_ecr_repo_return_value
+    ecr_repo.from_repository_arn.assert_called_once_with(
+        scope,
+        'custom_repo',
+        SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
+    )
+    build_image.from_ecr_repository.assert_called_once_with(
+        from_repo_arn_return_value,
+        SPECIFIC_CODEBUILD_IMAGE_ECR.get('tag'),
+    )
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_build_ecr_no_tag(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Not set.
+        Build: Specific config set, as ECR dict, should use these,
+            but has no specific tag set, so should use 'latest'.
+        Deploy: Specific config set, as str.
+
+    Tests:
+        Since the target is not set, it will determine that it is a build
+        step. As specific config for the default build provider is set
+        it should use these with ECR, not the deploy specific config.
+        Plus setting the 'latest' default tag, as that is not specified.
+    """
+    scope = core.Stack()
+    target = None
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['build'] = deepcopy(
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ECR
+    )
+    del map_params['default_providers']['build']['properties']['image']['tag']
+    # Set deploy one to alternative, so we can test
+    # that it is not using this in build steps
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    from_repo_arn_return_value = {'Some': 'Value'}
+    ecr_repo.from_repository_arn.return_value = from_repo_arn_return_value
+
+    from_ecr_repo_return_value = {'Another': 'Object'}
+    build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == from_ecr_repo_return_value
+    ecr_repo.from_repository_arn.assert_called_once_with(
+        scope,
+        'custom_repo',
+        SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
+    )
+    build_image.from_ecr_repository.assert_called_once_with(
+        from_repo_arn_return_value,
+        'latest',
+    )
+
+
+# Deploy mode
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_defaults(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Set, no config.
+        Build: Specific config set, as str.
+        Build: No specifics, i.e. use defaults.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As no specific config for the default deploy provider is set
+        it should return the default config.
+    """
+    scope = core.Stack()
+    target = SIMPLE_TARGET
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == getattr(
+        _codebuild.LinuxBuildImage,
+        DEFAULT_CODEBUILD_IMAGE,
+    )
+    ecr_repo.from_repository_arn.assert_not_called()
+    build_image.from_ecr_repository.assert_not_called()
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_target_str(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Specific config set, as str, should use this.
+        Build: Specific config set, as str.
+        Deploy: No specifics, i.e. would fallback to defaults if no
+            target specific config is set.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As specific config for the target is set it should use these,
+        not the default deploy specific config.
+    """
+    scope = core.Stack()
+    target = CODEBUILD_SPECIFIC_MAP_PARAMS_STR
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == getattr(
+        _codebuild.LinuxBuildImage,
+        SPECIFIC_CODEBUILD_IMAGE_STR,
+    )
+    ecr_repo.from_repository_arn.assert_not_called()
+    build_image.from_ecr_repository.assert_not_called()
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_str(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Set, no specific config.
+        Build: Specific config set, as str.
+        Deploy: Specific config set, as str, should use this.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As specific config for the default deploy provider is set
+        it should use these, not the build specific config.
+    """
+    scope = core.Stack()
+    target = SIMPLE_TARGET
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_STR
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == getattr(
+        _codebuild.LinuxBuildImage,
+        SPECIFIC_CODEBUILD_IMAGE_STR,
+    )
+    ecr_repo.from_repository_arn.assert_not_called()
+    build_image.from_ecr_repository.assert_not_called()
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_target_str_too(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Specific config set, should use this.
+        Build: Specific config set, as str.
+        Deploy: Specific config set, as str.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As specific config for the target is set it should use these,
+        not the default build or deploy specific config.
+    """
+    scope = core.Stack()
+    target = CODEBUILD_SPECIFIC_MAP_PARAMS_ALT2_STR
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_STR
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == getattr(
+        _codebuild.LinuxBuildImage,
+        SPECIFIC_CODEBUILD_IMAGE_ALT2_STR,
+    )
+    ecr_repo.from_repository_arn.assert_not_called()
+    build_image.from_ecr_repository.assert_not_called()
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_ecr(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Set, no specific config.
+        Build: Specific config set, as str.
+        Deploy: Specific config set, as ECR dict, should use this.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As specific config for the default deploy provider is set
+        it should use these with ECR, not the build specific config.
+        Plus setting the 'specific' tag, as that is specified.
+    """
+    scope = core.Stack()
+    target = SIMPLE_TARGET
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ECR
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    from_repo_arn_return_value = {'Some': 'Value'}
+    ecr_repo.from_repository_arn.return_value = from_repo_arn_return_value
+
+    from_ecr_repo_return_value = {'Another': 'Object'}
+    build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == from_ecr_repo_return_value
+    ecr_repo.from_repository_arn.assert_called_once_with(
+        scope,
+        'custom_repo',
+        SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
+    )
+    build_image.from_ecr_repository.assert_called_once_with(
+        from_repo_arn_return_value,
+        SPECIFIC_CODEBUILD_IMAGE_ECR.get('tag'),
+    )
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_ecr_too(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Specific config set, as ECR dict, should use this.
+        Build: Specific config set, as str.
+        Deploy: Specific config set, as ECR dict.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As specific config for the target is set it should use these
+        with ECR, not the default build or deploy specific config.
+        Plus setting the 'specific' tag, as that is specified.
+    """
+    scope = core.Stack()
+    target = deepcopy(CODEBUILD_SPECIFIC_MAP_PARAMS_ECR)
+    target['properties']['image']['repository_arn'] = 'arn:other:one'
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['deploy'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ECR
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    from_repo_arn_return_value = {'Some': 'Value'}
+    ecr_repo.from_repository_arn.return_value = from_repo_arn_return_value
+
+    from_ecr_repo_return_value = {'Another': 'Object'}
+    build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == from_ecr_repo_return_value
+    ecr_repo.from_repository_arn.assert_called_once_with(
+        scope,
+        'custom_repo',
+        target['properties']['image']['repository_arn'],
+    )
+    build_image.from_ecr_repository.assert_called_once_with(
+        from_repo_arn_return_value,
+        SPECIFIC_CODEBUILD_IMAGE_ECR.get('tag'),
+    )
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_ecr_no_tag(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Set, no specific config.
+        Build: Specific config set, as str.
+        Deploy: Specific config set, as ECR dict, should use these,
+            but has no specific tag set, so should use 'latest'.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As specific config for the default deploy provider is set
+        it should use these with ECR, not the build specific config.
+        Plus setting the 'latest' default tag, as that is not specified.
+    """
+    scope = core.Stack()
+    target = SIMPLE_TARGET
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['deploy'] = deepcopy(
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ECR
+    )
+    del map_params['default_providers']['deploy']['properties']['image']['tag']
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    from_repo_arn_return_value = {'Some': 'Value'}
+    ecr_repo.from_repository_arn.return_value = from_repo_arn_return_value
+
+    from_ecr_repo_return_value = {'Another': 'Object'}
+    build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == from_ecr_repo_return_value
+    ecr_repo.from_repository_arn.assert_called_once_with(
+        scope,
+        'custom_repo',
+        SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
+    )
+    build_image.from_ecr_repository.assert_called_once_with(
+        from_repo_arn_return_value,
+        'latest',
+    )
+
+
+@patch('cdk_constructs.adf_codebuild._codebuild.LinuxBuildImage')
+@patch('cdk_constructs.adf_codebuild._ecr.Repository')
+def test_determine_build_image_deploy_ecr_no_tag_too(ecr_repo, build_image):
+    """
+    Scenario:
+        Target: Specific config set, as ECR dict, should use these,
+            but has no specific tag set, so should use 'latest'.
+        Build: Specific config set, as str.
+        Deploy: Specific config set, as ECR dict.
+
+    Tests:
+        Since the target is set, it will determine that it is a deploy
+        step. As specific config for the target is set it should use these
+        with ECR, not the default build or deploy specific config.
+        Plus setting the 'latest' default tag, as that is not specified.
+    """
+    scope = core.Stack()
+    target = deepcopy(CODEBUILD_SPECIFIC_MAP_PARAMS_ECR)
+    target['properties']['image']['repository_arn'] = 'arn:other:one'
+    del target['properties']['image']['tag']
+    map_params = deepcopy(CODEBUILD_BASE_MAP_PARAMS)
+    map_params['default_providers']['deploy'] = deepcopy(
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ECR
+    )
+    # Set build one to alternative, so we can test
+    # that it is not using this in deploy steps
+    map_params['default_providers']['build'] = \
+        CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
+
+    from_repo_arn_return_value = {'Some': 'Value'}
+    ecr_repo.from_repository_arn.return_value = from_repo_arn_return_value
+
+    from_ecr_repo_return_value = {'Another': 'Object'}
+    build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
+
+    result = CodeBuild.determine_build_image(
+        scope=scope,
+        target=target,
+        map_params=map_params,
+    )
+
+    assert result == from_ecr_repo_return_value
+    ecr_repo.from_repository_arn.assert_called_once_with(
+        scope,
+        'custom_repo',
+        target['properties']['image']['repository_arn'],
+    )
+    build_image.from_ecr_repository.assert_called_once_with(
+        from_repo_arn_return_value,
+        'latest',
+    )

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = cdk_constructs/tests

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 testpaths = tests
-norecursedirs = python
+norecursedirs = python cdk

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
@@ -1,7 +1,7 @@
 # Install libs here that you might want in AWS CodeBuild
 pytest==3.0.7
 mock==2.0.0
-boto3==1.9.89
+boto3~=1.10, >=1.10.47
 pyyaml>=5.1
 schema==0.7.1
 jsii~=0.21.1

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ setenv=
 whitelist_externals = make
 deps =
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
     -r{toxinidir}/src/lambda_codebase/initial_commit/requirements.txt
 commands =
     make test


### PR DESCRIPTION
**Issue:**

When one would try to specify the CodeBuild image in the target
environment when using CodeBuild, it did not accept having strings
as input.

For example, with this deployment map:
```yaml
  - name: sample-pipeline
    default_providers:
      source:
        provider: codecommit
        properties:
          account_id: 111111111111
      build:
        provider: codebuild
        properties:
          image: STANDARD_3_0
      deploy:
        provider: cloudformation
    targets:
      - name: deploy-to-dev
        path: /development
      - name: integration-tests-on-dev
        provider: codebuild
        properties:
          image: STANDARD_3_0
          spec_filename: testspec.yml
```

This would fail with the following error:
```
jsii.errors.JSIIError: Expected object reference, got "STANDARD_3_0"

Subprocess exited with error 1
```

It was only able to handle ECR dictionary image types before.

**Fix:**

Refactored the `determine_build_image` function to accept both (default CodeBuild images specified as strings or ECR container images as a dictionary of arn and tag) + reduced
the complexity along the way. Additionally, tests have been written to cover
all the different use cases for this function.

As part of this PR, I added the test cases to the Makefile.
However, this introduced a new issue where it started to pylint the cdk_constructs as well, which ran into the following CDK error: when using class methods, it complained that certain variables are not set. This seems to be an open issue in CDK: aws/aws-cdk#5491. I've added the workarounds as a separate commit so it can be easily reverted in the future when that is fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
