### PR TITLE
Chore: Add editorconfig to repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,57 @@
+root = true
+
+[*]
+# Includes all - file types included in the ADF repo:
+# - .ini
+# - .java
+# - .js
+# - .json
+# - .md
+# - .py
+# - .rb
+# - .sh
+# - .ts
+# - .txt
+# - .xml
+# - .yml
+# - .yml.j2
+# - Makefile
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 80
+
+[*.py]
+indent_size = 4
+
+[*.{json,xml,html,ejs}]
+indent_size = 4
+
+[*.{json,yml,yml.j2}]
+max_line_length = 140
+
+[{package.json,package-lock.json}]
+indent_size = 2
+
+[*.java]
+indent_size = 4
+
+[*.md]
+indent_size = unset
+
+[*.txt]
+indent_size = 4
+
+[*.ini]
+indent_size = 4
+
+[tox.ini]
+max_line_length = 120
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+tab_width = 4

--- a/.yamllint
+++ b/.yamllint
@@ -36,5 +36,5 @@ rules:
   octal-values: enable
   quoted-strings: disable
   trailing-spaces: enable
-  truthy: 
+  truthy:
     level: error

--- a/src/template.yml
+++ b/src/template.yml
@@ -7,7 +7,9 @@ Description: ADF CloudFormation Initial Base Stack for the Master Account in the
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: aws-deployment-framework
-    Description: The AWS Deployment Framework (ADF) is an extensive and flexible framework to manage and deploy resources across multiple AWS accounts and regions based on AWS Organizations.
+    Description: >-
+      The AWS Deployment Framework (ADF) is an extensive and flexible framework to manage and deploy resources across multiple
+      AWS accounts and regions based on AWS Organizations.
     Author: AWS ADF Builders Team
     SpdxLicenseId: Apache-2.0
     LicenseUrl: ../LICENSE.txt
@@ -44,7 +46,8 @@ Parameters:
   DeploymentAccountId:
     Type: String
     Default: ""
-    Description: "Example -> 123456789012 (Only required if you have an existing AWS Account that you wish to use as the deployment account.)"
+    Description: >-
+      Example -> 123456789012 (Only required if you have an existing AWS Account that you wish to use as the deployment account.)
   DeploymentAccountMainRegion:
     Type: String
     Default: ""


### PR DESCRIPTION
**Why?**

With editorconfig, editors that are used across our collaborators will be able to use the same indentation / line lengths and other configuration settings.

You can find more information on how to install the editorconfig add-on for your editor on: https://editorconfig.org/

**What?**

* Adding specification as currently applied in the files in our repository.
* Minor updates to match line length and trailing space config.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
