### PR TITLE
GitHub default repository name change from master to main

### DIFF
--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -101,7 +101,7 @@ Provider type: `github`.
   > The GitHub repository name.
   > For example, for the ADF repository it would be:
   > `aws-deployment-framework`.
-- *branch* - *(String)* - default: `master`.
+- *branch* - *(String)* - default: `main`.
   > The Branch on the GitHub repository to use to trigger this specific
   > pipeline.
 - *owner* - *(String)* **(required)**

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_github.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_github.py
@@ -55,7 +55,7 @@ class GitHub(core.Construct):
             filters=[
                 _codepipeline.CfnWebhook.WebhookFilterRuleProperty(
                     json_path="$.ref",
-                    match_equals="refs/heads/{0}".format(map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('branch', {}) or 'master')
+                    match_equals="refs/heads/{0}".format(map_params.get('default_providers', {}).get('source', {}).get('properties', {}).get('branch', {}) or 'main')
                 )
             ],
             target_action="source",


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Github changed the name of the default branch name which is created when you create a new repository from **master** to **main**. There are two minor changes with this pull request. Only the default github branch is changed from master to main.
Also this name change is updated in the doc file too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
