### PR TITLE
Adds retry for InvalidTemplateError and GenericAccountConfigureError

### DIFF
--- a/src/template.yml
+++ b/src/template.yml
@@ -670,12 +670,18 @@ Resources:
                     "CreateOrUpdateBaseStack": {
                         "Type": "Task",
                         "Resource": "${CrossAccountExecuteFunction.Arn}",
-                        "Next": "WaitUntilBootstrapComplete",
+                        "Retry": [{
+                            "ErrorEquals": ["InvalidTemplateError", "GenericAccountConfigureError"],
+                            "IntervalSeconds": 1,
+                            "BackoffRate": 1.1,
+                            "MaxAttempts": 45
+                        }],
                         "Catch": [{
                             "ErrorEquals": ["States.ALL"],
                             "Next": "ExecuteDeploymentAccountStateMachine",
                             "ResultPath": "$.error"
                         }],
+                        "Next": "WaitUntilBootstrapComplete",
                         "TimeoutSeconds": 600
                     },
                     "MovedToRootAction": {


### PR DESCRIPTION
*Issue #, if available:*
#383

*Description of changes:*
Adds a retry for `InvalidTemplateError` and `GenericAccountConfigureError` that addresses a race condition that occurs with new accounts are initially joined to an organization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
