### PR TITLE
feat: allow adf-global-base-deployment parameter overwrites

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global-params.json
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global-params.json
@@ -1,0 +1,8 @@
+{
+    "Parameters": [
+        {
+            "ParameterKey": "StackPrefix",
+            "ParameterValue": ""
+        }
+    ]
+}

--- a/src/template.yml
+++ b/src/template.yml
@@ -521,7 +521,7 @@ Resources:
           - Name: S3_BUCKET
             Value: !Ref BootstrapTemplatesBucket
           - Name: ACCOUNT_BUCKET
-            Value: !GetAtt AccountProcessingApplication.Outputs.Bucket            
+            Value: !GetAtt AccountProcessingApplication.Outputs.Bucket
           - Name: MASTER_ACCOUNT_ID
             Value: !Ref AWS::AccountId
           - Name: DEPLOYMENT_ACCOUNT_BUCKET
@@ -548,6 +548,7 @@ Resources:
               commands:
                 - sam build -t adf-bootstrap/deployment/global.yml
                 - sam package --output-template-file adf-bootstrap/deployment/global.yml --s3-prefix adf-bootstrap/deployment --s3-bucket $DEPLOYMENT_ACCOUNT_BUCKET
+                - aws s3 sync ./adf-bootstrap/deployment/global-params.json s3://$DEPLOYMENT_ACCOUNT_BUCKET/adf-bootstrap/deployment --quiet
                 - aws s3 sync ./adf-build/shared s3://$DEPLOYMENT_ACCOUNT_BUCKET/adf-build --quiet # Shared Modules to be used with AWS CodeBuild
                 - aws s3 sync . s3://$S3_BUCKET --quiet --delete # Base Templates
                 - aws s3 sync ./adf-accounts s3://$ACCOUNT_BUCKET --quiet


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We use a prefix in the CodeCommit repo name. So all our stacks are already prefixed with that prefix.

For this reason we changed the StackPrefix to an empty string in the global.yml for the deployment account. This could not be done without an customization, so we removed the `adf-` prefix in the template.

This pull request adds support for setting parameters in a JSON file. I an not sure about the format of the file itself. Or that this will work in this form. Lets use this pull request to figure out what the best way is.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
