### PR TITLE
Fix global-iam example comment explaining where it is deployed

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-global-iam.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-global-iam.yml
@@ -2,7 +2,7 @@
 # // SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
-Description: ADF CloudFormation Template (Global) for IAM in the Deployment Account
+Description: ADF CloudFormation Template (Global) for IAM in the Target Accounts
 Resources:
   CloudFormationDeploymentPolicy:
     # This is the policy that will be used to deploy CloudFormation resources from


### PR DESCRIPTION
**Why?**

At the moment, the `global-iam.yml` is stating that it is deployed to the deployment account. However, this specific file is deployed to all target accounts instead.

**What?**

Simple, updated the comment.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
