### PR TITLE
Update docs to state the default branch used as the source

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -65,7 +65,7 @@ config:
     keep-default-scp: enabled # Optional
   scm: # Source Control Management
     auto-create-repositories: enabled # Optional
-    default-scm-branch: master        # Optional
+    default-scm-branch: main          # Optional
 ```
 
 In the above example the properties are categorized into `roles`, `regions`,

--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -55,7 +55,7 @@ Provider type: `codecommit`.
   > action to trigger the pipeline.
 - *repository* - *(String)* defaults to name of the pipeline.
   > The AWS CodeCommit repository name.
-- *branch* - *(String)* default: `master`.
+- *branch* - *(String)* default to configured [adfconfig.yml: config/scm/default-scm-branch](./admin-guide.md#adfconfig).
   > The Branch on the CodeCommit repository to use to trigger this specific
   > pipeline.
 - *poll_for_changes* - *(Boolean)* default: `False`.
@@ -105,7 +105,7 @@ Provider type: `github`.
   > The GitHub repository name.
   > For example, for the ADF repository it would be:
   > `aws-deployment-framework`.
-- *branch* - *(String)* - default: `master`.
+- *branch* - *(String)* default to configured [adfconfig.yml: config/scm/default-scm-branch](./admin-guide.md#adfconfig).
   > The Branch on the GitHub repository to use to trigger this specific
   > pipeline.
 - *owner* - *(String)* **(required)**
@@ -181,7 +181,7 @@ Provider type: `codestar`.
   > The CodeStar repository name.
   > For example, for the ADF repository it would be:
   > `aws-deployment-framework`.
-- *branch* - *(String)* - default: `master`.
+- *branch* - *(String)* default to configured [adfconfig.yml: config/scm/default-scm-branch](./admin-guide.md#adfconfig).
   > The Branch on the third-party repository to use to trigger this specific
   > pipeline.
 - *owner* - *(String)* **(required)**


### PR DESCRIPTION
**Why?**

The docs stated that the default branch would always default to `master`
when the branch is not specified.

However, the branch that is used is determined by looking up the
`config/scm/default-scm-branch` as configured in the `adfconfig.yml` file.

**What?**

Updated the docs accordingly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
