### PR TITLE
Fix yamllint detected error

### DIFF
--- a/samples/sample-rdk-rules/buildspec.yml
+++ b/samples/sample-rdk-rules/buildspec.yml
@@ -8,7 +8,7 @@ phases:
       - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet
       - pip install -r adf-build/requirements.txt -q
       - python adf-build/generate_params.py
-  
+
   build:
     commands:
       - pip install rdk


### PR DESCRIPTION
Fix issue detected by yamllint during MegaLinter process

There are also cfn-lint issues, but as I'm no Cloudformation expert, I don't know how to solve them ^^

```shell
E0002 Unknown exception while processing rule E2001: local variable 'reqname' referenced before assignment
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:1:1

E1001 Missing top level template section Resources
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:1:1

E1001 Top level template section Version is not valid
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:2:3

W2001 Parameter RuleName not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:4:5

W2001 Parameter Description not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:5:5

W2001 Parameter SourceRuntime not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:6:5

W2001 Parameter CodeKey not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:7:5

W2001 Parameter InputParameters not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:8:5

W2001 Parameter OptionalParameters not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:9:5

W2001 Parameter SourceEvents not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:10:5

W2001 Parameter SourcePeriodic not used.
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:11:5

E1001 Top level template section Tags is not valid
/github/workspace/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json:13:3

E1001 Missing top level template section Resources
/github/workspace/samples/sample-rdk-rules/templates/lambda-function.json:1:1

E1001 Top level template section Type is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-function.json:3:3

E1001 Top level template section DependsOn is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-function.json:4:3

E1001 Top level template section Properties is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-function.json:5:3

E1012 Ref SourceBucket not found as a resource or parameter
/github/workspace/samples/sample-rdk-rules/templates/lambda-function.json:8:7

E1010 Invalid GetAtt RuleNameStrippedLambdaRole.Arn for resource Role
/github/workspace/samples/sample-rdk-rules/templates/lambda-function.json:17:7

E1001 Missing top level template section Resources
/github/workspace/samples/sample-rdk-rules/templates/lambda-permission.json:1:1

E1001 Top level template section Type is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-permission.json:3:3

E1001 Top level template section DependsOn is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-permission.json:4:3

E1001 Top level template section Properties is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-permission.json:5:3

E1010 Invalid GetAtt RuleNameStrippedLambdaFunction.Arn for resource FunctionName
/github/workspace/samples/sample-rdk-rules/templates/lambda-permission.json:7:7

E1001 Missing top level template section Resources
/github/workspace/samples/sample-rdk-rules/templates/lambda-role.json:1:1

E1001 Top level template section Type is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-role.json:3:3

E1001 Top level template section Properties is not valid
/github/workspace/samples/sample-rdk-rules/templates/lambda-role.json:4:3

E1019 Parameter SourceBucket for Fn::Sub not found at Properties/Policies/0/PolicyDocument/Statement/0/Resource/Fn::Sub
/github/workspace/samples/sample-rdk-rules/templates/lambda-role.json:32:17

E1019 Parameter SourceBucketFolder for Fn::Sub not found at Properties/Policies/0/PolicyDocument/Statement/0/Resource/Fn::Sub
/github/workspace/samples/sample-rdk-rules/templates/lambda-role.json:32:17

W1020 Fn::Sub isn't needed because there are no variables at Properties/ManagedPolicyArns/0/Fn::Sub
/github/workspace/samples/sample-rdk-rules/templates/lambda-role.json:78:9

```