### PR TITLE
Use isort v4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 tox==2.2.1
 pylint==2.2.2
 pytest==3.0.7
+isort==4.3.21
 mock==2.0.0
 boto3~=1.10, >=1.10.47
 pyyaml>=5.1


### PR DESCRIPTION
With the release of isort v5 the builds of our main branch kept failing.
Travis CI was using the latest version as it was not instructed to do
otherwise.

With this release, we force it to install v4 instead so builds continue to
operate until they support isort v5 in pylint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
