### PR TITLE
Allow use timeout and environment_variables in codebuild deploy stage

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -33,7 +33,7 @@ class CodeBuild(core.Construct):
                 ADF_DEPLOYMENT_ACCOUNT_ID,
                 target.get('properties', {}).get('role')
             ) if target.get('properties', {}).get('role') else ADF_DEFAULT_BUILD_ROLE
-            _timeout = target.get('properties', {}).get('timeout') or ADF_DEFAULT_BUILD_TIMEOUT
+            _timeout = target.get('properties', {}).get('timeout') or map_params['default_providers']['deploy'].get('properties', {}).get('timeout') or ADF_DEFAULT_BUILD_TIMEOUT
             _env = _codebuild.BuildEnvironment(
                 build_image=CodeBuild.determine_build_image(scope, target, map_params),
                 compute_type=target.get(
@@ -163,6 +163,10 @@ class CodeBuild(core.Construct):
         for _env_var in _build_env_vars.items():
             _output[_env_var[0]] = codebuild.BuildEnvironmentVariable(value=str(_env_var[1]))
         if target:
+            _deploy_env_vars = map_params.get('default_providers', {}).get('deploy', {}).get('properties', {}).get('environment_variables', {})
+            for _env_var in _deploy_env_vars.items():
+                _output[_env_var[0]] = codebuild.BuildEnvironmentVariable(value=str(_env_var[1]))
+
             _target_env_vars = target.get('properties', {}).get('environment_variables', {})
             for _target_env_var in _target_env_vars.items():
                 _output[_target_env_var[0]] = codebuild.BuildEnvironmentVariable(value=_target_env_var[1])


### PR DESCRIPTION
Allow update timeout when being used in the deploy stage within codepipeline, Allow read of environment_variables when using codebuild in the deployment stage in codepipeline

*Issue #, if available:*
#306 

*Description of changes:*
Added the possibility to set timeout and environment_variables when using CodeBuild in the deployment stage of CodePipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
