### PR TITLE
Correct removing pipelines anchor

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -7,7 +7,7 @@
   - [Repositories](#repositories)
   - [Completion Triggers](#completion-triggers)
   - [Additional Deployment Maps](#additional-deployment-maps)
-  - [Removing Pipelines](#serverless-transforms)
+  - [Removing Pipelines](#removing-pipelines)
 - [Deploying via Pipelines](#deploying-via-pipelines)
   - [BuildSpec](#buildspec)
   - [Parameters and Tagging](#cloudformation-parameters-and-tagging)


### PR DESCRIPTION
*Issue #, if available:* Removing Pipelines anchor was pointing to the wrong subheading

*Description of changes:* Updated the anchor to point to the Removing Pipelines section


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.