### PR TITLE
fixing linter issues introduced by rdk examples

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -30,3 +30,5 @@ FILEIO_REPORTER: false
 JSON_PRETTIER_PRE_COMMANDS:
   - command: npm install prettier-plugin-multiline-arrays@1.1.0
     cwd: "workspace"
+
+CLOUDFORMATION_CFN_LINT_FILE_EXTENSIONS: [".yml", ".yaml"]

--- a/samples/sample-rdk-rules/buildspec.yml
+++ b/samples/sample-rdk-rules/buildspec.yml
@@ -8,7 +8,7 @@ phases:
       - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet
       - pip install -r adf-build/requirements.txt -q
       - python adf-build/generate_params.py
-  
+
   build:
     commands:
       - pip install rdk

--- a/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json
+++ b/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINIATION_PROTECTION_ADF/parameters.json
@@ -1,14 +1,14 @@
 {
-  "Version": "1.0",
-  "Parameters": {
-    "RuleName": "EC2_CHECKS_TERMINIATION_PROTECTION_ADF",
-    "Description": "EC2_CHECKS_TERMINIATION_PROTECTION_ADF",
-    "SourceRuntime": "python3.8",
-    "CodeKey": "EC2_CHECKS_TERMINIATION_PROTECTION_ADFeu-central-1.zip",
-    "InputParameters": "{}",
-    "OptionalParameters": "{}",
-    "SourceEvents": "AWS::EC2::Instance",
-    "SourcePeriodic": "One_Hour"
-  },
-  "Tags": "[]"
+    "Version": "1.0",
+    "Parameters": {
+        "RuleName": "EC2_CHECKS_TERMINIATION_PROTECTION_ADF",
+        "Description": "EC2_CHECKS_TERMINIATION_PROTECTION_ADF",
+        "SourceRuntime": "python3.8",
+        "CodeKey": "EC2_CHECKS_TERMINIATION_PROTECTION_ADFeu-central-1.zip",
+        "InputParameters": "{}",
+        "OptionalParameters": "{}",
+        "SourceEvents": "AWS::EC2::Instance",
+        "SourcePeriodic": "One_Hour"
+    },
+    "Tags": "[]"
 }

--- a/samples/sample-rdk-rules/templates/lambda-function.json
+++ b/samples/sample-rdk-rules/templates/lambda-function.json
@@ -1,26 +1,25 @@
-
 {
-  "Type": "AWS::Lambda::Function",
-  "DependsOn": "RuleNameStrippedLambdaRole",
-  "Properties": {
-    "FunctionName": "RDK-Rule-Function-RuleNameStripped",
-    "Code": {
-      "S3Bucket": {
-        "Ref": "SourceBucket"
-      },
-      "S3Key": "RuleName/RuleName.zip"
-    },
-    "Description": "Function for AWS Config Rule RuleName",
-    "Handler": "RuleName.lambda_handler",
-    "MemorySize": "256",
-    "Role": {
-      "Fn::GetAtt": [
-        "RuleNameStrippedLambdaRole",
-        "Arn"
-      ]
-    },
-    "Runtime": "RuleRuntime",
-    "Timeout": "60",
-    "Tags": []
-  }
+    "Type": "AWS::Lambda::Function",
+    "DependsOn": "RuleNameStrippedLambdaRole",
+    "Properties": {
+        "FunctionName": "RDK-Rule-Function-RuleNameStripped",
+        "Code": {
+            "S3Bucket": {
+                "Ref": "SourceBucket"
+            },
+            "S3Key": "RuleName/RuleName.zip"
+        },
+        "Description": "Function for AWS Config Rule RuleName",
+        "Handler": "RuleName.lambda_handler",
+        "MemorySize": "256",
+        "Role": {
+            "Fn::GetAtt": [
+                "RuleNameStrippedLambdaRole",
+                "Arn"
+            ]
+        },
+        "Runtime": "RuleRuntime",
+        "Timeout": "60",
+        "Tags": []
+    }
 }

