### PR TITLE
Use NodeJS 14 with CodeBuild STANDARD_5_0

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -665,7 +665,7 @@ phases:
   install:
     runtime-versions:
       python: 3.9
-      nodejs: 16
+      nodejs: 14
   pre_build:
     commands:
       - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet

--- a/samples/sample-cdk-app/buildspec.yml
+++ b/samples/sample-cdk-app/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   install:
     runtime-versions:
       python: 3.9
-      nodejs: 16
+      nodejs: 14
     commands:
       - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet
       - pip install -r adf-build/requirements.txt -q

--- a/samples/sample-rdk-rules/buildspec.yml
+++ b/samples/sample-rdk-rules/buildspec.yml
@@ -3,7 +3,7 @@ phases:
   install:
     runtime-versions:
       python: 3.9
-      nodejs: 16
+      nodejs: 14
     commands:
       - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet
       - pip install -r adf-build/requirements.txt -q

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -736,7 +736,7 @@ Resources:
             install:
               runtime-versions:
                 python: 3.9
-                nodejs: 16
+                nodejs: 14
             pre_build:
               commands:
                 - npm install cdk@1.169 -g -y --quiet --no-progress


### PR DESCRIPTION
**Why?**

Unfortunately `STANDARD_5_0` does not support the latest LTS v16 of NodeJS.

**What?**

NodeJS v14 is supported, changed accordingly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
