### PR TITLE
Allow top-level keys starting with x- or x_ in deployment maps

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -615,6 +615,23 @@ pipelines:
     targets: *generic_targets
 ```
 
+If you want to define anchors before you use them as an alias, you can use any top-level key that starts with `x-` or `x_`. For example, if you want to define all account ids in one place, you could write:
+
+```yaml
+x_account_ids:
+  - &codecommit_account: "111111111111"
+  - &some_target_account: "222222222222"
+pipelines:
+  - name: sample-vpc
+    default_providers:
+      source:
+        provider: codecommit
+        properties:
+          account_id: *codecommit_account
+    targets:
+      - *some_target_account
+```
+
 For more advanced yaml usage, see [here](https://learnxinyminutes.com/docs/yaml/)
 
 ### One to many relationships

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
@@ -302,7 +302,10 @@ PIPELINE_SCHEMA = {
     Optional("completion_trigger"): COMPLETION_TRIGGERS_SCHEMA
 }
 TOP_LEVEL_SCHEMA = {
-    "pipelines": [PIPELINE_SCHEMA]
+    "pipelines": [PIPELINE_SCHEMA],
+    # Allow any toplevel key starting with "x-" or "x_".
+    # ADF will ignore these, but users can use them to define anchors in one place.
+    Optional(Regex('^[x][-_].*')): object
 }
 
 class SchemaValidation:


### PR DESCRIPTION
This allows users to define anchors in one place.

ADF already encourages anchors in the documentation, this should make them even more convenient.

I added an example in the user guide to document this feature.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
