### PR TITLE
Fix: Lookup correct Organization API Region

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -15,9 +15,10 @@ from botocore.exceptions import ClientError
 from errors import RootOUIDError
 from logger import configure_logger
 from paginator import paginator
+from partition import get_organization_api_region
 
 LOGGER = configure_logger(__name__)
-REGION_DEFAULT = os.getenv('AWS_REGION')
+AWS_REGION = os.getenv('AWS_REGION')
 
 
 class Organizations:  # pylint: disable=R0904
@@ -32,9 +33,10 @@ class Organizations:  # pylint: disable=R0904
             'organizations',
             config=Organizations._config
         )
+        organization_api_region = get_organization_api_region(AWS_REGION)
         self.tags_client = role.client(
             'resourcegroupstaggingapi',
-            region_name=REGION_DEFAULT,
+            region_name=organization_api_region,
             config=Organizations._config
         )
         self.account_id = account_id

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-
 """Partition.
 
 A partition is a group of AWS Regions. This module provides a helper function
@@ -9,6 +8,14 @@ on partitions, see:
 https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
 """
 
+from boto3.session import Session
+
+COMPATIBLE_PARTITIONS = ['aws-us-gov', 'aws']
+
+
+class IncompatiblePartitionError(Exception):
+    pass
+
 
 def get_partition(region_name: str) -> str:
     """Given the region, this function will return the appropriate partition.
@@ -16,11 +23,14 @@ def get_partition(region_name: str) -> str:
     :param region_name: The name of the region (us-east-1, us-gov-west-1)
     :return: Returns the partition name as a string.
     """
+    partition = Session().get_partition_for_region(region_name)
+    if partition not in COMPATIBLE_PARTITIONS:
+        raise IncompatiblePartitionError(
+            f'The {partition} partition is not supported by this version of '
+            'ADF yet.'
+        )
 
-    if region_name.startswith('us-gov'):
-        return 'aws-us-gov'
-
-    return 'aws'
+    return partition
 
 
 def get_organization_api_region(region_name: str) -> str:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
@@ -21,3 +21,17 @@ def get_partition(region_name: str) -> str:
         return 'aws-us-gov'
 
     return 'aws'
+
+
+def get_organization_api_region(region_name: str) -> str:
+    """
+    Given the current region, it will determine the partition and use
+    that to return the Organizations API region (us-east-1 or us-gov-west-1)
+
+    :param region_name: The name of the region (eu-west-1, us-gov-east-1)
+    :return: Returns the AWS Organizations API region to use as a string.
+    """
+    if get_partition(region_name) == 'aws-us-gov':
+        return 'us-gov-west-1'
+
+    return 'us-east-1'

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_partition.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT-0
 
 import pytest
 
-from partition import get_partition
+from partition import get_partition, IncompatiblePartitionError
 
 _us_commercial_regions = [
     'us-east-1',
@@ -19,6 +19,11 @@ _govcloud_regions = [
     'us-gov-east-1'
 ]
 
+_incompatible_regions = [
+    'cn-north-1',
+    'cn-northwest-1'
+]
+
 
 @pytest.mark.parametrize('region', _govcloud_regions)
 def test_partition_govcloud_regions(region):
@@ -28,3 +33,12 @@ def test_partition_govcloud_regions(region):
 @pytest.mark.parametrize('region', _us_commercial_regions)
 def test_partition_us_commercial_regions(region):
     assert get_partition(region) == 'aws'
+
+
+@pytest.mark.parametrize('region', _incompatible_regions)
+def test_partition_incompatible_regions(region):
+    with pytest.raises(IncompatiblePartitionError) as excinfo:
+        get_partition(region)
+
+    error_message = str(excinfo.value)
+    assert error_message.find("partition is not supported") >= 0


### PR DESCRIPTION
**Why?**

At the moment, the organization API calls are made to the region where the `organizations.py` code is running.

However, which region to use depends on the partition that is in use.
For the US gov-cloud regions, it should use the `us-gov-west-1` region.
While the `aws` partition regions should use `us-east-1`.

**What?**

The code will determine the partition and return the correct region to use for the Organizations API.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
