### PR TITLE
Update Jinja2 to v2.11.3

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/requirements.txt
@@ -1,3 +1,3 @@
-Jinja2~=2.11.2
+Jinja2~=2.11.3
 boto3==1.14.63
 cfn-custom-resource~=1.0.1

--- a/src/lambda_codebase/initial_commit/requirements.txt
+++ b/src/lambda_codebase/initial_commit/requirements.txt
@@ -1,3 +1,3 @@
-Jinja2~=2.11.2
+Jinja2~=2.11.3
 boto3==1.14.63
 cfn-custom-resource~=1.0.1


### PR DESCRIPTION
**Why?**

A vulnerability was reported on v2.11.2 of Jinja2, as reported per
CVE-2020-28493. Since we make use of this dependency, we need to link to
the version that resolved this issue.

Since ADF does not use the `urlize` that is impacted, it is not at risk.
Hence it is not required to release a new version or update your ADF
installation.

**What?**

Updated to 2.11.3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
