### PR TITLE
feat: allow `TemplateConfiguration` override from the target properties

### DIFF
--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -89,8 +89,8 @@ Provider type: `codecommit`.
   > CodeCommit when an update to the repository took place.
 - *output_artifact_format* - *(String)* default: `CODE_ZIP`
   > The output artifact format. Values can be either CODEBUILD_CLONE_REF or CODE_ZIP. If unspecified, the default is CODE_ZIP.
-  > If you are using CODEBUILD_CLONE_REF, you need to ensure that the IAM role passed in via the *role* property has the CodeCommit:GitPull permission. 
-  > NB: The CODEBUILD_CLONE_REF value can only be used by CodeBuild downstream actions. 
+  > If you are using CODEBUILD_CLONE_REF, you need to ensure that the IAM role passed in via the *role* property has the CodeCommit:GitPull permission.
+  > NB: The CODEBUILD_CLONE_REF value can only be used by CodeBuild downstream actions.
 
 ### GitHub
 
@@ -235,7 +235,7 @@ Provider type: `codebuild`.
   > Along with `repository_arn`, we also support a `tag` key which can be used
   > to define which image should be used (defaults to `latest`).
   > An example of this setup is provided [here](https://github.com/awslabs/aws-deployment-framework/blob/master/docs/user-guide.md#custom-build-images).
-  > 
+  >
   > Image can also take an object that contains a reference to a
   > public docker hub image with a prefix of `docker-hub://`, such as
   > `docker-hub://bitnami/mongodb`. This allows your pipeline
@@ -470,6 +470,8 @@ Provider type: `cloudformation`.
   - *key_name* *(String)*
     > The key name from the stack output that you wish to use as the input
     > in this stage.
+- *configuration_file_path* - *(String)* default: `params/${account-name}_${region}.json`
+  > If you wish to pass a custom path to the configuration file path.
 
 ### Lambda
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -180,6 +180,7 @@ class Action:
             if _path_prefix and not _path_prefix.endswith('/'):
                 _path_prefix = f"{_path_prefix}/"
             _input_artifact = f"{self.map_params['name']}-build"
+            _template_configuration = self.target.get('properties', {}).get('configuration_file_path', f"params/{self.target['name']}_{self.region}.json")
             _props = {
                 "ActionMode": self.action_mode,
                 "StackName": (
@@ -189,9 +190,7 @@ class Action:
                     or f"{ADF_STACK_PREFIX}{self.map_params['name']}"
                 ),
                 "ChangeSetName": f"{ADF_STACK_PREFIX}{self.map_params['name']}",
-                "TemplateConfiguration": (
-                    f"{_input_artifact}::{_path_prefix}params/{self.target['name']}_{self.region}.json"
-                ),
+                "TemplateConfiguration": f"{_input_artifact}::{_path_prefix}{_template_configuration}",
                 "Capabilities": "CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND",
                 "RoleArn": self.role_arn if self.role_arn else (
                     f"arn:{ADF_DEPLOYMENT_PARTITION}:iam::{self.target['id']}:"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
@@ -166,7 +166,8 @@ CLOUDFORMATION_PROPS = {
     Optional("action"): CLOUDFORMATION_ACTIONS,
     Optional("outputs"): str,
     Optional("change_set_approval"): bool,
-    Optional("param_overrides"): [PARAM_OVERRIDE_SCHEMA]
+    Optional("param_overrides"): [PARAM_OVERRIDE_SCHEMA],
+    Optional("configuration_file_path"): str
 }
 # No need for a stage schema since CFN takes all optional props
 DEFAULT_CLOUDFORMATION_DEPLOY = {


### PR DESCRIPTION
*Issue #, if available:* #449

*Description of changes:*
By specifying a `configuration_file_path` property on the target properties you control the configuration used. This could be useful when you do not want to use the `generate_params.py` script. Or if you have multiple stacks with different parameters that you want to deploy from a single pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
