### PR TITLE
Fix permission to set Support Subscription upon account creation

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/support.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/support.py
@@ -39,7 +39,7 @@ class Support: # pylint: disable=R0904
 
         """
         try:
-            severity_levels = self.client.get_severity_levels()['severityLevels']
+            severity_levels = self.client.describe_severity_levels()['severityLevels']
             available_support_codes = [level['code'] for level in severity_levels]
 
             # See: https://aws.amazon.com/premiumsupport/plans/ for insights into the interpretation of

--- a/src/template.yml
+++ b/src/template.yml
@@ -365,6 +365,30 @@ Resources:
       ManagedPolicyArns:
         - !Ref "CodeBuildPolicy"
       RoleName: "adf-codebuild-role"
+  BootstrapCodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "codebuild.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - !Ref "CodeBuildPolicy"
+      Policies:
+        - PolicyName: bootstrap-only
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'support:CreateCase'
+                  - 'support:DescribeSeverityLevels'
+                Resource: '*'
   CodeBuildPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -493,7 +517,7 @@ Resources:
             Value: INFO
         Type: LINUX_CONTAINER
       Name: "aws-deployment-framework-base-templates"
-      ServiceRole: !Ref CodeBuildRole
+      ServiceRole: !Ref BootstrapCodeBuildRole
       Source:
         BuildSpec: !Sub |
           version: 0.2


### PR DESCRIPTION
**Why?**

As reported in #379, the IAM permission required to enable Support Subscriptions upon account creation is missing.

**What?**

This change adds another Role that is used by the Bootstrap CodeBuild project to request the right support level upon account creation.

A separate role is required, as the permissions should not be added to the default ADF CodeBuild role that is also used by the pipelines generated by ADF.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
