### PR TITLE
Update CodeBuild version from 2.0 to 3.0

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -26,7 +26,7 @@ Parameters:
   Image:
     Description: The Image you wish to use for CodeBuild (defaults to ubuntu).
     Type: String
-    Default: "aws/codebuild/standard:2.0"
+    Default: "aws/codebuild/standard:3.0"
   ComputeType:
     Description: The Compute Type to use for AWS CodeBuild
     Type: String
@@ -654,7 +654,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.7
+                python: 3.8
                 nodejs: 10
             pre_build:
               commands:
@@ -930,7 +930,7 @@ Resources:
         Variables:
           ADF_PIPELINE_PREFIX: !Ref PipelinePrefix
           ADF_LOG_LEVEL: !Ref ADFLogLevel
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 10
   EnableCrossAccountAccess:
     Type: "AWS::Serverless::Function"
@@ -948,7 +948,7 @@ Resources:
       FunctionName: UpdateCrossAccountIAM
       Handler: enable_cross_account_access.lambda_handler
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 900
   CheckPipelineStatus:
     Type: "AWS::Serverless::Function"
@@ -965,7 +965,7 @@ Resources:
       FunctionName: CheckPipelineStatus
       Handler: update_pipelines.lambda_handler
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 120
   LambdaRole:
     Type: "AWS::IAM::Role"
@@ -1172,7 +1172,7 @@ Resources:
                 - codecommit:DeleteBranch
               Resource: !GetAtt CodeCommitRepository.Arn
       FunctionName: PipelinesCreateInitialCommitFunction
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   KmsKeyArnParameter:
     Type: "AWS::SSM::Parameter"

--- a/src/template.yml
+++ b/src/template.yml
@@ -176,7 +176,7 @@ Resources:
           ADF_LOG_LEVEL: INFO
       FunctionName: StackWaiter
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   DetermineEventFunction:
     Type: 'AWS::Serverless::Function'
@@ -197,7 +197,7 @@ Resources:
           ADF_LOG_LEVEL: INFO
       FunctionName: DetermineEventFunction
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   CrossAccountExecuteFunction:
     Type: 'AWS::Serverless::Function'
@@ -218,7 +218,7 @@ Resources:
           ADF_LOG_LEVEL: INFO
       FunctionName: CrossAccountExecuteFunction
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 600
   RoleStackDeploymentFunction:
     Type: 'AWS::Serverless::Function'
@@ -237,7 +237,7 @@ Resources:
           ADF_LOG_LEVEL: INFO
       FunctionName: RoleStackDeploymentFunction
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   MovedToRootActionFunction:
     Type: 'AWS::Serverless::Function'
@@ -256,7 +256,7 @@ Resources:
           ADF_LOG_LEVEL: INFO
       FunctionName: MovedToRootActionFunction
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 900
   UpdateResourcePoliciesFunction:
     Type: 'AWS::Serverless::Function'
@@ -275,7 +275,7 @@ Resources:
           ADF_LOG_LEVEL: INFO
       FunctionName: UpdateResourcePoliciesFunction
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   CloudWatchEventsRule:
     Type: "AWS::Events::Rule"
@@ -446,7 +446,7 @@ Resources:
       Environment:
         ComputeType: "BUILD_GENERAL1_LARGE"
         PrivilegedMode: false
-        Image: "aws/codebuild/standard:2.0"
+        Image: "aws/codebuild/standard:3.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
             Value: 3.0.6
@@ -473,7 +473,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.7
+                python: 3.8
             pre_build:
               commands:
                 - apt-get update -qq
@@ -745,7 +745,7 @@ Resources:
                 - codecommit:GetDifferences
               Resource: !GetAtt CodeCommitRepository.Arn
       FunctionName: BootstrapCreateInitialCommitFunction
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   SharedModulesBucket:
     Type: Custom::CrossRegionBucket
@@ -809,7 +809,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/shared_modules_bucket"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/deployment_account_region"
       FunctionName: CrossRegionBucketHandler
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   Organization:
     Type: Custom::Organization
@@ -835,7 +835,7 @@ Resources:
               Action: "iam:CreateServiceLinkedRole"
               Resource: "arn:aws:iam::*:role/aws-service-role/*"
       FunctionName: AwsOrganizationsHandler
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   DeploymentOrganizationUnit:
     Type: Custom::OrganizationUnit
@@ -859,7 +859,7 @@ Resources:
                 - "organizations:ListOrganizationalUnitsForParent"
               Resource: "*"
       FunctionName: OrganizationUnitHandler
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   DeploymentAccount:
     Type: Custom::Account
@@ -888,7 +888,7 @@ Resources:
               Action: ssm:GetParameter
               Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/deployment_account_id"
       FunctionName: AccountHandler
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
   PipelineCloudWatchEventRole:
       Type: AWS::IAM::Role


### PR DESCRIPTION
Updated the CodeBuild version in 'template.yml' in the src folder. Because 2.0 is no longer supported. Changed to python version to 3.8, 3.7 is not supported in CodeBuild version 3.0. Same changes applied in the 'global.yml' in the adf-bootstrap --> deployment folder.

*Issue #, if available:*

ADF using a deprecated version of CodeBuild (2.0)

*Description of changes:*

Updated the CodeBuild versions to 3.0 and updated the python versions to 3.8 because this build image has the following version: 3.8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
