### PR TITLE
Fix find command on macOS, removing trailing slash in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 
 lint:
 	# Linter performs static analysis to catch latent bugs
-	find src/ -iname "*.py" -not -path "src/.aws-sam/*" | xargs pylint --rcfile .pylintrc
+	find src -iname "*.py" -not -path "src/.aws-sam/*" | xargs pylint --rcfile .pylintrc
 	find src -iname "*.yml" -o -iname "*.yaml" -not -path "src/.aws-sam/*" | xargs yamllint -c .yamllint.yml
 	cfn-lint
 


### PR DESCRIPTION
**Issue:** #473

**What?**

Fixed as suggested by @javydekoning in the original issue.
Personally I did not experience this issue on my machine, but removing the trailing slash wouldn't hurt either way.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
