### PR TITLE
Fix: #474 Generated Policy Size Too Long

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -526,7 +526,7 @@ Resources:
               - kms:ReEncrypt*
             Resource: !GetAtt KMSKey.Arn
       Roles:
-        - !Ref CloudFormationRole              
+        - !Ref CloudFormationRole
   CloudFormationDeploymentRole:
     Type: AWS::IAM::Role
     Properties:
@@ -917,7 +917,7 @@ Resources:
             Resource: "*"
       Roles:
         - !Ref CodePipelineRole
-  CodePipelineRolePolicyKMS: 
+  CodePipelineRolePolicyKMS:
     Type: AWS::IAM::Policy
     DependsOn: PipelineBucketPolicy
     Properties:
@@ -936,7 +936,7 @@ Resources:
             Resource: !GetAtt KMSKey.Arn
       Roles:
         - !Ref CodePipelineRole
-  CodePipelineRolePolicySTS: 
+  CodePipelineRolePolicySTS:
     Type: AWS::IAM::Policy
     DependsOn: PipelineBucketPolicy
     Properties:
@@ -977,7 +977,7 @@ Resources:
               - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}
               - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}/*
       Roles:
-        - !Ref CodePipelineRole                        
+        - !Ref CodePipelineRole
   PipelineBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -506,6 +506,15 @@ Resources:
               - s3:List*
               - s3:Put*
             Resource: "*"
+      Roles:
+        - !Ref CloudFormationRole
+  CloudFormationPolicyKMS:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "adf-cloudformation-role-policy-kms"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
           - Effect: Allow
             Sid: "KMS"
             Action:
@@ -516,7 +525,7 @@ Resources:
               - kms:ReEncrypt*
             Resource: !GetAtt KMSKey.Arn
       Roles:
-        - !Ref CloudFormationRole
+        - !Ref CloudFormationRole              
   CloudFormationDeploymentRole:
     Type: AWS::IAM::Role
     Properties:
@@ -874,37 +883,6 @@ Resources:
             Resource:
               - "*"
           - Effect: Allow
-            Sid: "KMS"
-            Action:
-              - kms:Decrypt
-              - kms:DescribeKey
-              - kms:Encrypt
-              - kms:GenerateDataKey*
-              - kms:ReEncrypt*
-            Resource: !GetAtt KMSKey.Arn
-          - Effect: Allow
-            Sid: "AssumeRole"
-            Action:
-              - sts:AssumeRole
-            Resource:
-              - !Sub arn:${AWS::Partition}:iam::*:role/adf-cloudformation-role
-              - !Sub arn:${AWS::Partition}:iam::*:role/adf-codecommit-role
-            Condition:
-              StringEquals:
-                aws:PrincipalOrgID: !Ref OrganizationId
-          - Effect: Allow
-            Sid: "S3"
-            Action:
-              - s3:Get*
-              - s3:List*
-              - s3:Put*
-              - s3:ReplicateDelete
-              - s3:ReplicateObject
-              - s3:ReplicateTags
-            Resource:
-              - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}
-              - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}/*
-          - Effect: Allow
             Sid: "CodeCommit"
             Action:
               - codecommit:GetBranch
@@ -938,6 +916,67 @@ Resources:
             Resource: "*"
       Roles:
         - !Ref CodePipelineRole
+  CodePipelineRolePolicyKMS: 
+    Type: AWS::IAM::Policy
+    DependsOn: PipelineBucketPolicy
+    Properties:
+      PolicyName: "adf-codepipeline-role-policy-kms"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Sid: "KMS"
+            Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource: !GetAtt KMSKey.Arn
+      Roles:
+        - !Ref CodePipelineRole
+  CodePipelineRolePolicySTS: 
+    Type: AWS::IAM::Policy
+    DependsOn: PipelineBucketPolicy
+    Properties:
+      PolicyName: "adf-codepipeline-role-policy-sts"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Sid: "AssumeRole"
+            Action:
+              - sts:AssumeRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::*:role/adf-cloudformation-role
+              - !Sub arn:${AWS::Partition}:iam::*:role/adf-codecommit-role
+            Condition:
+              StringEquals:
+                aws:PrincipalOrgID: !Ref OrganizationId
+      Roles:
+        - !Ref CodePipelineRole  
+  CodePipelineRolePolicyS3: 
+    Type: AWS::IAM::Policy
+    DependsOn: PipelineBucketPolicy
+    Properties:
+      PolicyName: "adf-codepipeline-role-policy-s3"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Sid: "S3"
+            Action:
+              - s3:Get*
+              - s3:List*
+              - s3:Put*
+              - s3:ReplicateDelete
+              - s3:ReplicateObject
+              - s3:ReplicateTags
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}/*
+      Roles:
+        - !Ref CodePipelineRole                        
   PipelineBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
@@ -20,47 +20,52 @@ from iam import IAM
 from partition import get_partition
 
 
-KEY_ID = os.environ['KMS_KEY_ID']
-S3_BUCKET = os.environ['S3_BUCKET_NAME']
-REGION_DEFAULT = os.getenv('AWS_REGION')
+KEY_ID = os.environ["KMS_KEY_ID"]
+S3_BUCKET = os.environ["S3_BUCKET_NAME"]
+REGION_DEFAULT = os.getenv("AWS_REGION")
 LOGGER = configure_logger(__name__)
 
 
 def update_iam(role, s3_buckets, kms_key_arns, role_policies):
     iam = IAM(role.client("iam"))
-    iam.update_iam_roles(
-        s3_buckets,
-        kms_key_arns,
-        role_policies
-    )
+    iam.update_iam_roles(s3_buckets, kms_key_arns, role_policies)
 
 
 def lambda_handler(event, _):
+    # Target Role Policies are updated in target accounts
     target_role_policies = {
-        'adf-cloudformation-deployment-role': 'adf-cloudformation-deployment-role-policy-kms',
-        'adf-cloudformation-role': 'adf-cloudformation-role-policy'
+        "adf-cloudformation-deployment-role": "adf-cloudformation-deployment-role-policy-kms",
+        "adf-cloudformation-role": [
+            "adf-cloudformation-role-policy",
+            "adf-cloudformation-role-policy-s3",
+            "adf-cloudformation-role-policy-kms",
+        ],
     }
 
+    # Role Policies are updated in the deployment account.
     role_policies = {
-        'adf-codepipeline-role': 'adf-codepipeline-role-policy',
-        'adf-cloudformation-deployment-role': 'adf-cloudformation-deployment-role-policy',
-        'adf-cloudformation-role': 'adf-cloudformation-role-policy'
+        "adf-codepipeline-role": [
+            "adf-codepipeline-role-policy",
+            "adf-codepipeline-role-policy-s3",
+            "adf-codepipeline-role-policy-kms",
+        ],
+        "adf-cloudformation-deployment-role": "adf-cloudformation-deployment-role-policy",
+        "adf-cloudformation-role": "adf-cloudformation-role-policy",
     }
 
     sts = STS()
     partition = get_partition(REGION_DEFAULT)
 
     parameter_store = ParameterStore(
-        region=event.get('deployment_account_region'),
-        role=boto3
+        region=event.get("deployment_account_region"), role=boto3
     )
     account_id = event.get("account_id")
     kms_key_arns = []
     s3_buckets = []
-    for region in list(set([event.get('deployment_account_region')] + event.get("regions", []))):
-        kms_key_arn = parameter_store.fetch_parameter(
-            f"/cross_region/kms_arn/{region}"
-        )
+    for region in list(
+        set([event.get("deployment_account_region")] + event.get("regions", []))
+    ):
+        kms_key_arn = parameter_store.fetch_parameter(f"/cross_region/kms_arn/{region}")
         kms_key_arns.append(kms_key_arn)
         s3_bucket = parameter_store.fetch_parameter(
             f"/cross_region/s3_regional_bucket/{region}"
@@ -68,13 +73,18 @@ def lambda_handler(event, _):
         s3_buckets.append(s3_bucket)
         try:
             role = sts.assume_cross_account_role(
-                f'arn:{partition}:iam::{account_id}:role/adf-cloudformation-deployment-role',
-                'base_cfn_role'
+                f"arn:{partition}:iam::{account_id}:role/adf-cloudformation-deployment-role",
+                "base_cfn_role",
             )
             LOGGER.debug("Role has been assumed for %s", account_id)
             update_iam(role, s3_bucket, kms_key_arn, target_role_policies)
         except ClientError as err:
-            LOGGER.debug("%s could not be assumed (%s), continuing", account_id, err, exc_info=True)
+            LOGGER.debug(
+                "%s could not be assumed (%s), continuing",
+                account_id,
+                err,
+                exc_info=True,
+            )
             continue
 
     update_iam(boto3, s3_buckets, kms_key_arns, role_policies)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -134,7 +134,7 @@ Resources:
               - !Sub arn:${AWS::Partition}:s3:::${DeploymentAccountBucketName}
               - !Sub arn:${AWS::Partition}:s3:::${DeploymentAccountBucketName}/*
       Roles:
-        - !Ref CloudFormationRole                
+        - !Ref CloudFormationRole
   CloudFormationRole:
     Type: AWS::IAM::Role
     Properties:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -97,15 +97,15 @@ Resources:
               - servicecatalog:ListProvisioningArtifacts
               - servicecatalog:UpdateProduct
             Resource: "*"
-          - Effect: Allow
-            Sid: "S3"
-            Action:
-              - s3:Get*
-              - s3:List*
-              - s3:Put*
-            Resource:
-              - !Sub arn:${AWS::Partition}:s3:::${DeploymentAccountBucketName}
-              - !Sub arn:${AWS::Partition}:s3:::${DeploymentAccountBucketName}/*
+      Roles:
+        - !Ref CloudFormationRole
+  CloudFormationKMSPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "adf-cloudformation-role-policy-kms"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
           - Effect: Allow
             Sid: "KMS"
             Action:
@@ -117,6 +117,24 @@ Resources:
             Resource: !Ref KMSArn
       Roles:
         - !Ref CloudFormationRole
+  CloudFormationPolicyS3:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "adf-cloudformation-role-policy-s3"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Sid: "S3"
+            Action:
+              - s3:Get*
+              - s3:List*
+              - s3:Put*
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${DeploymentAccountBucketName}
+              - !Sub arn:${AWS::Partition}:s3:::${DeploymentAccountBucketName}/*
+      Roles:
+        - !Ref CloudFormationRole                
   CloudFormationRole:
     Type: AWS::IAM::Role
     Properties:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_inputs.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_inputs.py
@@ -114,7 +114,7 @@ def worker_thread(p, organizations, auto_create_repositories, deployment_map, pa
                 pipeline_target = Target(path_or_tag, target_structure, organizations, step, regions)
                 pipeline_target.fetch_accounts_for_target()
 
-            pipeline.template_dictionary["targets"].append(target.target_structure.generate_waves())
+            pipeline.template_dictionary["targets"].append(target_structure.generate_waves())
 
     if DEPLOYMENT_ACCOUNT_REGION not in regions:
         pipeline.stage_regions.append(DEPLOYMENT_ACCOUNT_REGION)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/iam.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/iam.py
@@ -34,14 +34,17 @@ class IAM:
             s3_buckets = [s3_buckets]
         if not isinstance(kms_key_arns, list):
             kms_key_arns = [kms_key_arns]
+        for role_name, policy_names in role_policies.items():
+            if not isinstance(policy_names, list):
+                policy_names = [policy_names]
+            for policy_name in policy_names:
+                self._fetch_policy_document(role_name, policy_name)
+                for s3_bucket in s3_buckets:
+                    self._update_iam_policy_bucket(s3_bucket)
+                for kms_key_arn in kms_key_arns:
+                    self._update_iam_cfn(kms_key_arn)
+                self._put_role_policy()
 
-        for role_name, policy_name in role_policies.items():
-            self._fetch_policy_document(role_name, policy_name)
-            for s3_bucket in s3_buckets:
-                self._update_iam_policy_bucket(s3_bucket)
-            for kms_key_arn in kms_key_arns:
-                self._update_iam_cfn(kms_key_arn)
-            self._put_role_policy()
 
     def _get_policy(self):
         return self.policy


### PR DESCRIPTION
*Issue #, if available:* #474

*Description of changes:*
[Broken down in the gist here](https://gist.github.com/StewartW/aff84e6f86811b128ca03b4d2014f559)

Separates out the policies for cloudformation-role in the target accounts and codepipeline role in the deployment account. 
Now have policies for S3, KMS and a base policy that catches everything else. 

Updated the shared IAM library to take in a list of policies to update now, also accepts single string and will treat it accordingly. 
Existing update policy code also provides backward compatibility because it checks if the statement with the SID exists in the policy and if it can't find it - it does nothing. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
