### PR TITLE
feat: encrypt sns topic using the ADF CMK KMS Key

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -119,7 +119,7 @@ Resources:
                 aws:PrincipalOrgID: !Ref OrganizationId
           - Action:
               - kms:Decrypt
-              - kms:GenerateDataKey
+              - kms:GenerateDataKey*
             Effect: Allow
             Principal:
               Service:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -117,6 +117,16 @@ Resources:
             Condition:
               StringEquals:
                 aws:PrincipalOrgID: !Ref OrganizationId
+          - Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+            Effect: Allow
+            Principal:
+              Service:
+                - sns.amazonaws.com
+                - events.amazonaws.com
+                - codecommit.amazonaws.com
+            Resource: "*"
   KMSAlias:
     Type: AWS::KMS::Alias
     Properties:
@@ -1137,7 +1147,7 @@ Resources:
                               "IntervalSeconds": 1,
                               "MaxAttempts": 10
                             }
-                          ]                          
+                          ]
                         }
                       }
                     },

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
@@ -35,8 +35,8 @@ class Notifications(core.Construct):
             f'arn:{stack.partition}:lambda:{ADF_DEPLOYMENT_REGION}:'
             f'{ADF_DEPLOYMENT_ACCOUNT_ID}:function:SendSlackNotification'
         )
-        kms_alias = _kms.Alias.from_alias_name(self, 'KMSAlias', f"alias/codepipeline-{ADF_DEPLOYMENT_ACCOUNT_ID}")
-        _topic = _sns.Topic(self, 'PipelineTopic', master_key=kms_alias)
+        kms_alias = _kms.Alias.from_alias_name(self, "KMSAlias", f"alias/codepipeline-{ADF_DEPLOYMENT_ACCOUNT_ID}")
+        _topic = _sns.Topic(self, "PipelineTopic", master_key=kms_alias)
         _statement = _iam.PolicyStatement(
             actions=["sns:Publish"],
             effect=_iam.Effect.ALLOW,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
@@ -9,6 +9,7 @@ from aws_cdk import (
     aws_lambda as _lambda,
     aws_sns as _sns,
     aws_iam as _iam,
+    aws_kms as _kms,
     aws_lambda_event_sources as _event_sources,
     core
 )
@@ -34,7 +35,8 @@ class Notifications(core.Construct):
             f'arn:{stack.partition}:lambda:{ADF_DEPLOYMENT_REGION}:'
             f'{ADF_DEPLOYMENT_ACCOUNT_ID}:function:SendSlackNotification'
         )
-        _topic = _sns.Topic(self, "PipelineTopic")
+        kms_alias = _kms.Alias.from_alias_name(self, 'KMSAlias', f"alias/codepipeline-{ADF_DEPLOYMENT_ACCOUNT_ID}")
+        _topic = _sns.Topic(self, 'PipelineTopic', master_key=kms_alias)
         _statement = _iam.PolicyStatement(
             actions=["sns:Publish"],
             effect=_iam.Effect.ALLOW,


### PR DESCRIPTION
*Issue #, if available:* #422

*Description of changes:*
Because ADF already has a KMS key that is used for encryption. It makes sense to use that key for the SNS notifications as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
