### PR TITLE
Release v3.1.0

### DIFF
--- a/src/template.yml
+++ b/src/template.yml
@@ -14,7 +14,7 @@ Metadata:
     ReadmeUrl: ../docs/serverless-application-repo.md
     Labels: ['adf', 'aws-deployment-framework', 'multi-account', 'cicd', 'devops']
     HomePageUrl: https://github.com/awslabs/aws-deployment-framework
-    SemanticVersion: 3.0.6
+    SemanticVersion: 3.1.0
     SourceCodeUrl: https://github.com/awslabs/aws-deployment-framework
 Parameters:
   CrossAccountAccessRoleName:
@@ -172,7 +172,7 @@ Resources:
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 3.0.6
+          ADF_VERSION: 3.1.0
           ADF_LOG_LEVEL: INFO
       FunctionName: StackWaiter
       Role: !GetAtt LambdaRole.Arn
@@ -193,7 +193,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 3.0.6
+          ADF_VERSION: 3.1.0
           ADF_LOG_LEVEL: INFO
       FunctionName: DetermineEventFunction
       Role: !GetAtt LambdaRole.Arn
@@ -214,7 +214,7 @@ Resources:
           DEPLOYMENT_ACCOUNT_BUCKET: !GetAtt SharedModulesBucketName.Value
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: 3.0.6
+          ADF_VERSION: 3.1.0
           ADF_LOG_LEVEL: INFO
       FunctionName: CrossAccountExecuteFunction
       Role: !GetAtt LambdaRole.Arn
@@ -233,7 +233,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 3.0.6
+          ADF_VERSION: 3.1.0
           ADF_LOG_LEVEL: INFO
       FunctionName: RoleStackDeploymentFunction
       Role: !GetAtt LambdaRole.Arn
@@ -252,7 +252,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 3.0.6
+          ADF_VERSION: 3.1.0
           ADF_LOG_LEVEL: INFO
       FunctionName: MovedToRootActionFunction
       Role: !GetAtt LambdaRole.Arn
@@ -271,7 +271,7 @@ Resources:
           S3_BUCKET_NAME: !Ref BootstrapTemplatesBucket
           TERMINATION_PROTECTION: false
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ADF_VERSION: 3.0.6
+          ADF_VERSION: 3.1.0
           ADF_LOG_LEVEL: INFO
       FunctionName: UpdateResourcePoliciesFunction
       Role: !GetAtt LambdaRole.Arn
@@ -449,7 +449,7 @@ Resources:
         Image: "aws/codebuild/standard:5.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
-            Value: 3.0.6
+            Value: 3.1.0
           - Name: TERMINATION_PROTECTION
             Value: false
           - Name: PYTHONPATH
@@ -713,7 +713,7 @@ Resources:
     Type: Custom::InitialCommit
     Properties:
       ServiceToken: !GetAtt InitialCommitHandler.Arn
-      Version: 3.0.6
+      Version: 3.1.0
       RepositoryArn: !GetAtt CodeCommitRepository.Arn
       DirectoryName: bootstrap_repository
       ExistingAccountId: !Ref DeploymentAccountId
@@ -934,7 +934,7 @@ Resources:
           Id: adf-codepipeline-trigger-bootstrap
 Outputs:
   ADFVersionNumber:
-    Value: 3.0.6
+    Value: 3.1.0
     Export:
       Name: "ADFVersionNumber"
   LayerArn:


### PR DESCRIPTION
v3.1.0 release notes:

**Features 🏗**

* Adds Enterprise Support to account creation process #233, closes #232:
  * ADF will raise a ticket to add the account to an existing AWS support subscription when an account is created. As a prerequisite, your organization master account must already have enterprise support activated.
* Adds nested deployment map support #266 and #328, closes #265:
  * This enables usage of sub directories within the deployment_maps folder.

**Fixes 🐞**

* Fixes specific role usage to be used in Build and Deploy only #295.
* Corrects removing pipelines anchor in docs #279.
* Fixes CI builds due to isort version mismatch #284.
* Fixes error handling of generate_params intrinsic upload function #277, closes #276.
* Fixes spec_inline attribute of CodeBuild in docs #289.
* Fixes provider spec_inline support of CodeBuild in #293.
* Fixes supported list of intrinsic upload path styles, enables usage of s3-url and s3-key-only #275, closes #299.
* Fixes create deployment account concurrency failure #287, closes #280.
* Fixes approval stage usage, by limiting specific role usage to Build and Deploy steps #295.
* Fixes yarnpkg GPG #313,  closes #325.
* Removes dependency on botocore.vendored.requests #326, closes #324.

**Improvements ✨**

* Improves docs on providers and their properties #274.
* Separates pipeline cleanup from input generation script #288.
* Upgrades Python from v3.7 to v3.8 #313.
* Upgrades CodeBuild image from "aws/codebuild/standard:2.0" to "aws/codebuild/standard:5.0" #313, closes #267, closes #300.
* Upgrades CDK from v1.32 to v1.88 #313, closes #292.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
