### PR TITLE
Fix #458

### DIFF
--- a/src/account_processing.yml
+++ b/src/account_processing.yml
@@ -177,6 +177,17 @@ Resources:
                 Rules:
                 - Name: suffix
                   Value: yml
+        S3Event2:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: ADFAccountBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                - Name: suffix
+                  Value: yaml
   AccountAliasConfigFunctionRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/src/account_processing.yml
+++ b/src/account_processing.yml
@@ -172,7 +172,11 @@ Resources:
             Bucket:
               Ref: ADFAccountBucket
             Events: s3:ObjectCreated:*
-
+            Filter:
+              S3Key:
+                Rules:
+                - Name: suffix
+                  Value: yml
   AccountAliasConfigFunctionRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/src/account_processing.yml
+++ b/src/account_processing.yml
@@ -166,7 +166,7 @@ Resources:
       FunctionName: AccountFileProcessorFunction
       Role: !GetAtt AccountProcessingLambdaRole.Arn
       Events:
-        S3Event:
+        S3YmlSuffixEvent:
           Type: S3
           Properties:
             Bucket:
@@ -177,7 +177,7 @@ Resources:
                 Rules:
                 - Name: suffix
                   Value: yml
-        S3Event2:
+        S3YamlSuffixEvent:
           Type: S3
           Properties:
             Bucket:

--- a/src/lambda_codebase/account_processing/process_account_files.py
+++ b/src/lambda_codebase/account_processing/process_account_files.py
@@ -10,8 +10,8 @@ invokes the account processing step function per account.
 import json
 import os
 import tempfile
-import yaml
 import logging
+import yaml
 
 from yaml.error import YAMLError
 
@@ -103,7 +103,7 @@ def start_executions(sfn_client, processed_account_list):
 
 def lambda_handler(event, _):
     """Main Lambda Entry point"""
-    LOGGER.debug(json.dumps(s3_object, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--")
+    LOGGER.debug(json.dumps(event, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--")
     sfn_client = boto3.client("stepfunctions")
     s3_resource = boto3.resource("s3")
 

--- a/src/lambda_codebase/account_processing/process_account_files.py
+++ b/src/lambda_codebase/account_processing/process_account_files.py
@@ -11,6 +11,8 @@ import json
 import os
 import tempfile
 import yaml
+import logging
+
 from yaml.error import YAMLError
 
 import boto3
@@ -39,7 +41,7 @@ def get_details_from_event(event: dict):
 
 def get_file_from_s3(s3_object: dict, s3_resource: boto3.resource):
     try:
-        LOGGER.debug(json.dumps(s3_object))
+        LOGGER.debug(json.dumps(s3_object, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--")
         s3_object = s3_resource.Object(**s3_object)
         with tempfile.TemporaryFile(mode='w+b') as file_pointer:
             s3_object.download_fileobj(file_pointer)
@@ -101,7 +103,7 @@ def start_executions(sfn_client, processed_account_list):
 
 def lambda_handler(event, _):
     """Main Lambda Entry point"""
-    LOGGER.debug(json.dumps(event, indent=2))
+    LOGGER.debug(json.dumps(s3_object, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--")
     sfn_client = boto3.client("stepfunctions")
     s3_resource = boto3.resource("s3")
 

--- a/src/lambda_codebase/account_processing/process_account_files.py
+++ b/src/lambda_codebase/account_processing/process_account_files.py
@@ -33,14 +33,15 @@ def get_details_from_event(event: dict):
     object_key = s3_details.get("object", {}).get("key")
     return {
         "bucket_name": bucket_name,
-        "object_key": object_key,
+        "key": object_key,
     }
 
 
 def get_file_from_s3(s3_object: dict, s3_resource: boto3.resource):
     try:
+        LOGGER.debug(json.dumps(s3_object))
         s3_object = s3_resource.Object(**s3_object)
-        with tempfile.TemporaryFile(encoding='utf-8') as file_pointer:
+        with tempfile.TemporaryFile(mode='w+b') as file_pointer:
             s3_object.download_fileobj(file_pointer)
 
             # Move pointer to the start of the file
@@ -100,6 +101,7 @@ def start_executions(sfn_client, processed_account_list):
 
 def lambda_handler(event, _):
     """Main Lambda Entry point"""
+    LOGGER.debug(json.dumps(event, indent=2))
     sfn_client = boto3.client("stepfunctions")
     s3_resource = boto3.resource("s3")
 

--- a/src/lambda_codebase/account_processing/process_account_files.py
+++ b/src/lambda_codebase/account_processing/process_account_files.py
@@ -41,7 +41,10 @@ def get_details_from_event(event: dict):
 
 def get_file_from_s3(s3_object: dict, s3_resource: boto3.resource):
     try:
-        LOGGER.debug(json.dumps(s3_object, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--")
+        LOGGER.debug(
+            "Reading YAML from S3: %s",
+            json.dumps(s3_object, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--"
+        )
         s3_object = s3_resource.Object(**s3_object)
         with tempfile.TemporaryFile(mode='w+b') as file_pointer:
             s3_object.download_fileobj(file_pointer)
@@ -103,7 +106,10 @@ def start_executions(sfn_client, processed_account_list):
 
 def lambda_handler(event, _):
     """Main Lambda Entry point"""
-    LOGGER.debug(json.dumps(event, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--")
+    LOGGER.debug(
+        "Processing event: %s",
+        json.dumps(event, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--"
+    )
     sfn_client = boto3.client("stepfunctions")
     s3_resource = boto3.resource("s3")
 


### PR DESCRIPTION
*Issue #, if available:*
#458 

*Description of changes:*
- Fixed keyword error `key` instead of `object_key`.
- Remove encoding for `TemporaryFile`, which is not supported when streaming binary.
- Added S3Key filter to only invoke the Lambda on `.yml` files (no others are supported). 
- Added debug logging. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