--- a/samples/sample-rdk-rules/templates/lambda-permission.json
+++ b/samples/sample-rdk-rules/templates/lambda-permission.json
@@ -1,15 +1,14 @@
-
 {
-  "Type": "AWS::Lambda::Permission",
-  "DependsOn": "RuleNameStrippedLambdaFunction",
-  "Properties": {
-    "FunctionName": {
-      "Fn::GetAtt": [
-        "RuleNameStrippedLambdaFunction",
-        "Arn"
-      ]
-    },
-    "Action": "lambda:InvokeFunction",
-    "Principal": "config.amazonaws.com"
-  }
+    "Type": "AWS::Lambda::Permission",
+    "DependsOn": "RuleNameStrippedLambdaFunction",
+    "Properties": {
+        "FunctionName": {
+            "Fn::GetAtt": [
+                "RuleNameStrippedLambdaFunction",
+                "Arn"
+            ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "config.amazonaws.com"
+    }
 }

--- a/samples/sample-rdk-rules/templates/lambda-role.json
+++ b/samples/sample-rdk-rules/templates/lambda-role.json
@@ -1,82 +1,75 @@
-
 {
-  "Type": "AWS::IAM::Role",
-  "Properties": {
-    "Path": "/rdk/",
-    "AssumeRolePolicyDocument": {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Sid": "AllowLambdaAssumeRole",
-          "Effect": "Allow",
-          "Principal": {
-            "Service": "lambda.amazonaws.com"
-          },
-          "Action": "sts:AssumeRole"
-        }
-      ]
-    },
-    "Policies": [
-      {
-        "PolicyName": "ConfigRulePolicy",
-        "PolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
+    "Type": "AWS::IAM::Role",
+    "Properties": {
+        "Path": "/rdk/",
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "AllowLambdaAssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                    },
+                    "Action": "sts:AssumeRole"
+                }
+            ]
+        },
+        "Policies": [
             {
-              "Sid": "1",
-              "Action": [
-                "s3:GetObject"
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Sub": "arn:aws:s3:::${SourceBucket}/${SourceBucketFolder}/*"
-              }
-            },
-            {
-              "Sid": "2",
-              "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-                "logs:DescribeLogStreams"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            },
-            {
-              "Sid": "3",
-              "Action": [
-                "config:PutEvaluations"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            },
-            {
-              "Sid": "4",
-              "Action": [
-                "iam:List*",
-                "iam:Describe*",
-                "iam:Get*"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            },
-            {
-              "Sid": "5",
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Resource": "${ConfigRoleArnToAssume}"
+                "PolicyName": "ConfigRulePolicy",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "1",
+                            "Action": ["s3:GetObject"],
+                            "Effect": "Allow",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:s3:::${SourceBucket}/${SourceBucketFolder}/*"
+                            }
+                        },
+                        {
+                            "Sid": "2",
+                            "Action": [
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents",
+                                "logs:DescribeLogStreams"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": "*"
+                        },
+                        {
+                            "Sid": "3",
+                            "Action": ["config:PutEvaluations"],
+                            "Effect": "Allow",
+                            "Resource": "*"
+                        },
+                        {
+                            "Sid": "4",
+                            "Action": [
+                                "iam:List*",
+                                "iam:Describe*",
+                                "iam:Get*"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": "*"
+                        },
+                        {
+                            "Sid": "5",
+                            "Action": ["sts:AssumeRole"],
+                            "Effect": "Allow",
+                            "Resource": "${ConfigRoleArnToAssume}"
+                        }
+                    ]
+                }
             }
-          ]
-        }
-      }
-    ],
-    "ManagedPolicyArns": [
-      {
-        "Fn::Sub": "arn:aws:iam::aws:policy/ReadOnlyAccess"
-      }
-    ]
-  }
+        ],
+        "ManagedPolicyArns": [
+            {
+                "Fn::Sub": "arn:aws:iam::aws:policy/ReadOnlyAccess"
+            }
+        ]
+    }
 }

--- a/samples/sample-rdk-rules/templates/parameters.json
+++ b/samples/sample-rdk-rules/templates/parameters.json
@@ -1,25 +1,24 @@
-
 {
-  "SourceBucket": {
-    "Description": "Name of the S3 bucket that you have stored the rule zip files in.",
-    "Type": "String",
-    "MinLength": "1",
-    "MaxLength": "255"
-  },
-  "SourceBucketFolder": {
-    "Description": "Folder in the s3 bucket all the lambda function code stored",
-    "Type": "String",
-    "MinLength": "1",
-    "MaxLength": "255"
-  },
-  "LambdaAccountId": {
-    "Description": "Account ID that contains Lambda functions for Config Rules.",
-    "Type": "String",
-    "MinLength": "12",
-    "MaxLength": "12"
-  },
-  "ConfigRoleArnToAssume": {
-    "Description": "Lambda function required to assume this config role in target accounts to put evaluations",
-    "Type": "String"
-  }
+    "SourceBucket": {
+        "Description": "Name of the S3 bucket that you have stored the rule zip files in.",
+        "Type": "String",
+        "MinLength": "1",
+        "MaxLength": "255"
+    },
+    "SourceBucketFolder": {
+        "Description": "Folder in the s3 bucket all the lambda function code stored",
+        "Type": "String",
+        "MinLength": "1",
+        "MaxLength": "255"
+    },
+    "LambdaAccountId": {
+        "Description": "Account ID that contains Lambda functions for Config Rules.",
+        "Type": "String",
+        "MinLength": "12",
+        "MaxLength": "12"
+    },
+    "ConfigRoleArnToAssume": {
+        "Description": "Lambda function required to assume this config role in target accounts to put evaluations",
+        "Type": "String"
+    }
 }

--- a/samples/sample-rdk-rules/templates/skeleton.json
+++ b/samples/sample-rdk-rules/templates/skeleton.json
@@ -1,6 +1,5 @@
-
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "AWS CloudFormation template to create Lambda functions for backing custom AWS Config rules. You will be billed for the AWS resources used if you create a stack from this template.",
-  "Resources": {}
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "AWS CloudFormation template to create Lambda functions for backing custom AWS Config rules. You will be billed for the AWS resources used if you create a stack from this template.",
+    "Resources": {}
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR makes style adjustments that do not satisfy our linters. Unfortunately the `rdk` samples PR merge crossed the merge of the linter, hence they where not caught. Specifically this rule:

https://github.com/awslabs/aws-deployment-framework/blob/master/.editorconfig#L30-L31

Also added: 

```yaml
CLOUDFORMATION_CFN_LINT_FILE_EXTENSIONS: [".yml", ".yaml"]
```

To the linter config to bring it inline with our `cfn-lint` configuration. This repo doesn't have `json` CloudFormation templates, but the `rdk` samples have partial templates in `json` that are otherwise incorrectly flagged.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
