### PR TITLE
Fix specific role usage to be used in Build and Deploy only

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -43,6 +43,8 @@ class Action:
         self.config = self.generate()
 
     def _generate_role_arn(self):
+        if self.category not in ['Build', 'Deploy']:
+            return None
         default_provider = self.map_params['default_providers'][self.category.lower()]
         specific_role = self.target.get('properties', {}).get('role') or default_provider.get('properties', {}).get('role')
         if specific_role:


### PR DESCRIPTION
**Why?**
A bug prevented stages like Approvals to be included in a pipeline. As
the _generate_role_arn function tried to retrieve the specific role for
the approval stage, while that stage doesn't support such properties.

**What changed?**
Added a check to look for specific roles in Build and Deploy stages
only. All other stages should not use a specific role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
