### PR TITLE
Fix resolve intrinsic function use in first parameter

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
@@ -62,7 +62,7 @@ class Parameters:
     def create_parameter_files(self):
         for account, ou in self.account_ous.items():
             for region in self.regions:
-                compare_params = {}
+                compare_params = {'Parameters': {}, 'Tags': {}}
                 compare_params = self._param_updater(
                     Parameters._parse("{0}/params/{1}".format(self.cwd, "{0}_{1}".format(account, region))),
                     compare_params,


### PR DESCRIPTION
**Why?**

A bug prevented the use of the `resolve:` intrinsic function on the first parameter in in the first parameter file.

**What?**

The parameters were initialized as an empty dictionary. While reading a file that does not exist would return a predefined object instead. The fix uses the later instead of an empty dictionary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
