### PR TITLE
Fix order of intrinsic upload region usage in docs

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -444,7 +444,7 @@ Syntax:
 upload:${style}:${local_path}
 
 # Or, when you would like to choose a specific region:
-upload:${style}:${region}:${local_path}
+upload:${region}:${style}:${local_path}
 ```
 
 There are five different styles that one could choose from.
@@ -472,7 +472,7 @@ There are five different styles that one could choose from.
 The `region` is optional.
 This allows you to upload files to S3 Buckets within specific regions by
 adding in the region name as part of the string
-(eg. `upload:path:us-west-1:productY/template.yml`).
+(eg. `upload:us-west-1:path:productY/template.yml`).
 
 The `local_path` references the files that you would like to be uploaded from
 the location where `adf-build/generate-params.py` scripts gets executed from.


### PR DESCRIPTION
When using the intrinsic `upload:` function, the user documentation
stated that the region should be added after the style of the returned
S3 object location.

This causes the look-up of the bucket to use to fail, as it tries to
lookup the bucket for the region referencing the style of the upload.

When using: `upload:s3-key-only:us-east-1:somefile.zip` you get:

```
errors.ParameterNotFoundError: Parameter /cross_region/s3_regional_bucket/s3-key-only Not Found
```

When looking at the [code: src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py#L103](https://github.com/awslabs/aws-deployment-framework/blob/8ae0f35da64e90da3790935a664908e3e5adf133/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py#L103)
it shows that the region should be placed before the style.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
