### PR TITLE
feat: use default description as CodeCommit repository description

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -39,6 +39,7 @@ A basic example of a `deployment_map.yml` would look like the following:
 ```yaml
 pipelines:
   - name: iam
+    description: This description is used as a description for the CodeCommit repository.
     default_providers:
       source:
         provider: codecommit
@@ -120,6 +121,7 @@ definition:
 ```yaml
 pipelines:
   - name: sample-ec2-java-app-codedeploy
+    description: This description is used as a description for the CodeCommit repository.
     default_providers:
       source:
         provider: codecommit
@@ -194,9 +196,9 @@ targets:
     name: another_step
     wave:
       size: 30 # (Optional) This forces the pipeline to split this OU into seperate stages, each stage containing up to X accounts
-    exclude: 
-      - 9999999999 # (Optional) List of accounts to exclude from this target. Currently only supports account Ids 
-    properties: ...    
+    exclude:
+      - 9999999999 # (Optional) List of accounts to exclude from this target. Currently only supports account Ids
+    properties: ...
 ```
 
 CodePipeline has a limit of 50 actions per stage.
@@ -216,8 +218,8 @@ Pipelines also have parameters that don't relate to a specific stage but rather 
 The following are the available pipeline parameters:
 
 - *notification_endpoint* *(String) | (Dict) * defaults to none.
-  > Can either be a valid email address or a string that represents the name of a Slack Channel. 
-  > A more complex configuration can be provided to integrate with Slack via AWS ChatBot. 
+  > Can either be a valid email address or a string that represents the name of a Slack Channel.
+  > A more complex configuration can be provided to integrate with Slack via AWS ChatBot.
   > ```yaml
   > notification_endpoint:
   >   type: chat_bot
@@ -308,7 +310,7 @@ pipelines:
           repository: my_test_repository
 ```
 
-In the above example, the *ami-builder* pipeline is triggered when a new package version is published to the *my_test_repository* repository in CodeArtifact. 
+In the above example, the *ami-builder* pipeline is triggered when a new package version is published to the *my_test_repository* repository in CodeArtifact.
 
 ### Additional Deployment Maps
 
@@ -597,7 +599,7 @@ There are five different styles that one could choose from.
   * In case the bucket is stored in any other region, it will return:
     `https://${bucket}.s3-${region}.amazonaws.com/${key}`
 * `s3-url` style, will return the S3 location using S3 URL with the `s3://` protocol.
-  As an example, this style is required for [CloudFormation AWS::Include transform](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html). 
+  As an example, this style is required for [CloudFormation AWS::Include transform](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html).
   * It returns: `s3://${bucket}/${key}`
 * `s3-uri` style, will return the S3 location using S3 URI without specifying a protocol.
   As an example, this style is required for [CodeBuild project source locations](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-source.html#cfn-codebuild-project-source-location).

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -605,7 +605,7 @@ Resources:
             Sid: "CodeCommit"
             Action:
               - "codecommit:CreateRepository"
-              - "codecommit:UpdateRepository"
+              - "codecommit:UpdateRepositoryDescription"
               - "codecommit:GetRepository"
               - "codecommit:TagResource"
             Resource:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -606,6 +606,7 @@ Resources:
             Action:
               - "codecommit:CreateRepository"
               - "codecommit:UpdateRepositoryDescription"
+              - "codecommit:PutRepositoryTriggers"
               - "codecommit:GetRepository"
               - "codecommit:TagResource"
             Resource:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -241,6 +241,7 @@ Resources:
             Action:
               - "codecommit:CreateRepository"
               - "codecommit:UpdateRepositoryDescription"
+              - "codecommit:PutRepositoryTriggers"
               - "codecommit:GetRepository"
               - "codecommit:TagResource"
             Resource:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -240,7 +240,7 @@ Resources:
             Sid: "CodeCommit"
             Action:
               - "codecommit:CreateRepository"
-              - "codecommit:UpdateRepository"
+              - "codecommit:UpdateRepositoryDescription"
               - "codecommit:GetRepository"
               - "codecommit:TagResource"
             Resource:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/repo.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/repo.py
@@ -81,6 +81,6 @@ class Repo:
         if _repo_exists and not _stack_exists:
             # return when the repository exists without a stack (previously made)
             return
-        else:
-            LOGGER.info(f"Ensuring State for CodeCommit Repository Stack {self.name} on Account {self.account_id}")
-            cloudformation.create_stack()
+
+        LOGGER.info(f"Ensuring State for CodeCommit Repository Stack {self.name} on Account {self.account_id}")
+        cloudformation.create_stack()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/repo.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/repo.py
@@ -75,16 +75,12 @@ class Repo:
             s3_key_path=None,
             account_id=DEPLOYMENT_ACCOUNT_ID,
         )
-        # Update the stack if the repo and the ADF controlled stack exist,
-        # return if the repo exists but no stack (previously made)
+
         _repo_exists = self.repo_exists()
         _stack_exists = cloudformation.get_stack_status()
         if _repo_exists and not _stack_exists:
+            # return when the repository exists without a stack (previously made)
             return
-        if not _repo_exists and not _stack_exists:
-            LOGGER.info(
-                'Ensuring State for CodeCommit Repository Stack %s on Account %s',
-                self.name,
-                self.account_id,
-            )
+        else:
+            LOGGER.info(f"Ensuring State for CodeCommit Repository Stack {self.name} on Account {self.account_id}")
             cloudformation.create_stack()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
@@ -335,6 +335,7 @@ TRIGGERS_SCHEMA = {
 PIPELINE_SCHEMA = {
     "name": And(str, len),
     "default_providers": PROVIDER_SCHEMA,
+    Optional("description"): str,
     Optional("params"): PARAM_SCHEMA,
     Optional("tags"): dict,
     Optional("targets"): [Or(str, int, TARGET_SCHEMA, TARGET_LIST_SCHEMA)],

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/templates/codecommit.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/templates/codecommit.yml
@@ -11,6 +11,7 @@ Resources:
   Repo:
     Type: AWS::CodeCommit::Repository
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       RepositoryName: !Ref RepoName
       RepositoryDescription: !Ref Description


### PR DESCRIPTION
*Issue #, if available:* #468

*Description of changes:*
When a pipeline description is given it was already propagated to the CodeCommit repository. Only the schema did not allow to provide the description, and the IAM policy contained an invalid action and did not allow description updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
