### PR TITLE
fix: breaking cdk command

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -677,7 +677,7 @@ Resources:
                 nodejs: 12
             pre_build:
               commands:
-                - npm install cdk@1.137 -g -y --quiet --no-progress
+                - npm install cdk@2.5.0 -g -y --quiet --no-progress
                 - aws s3 cp s3://$SHARED_MODULES_BUCKET/adf-build/ ./adf-build/ --recursive --quiet
                 - pip install -r adf-build/requirements.txt -q -t ./adf-build
             build:
@@ -1137,7 +1137,7 @@ Resources:
                               "IntervalSeconds": 1,
                               "MaxAttempts": 10
                             }
-                          ]                          
+                          ]
                         }
                       }
                     },


### PR DESCRIPTION
*Issue #, if available:* awslabs/aws-deployment-framework#425

*Description of changes:*

Because CDK depends on colors.js and the newest pulled version contains a loop that print gibberish output the build execution will timeout.
CDK 2.5.0 has a fix in place to solve this, so any previous version may be affected by this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
