### PR TITLE
feat: enable use of codebuild reports

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -280,6 +280,15 @@ Resources:
               - "ecr:PutImage"
             Resource:
               - "*"
+          - Effect: Allow
+            Action:
+              - "codebuild:CreateReportGroup"
+              - "codebuild:CreateReport"
+              - "codebuild:UpdateReport"
+              - "codebuild:BatchPutTestCases"
+              - "codebuild:BatchPutCodeCoverages"
+            Resource:
+              - !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/*
       Roles:
         - !Ref CodeBuildRole
   PipelineProvisionerCodeBuildRole:
@@ -1137,7 +1146,7 @@ Resources:
                               "IntervalSeconds": 1,
                               "MaxAttempts": 10
                             }
-                          ]                          
+                          ]
                         }
                       }
                     },


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Currently, you cannot use the reports functionality in the build phases of your pipelines. This has to do with the fact that the IAM Role that is executing the build has no permissions to do so. This prevents you from collecting reports using the CodeBuild Reports functionality. By adding the needed IAM actions to the CodeBuild Role you will be able to collect your reports for unit tests and coverage reports.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
