### PR TITLE
Reject more characters from a CloudFormation Stack name

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
@@ -21,7 +21,8 @@ CFN_CONFIG = Config(
         max_attempts=10
     )
 )
-CFN_UNACCEPTED_CHARS = re.compile(r"[^-a-zA-Z0-9:/._+]")
+# A stack name can contain only alphanumeric characters (case sensitive) and hyphens.
+CFN_UNACCEPTED_CHARS = re.compile(r"[^-a-zA-Z0-9]")
 
 class StackProperties:
     clean_stack_status = [


### PR DESCRIPTION
We are running into this with an OU that has a `.` in the name.

I used the constraints found on https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
