### PR TITLE
Fix use of separate container image per target

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_determine_build_image.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_determine_build_image.py
@@ -77,6 +77,7 @@ def test_determine_build_image_build_defaults(ecr_repo, build_image):
         CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -115,6 +116,7 @@ def test_determine_build_image_build_str(ecr_repo, build_image):
         CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -160,6 +162,7 @@ def test_determine_build_image_build_ecr(ecr_repo, build_image):
     build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -168,7 +171,7 @@ def test_determine_build_image_build_ecr(ecr_repo, build_image):
     assert result == from_ecr_repo_return_value
     ecr_repo.from_repository_arn.assert_called_once_with(
         scope,
-        'custom_repo',
+        'custom_repo_some_id',
         SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
     )
     build_image.from_ecr_repository.assert_called_once_with(
@@ -212,6 +215,7 @@ def test_determine_build_image_build_ecr_no_tag(ecr_repo, build_image):
     build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -220,7 +224,7 @@ def test_determine_build_image_build_ecr_no_tag(ecr_repo, build_image):
     assert result == from_ecr_repo_return_value
     ecr_repo.from_repository_arn.assert_called_once_with(
         scope,
-        'custom_repo',
+        'custom_repo_some_id',
         SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
     )
     build_image.from_ecr_repository.assert_called_once_with(
@@ -254,6 +258,7 @@ def test_determine_build_image_deploy_defaults(ecr_repo, build_image):
         CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -291,6 +296,7 @@ def test_determine_build_image_deploy_target_str(ecr_repo, build_image):
         CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -329,6 +335,7 @@ def test_determine_build_image_deploy_str(ecr_repo, build_image):
         CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -367,6 +374,7 @@ def test_determine_build_image_deploy_target_str_too(ecr_repo, build_image):
         CODEBUILD_SPECIFIC_MAP_PARAMS_ALT_STR
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -412,6 +420,7 @@ def test_determine_build_image_deploy_ecr(ecr_repo, build_image):
     build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -420,7 +429,7 @@ def test_determine_build_image_deploy_ecr(ecr_repo, build_image):
     assert result == from_ecr_repo_return_value
     ecr_repo.from_repository_arn.assert_called_once_with(
         scope,
-        'custom_repo',
+        'custom_repo_some_id',
         SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
     )
     build_image.from_ecr_repository.assert_called_once_with(
@@ -462,6 +471,7 @@ def test_determine_build_image_deploy_ecr_too(ecr_repo, build_image):
     build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -470,7 +480,7 @@ def test_determine_build_image_deploy_ecr_too(ecr_repo, build_image):
     assert result == from_ecr_repo_return_value
     ecr_repo.from_repository_arn.assert_called_once_with(
         scope,
-        'custom_repo',
+        'custom_repo_some_id',
         target['properties']['image']['repository_arn'],
     )
     build_image.from_ecr_repository.assert_called_once_with(
@@ -514,6 +524,7 @@ def test_determine_build_image_deploy_ecr_no_tag(ecr_repo, build_image):
     build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -522,7 +533,7 @@ def test_determine_build_image_deploy_ecr_no_tag(ecr_repo, build_image):
     assert result == from_ecr_repo_return_value
     ecr_repo.from_repository_arn.assert_called_once_with(
         scope,
-        'custom_repo',
+        'custom_repo_some_id',
         SPECIFIC_CODEBUILD_IMAGE_ECR.get('repository_arn'),
     )
     build_image.from_ecr_repository.assert_called_once_with(
@@ -567,6 +578,7 @@ def test_determine_build_image_deploy_ecr_no_tag_too(ecr_repo, build_image):
     build_image.from_ecr_repository.return_value = from_ecr_repo_return_value
 
     result = CodeBuild.determine_build_image(
+        codebuild_id='some_id',
         scope=scope,
         target=target,
         map_params=map_params,
@@ -575,7 +587,7 @@ def test_determine_build_image_deploy_ecr_no_tag_too(ecr_repo, build_image):
     assert result == from_ecr_repo_return_value
     ecr_repo.from_repository_arn.assert_called_once_with(
         scope,
-        'custom_repo',
+        'custom_repo_some_id',
         target['properties']['image']['repository_arn'],
     )
     build_image.from_ecr_repository.assert_called_once_with(


### PR DESCRIPTION
**Issue:** #382

**Why?**

As reported by #382, setting a specific container image to use by the
CodeBuild provider to deploy to a target resulted in an error.

The CDK stack would fail to synthesize as the 'custom_repo' resource
name was already present in the stack.

**What?**

This fix ensures a unique identifier is used for custom container repositories.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
