### PR TITLE
Fix: Wave deployment input data

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_inputs.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_inputs.py
@@ -59,7 +59,7 @@ def store_regional_parameter_config(pipeline, parameter_store):
     """
     if pipeline.top_level_regions:
         parameter_store.put_parameter(
-            f"/deployment/{pipeline.nam}/regions",
+            f"/deployment/{pipeline.name}/regions",
             str(list(set(pipeline.top_level_regions)))
         )
         return
@@ -115,7 +115,15 @@ def worker_thread(p, organizations, auto_create_repositories, deployment_map, pa
                 pipeline_target = Target(path_or_tag, target_structure, organizations, step, regions)
                 pipeline_target.fetch_accounts_for_target()
 
-            pipeline.template_dictionary["targets"].append(target_structure.generate_waves())
+        # Targets should be a list of lists.
+
+        # Note: This is a big shift away from how ADF handles targets natively.
+        # Previously this would be a list of [accountId(s)] it now returns a list of [[account_ids], [account_ids]]
+        # for the sake of consistency we should probably think of a target consisting of multiple "waves". So if you see
+        # any reference to a wave going forward it will be the individual batch of account ids
+        pipeline.template_dictionary["targets"].append(
+            list(target_structure.generate_waves()),
+        )
 
     if DEPLOYMENT_ACCOUNT_REGION not in regions:
         pipeline.stage_regions.append(DEPLOYMENT_ACCOUNT_REGION)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/deployment_map.py
@@ -35,13 +35,18 @@ class DeploymentMap:
 
     def update_deployment_parameters(self, pipeline):
         for target in pipeline.template_dictionary['targets']:
-            for _t in target:
-                if _t.get('target'): # Allows target to be interchangeable with path
-                    _t['path'] = _t.pop('target')
-                if _t.get('path'):
-                    self.account_ou_names.update(
-                        {item['name']: item['path'] for item in target if item['name'] != 'approval'}
-                    )
+            for wave in target:
+                for wave_target in wave:
+                    if wave_target.get('target'): # Allows target to be interchangeable with path
+                        wave_target['path'] = wave_target.pop('target')
+                    if wave_target.get('path'):
+                        self.account_ou_names.update(
+                            {
+                                item['name']: item['path']
+                                for item in wave
+                                if item['name'] != 'approval'
+                            }
+                        )
         with open(f'{pipeline.name}.json', mode='w', encoding='utf-8') as outfile:
             json.dump(self.account_ou_names, outfile)
         self.s3.put_object(

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/target.py
@@ -48,13 +48,10 @@ class TargetStructure:
         return target
 
     def generate_waves(self):
-        waves = []
         wave_size = self.wave.get('size', 50)
         length = len(self.account_list)
         for index in range(0, length, wave_size):
             yield self.account_list[index:min(index + wave_size, length)]
-            waves.append(self.account_list[index:min(index + wave_size, length)])
-        return waves
 
 
 class Target:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_deployment_map.py
@@ -43,13 +43,84 @@ def test_update_deployment_parameters(cls):
         }
     })
     pipeline.template_dictionary = {
-        "targets": [[
-            {
-                "name": "some_pipeline",
-                "path": "/fake/path",
-            }
-        ]]
+        "targets": [
+            # Array holding all waves
+            [
+                # First wave of targets
+                [
+                    # First batch within the first wave
+                    {
+                        # First target in first wave
+                        "name": "some_pipeline",
+                        "path": "/fake/path",
+                    }
+                ],
+            ],
+        ],
     }
 
     cls.update_deployment_parameters(pipeline)
     assert cls.account_ou_names['some_pipeline'] == '/fake/path'
+
+
+def test_update_deployment_parameters_waves(cls):
+    cls.s3 = Mock()
+    cls.s3.put_object.return_value = None
+
+    pipeline = Pipeline({
+        "name": "pipeline",
+        "params": {"key": "value"},
+        "targets": [],
+        "default_providers": {
+            "source": {
+                "name": "codecommit",
+                "properties" : {
+                    "account_id": 111111111111,
+                }
+            }
+        }
+    })
+    pipeline.template_dictionary = {
+        "targets": [  # Array holding all waves
+            [  # First wave of targets
+                [  # First batch within the first wave
+                    {  # First target in first wave
+                        "name": "first",
+                        "path": "/first/path",
+                    },
+                    {  # Second target in first wave
+                        "name": "second",
+                        "path": "/second/path",
+                    }
+                ],
+                [  # Second batch within the first wave
+                    {
+                        # Third target in first wave
+                        "name": "third",
+                        "path": "/third/path",
+                    },
+                ],
+            ],
+            [  # Second wave of targets
+                [  # First batch within the second wave
+                    {
+                        # Third target in first wave
+                        "name": "approval",
+                    },
+                ],
+            ],
+            [  # Third wave of targets
+                [  # First batch within the third wave
+                    {
+                        # Third target in first wave
+                        "name": "fourth",
+                        "path": "/fourth/path",
+                    },
+                ],
+            ]
+        ],
+    }
+
+    cls.update_deployment_parameters(pipeline)
+    for target in ['first', 'second', 'third', 'fourth']:
+        assert cls.account_ou_names[target] == f'/{target}/path'


### PR DESCRIPTION
**Why?**

When generating the waves, it does so in the input generation.
When it was shared to the actual deployment of the CodePipeline stack, the data types did not match.

**What?**

This pull request adds comments and restructures the wave generation at the input side to make it work.

This PR also fixes a typo and optimizes the generation of waves by using `yield` only.

Co-authored by: StewartW

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
