### PR TITLE
fix: object ownership controls

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -137,6 +137,9 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       AccessControl: BucketOwnerFullControl
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       VersioningConfiguration:
         Status: Enabled
       BucketEncryption:


### PR DESCRIPTION
*Issue #, if available:* #447

*Description of changes:*

Older buckets have set the object ownership set to `Object writer`. Newer buckets deviate from this behavior causing permission issues in the deployment pipelines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
