### PR TITLE
Updating get account region function to use opted-in regions too

### DIFF
--- a/src/lambda_codebase/account_processing/get_account_regions.py
+++ b/src/lambda_codebase/account_processing/get_account_regions.py
@@ -35,6 +35,7 @@ def lambda_handler(event, _):
                     "Name": "opt-in-status",
                     "Values": [
                         "opt-in-not-required",
+                        "opted-in"
                     ],
                 }
             ],


### PR DESCRIPTION
*Issue #, if available:* #420 

*Description of changes:*
Updated the get_account_regions function to use the opted-in value in the region filter. 
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_regions 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
