### PR TITLE
Fix intrinsic functions for account_region param files

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
@@ -62,9 +62,14 @@ class Parameters:
     def create_parameter_files(self):
         for account, ou in self.account_ous.items():
             for region in self.regions:
+                compare_params = {}
+                compare_params = self._param_updater(
+                    Parameters._parse("{0}/params/{1}".format(self.cwd, "{0}_{1}".format(account, region))),
+                    compare_params,
+                )
                 compare_params = self._param_updater(
                     Parameters._parse("{0}/params/{1}".format(self.cwd, account)),
-                    Parameters._parse("{0}/params/{1}".format(self.cwd, "{0}_{1}".format(account, region)))
+                    compare_params,
                 )
                 if not Parameters._is_account_id(ou):
                     # Compare account_region final to ou_region


### PR DESCRIPTION
**Why?**

As reported by issue #147, the leaf parameter files that specify the parameters/tags for
the account region environment did not work.

**What?**

The account_region parameter was not processed properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
