### PR TITLE
Fix correct use of partitions

### DIFF
--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -139,7 +139,7 @@ Please note: you can use S3 as a source and deployment provider. The properties
 that are available are slightly different.
 
 The role used to fetch the object from the S3 bucket is:
-`arn:aws:iam::${source_account_id}:role/adf-codecommit-role`.
+`arn:${partition}:iam::${source_account_id}:role/adf-codecommit-role`.
 
 Provider type: `s3`.
 
@@ -383,7 +383,7 @@ Provider type: `codedeploy`.
   > The name of the CodeDeploy Application you want to use for this deployment.
 - *deployment_group_name* *(String)* **(required)**
   > The name of the Deployment Group you want to use for this deployment.
-- *role* - *(String)* default `arn:aws:iam::${target_account_id}:role/adf-cloudformation-role`.
+- *role* - *(String)* default `arn:${partition}:iam::${target_account_id}:role/adf-cloudformation-role`.
   > The role you would like to use on the target AWS account to execute the
   > CodeDeploy action. The role should allow the CodeDeploy service to assume
   > it. As is [documented in the CodeDeploy service role documentation](https://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-create-service-role.html).
@@ -436,7 +436,7 @@ Provider type: `cloudformation`.
   >
   > Defaults to empty string, the root of the source repository or input
   > artifact.
-- *role* - *(String)* default `arn:aws:iam::${target_account_id}:role/adf-cloudformation-deployment-role`.
+- *role* - *(String)* default `arn:${partition}:iam::${target_account_id}:role/adf-cloudformation-deployment-role`.
   > The role you would like to use on the target AWS account to execute the
   > CloudFormation action. Ensure that the CloudFormation service should be
   > allowed to assume that role.
@@ -495,7 +495,7 @@ Provider type: `lambda`.
 Service Catalog deployment provider.
 
 The role used to deploy the service catalog is:
-`arn:aws:iam::${target_account_id}:role/adf-cloudformation-role`.
+`arn:${partition}:iam::${target_account_id}:role/adf-cloudformation-role`.
 
 Provider type: `service_catalog`.
 
@@ -520,7 +520,7 @@ Please note: you can use S3 as a source and deployment provider. The properties
 that are available are slightly different.
 
 The role used to upload the object(s) to the S3 bucket is:
-`arn:aws:iam::${target_account_id}:role/adf-cloudformation-role`.
+`arn:${partition}:iam::${target_account_id}:role/adf-cloudformation-role`.
 
 Provider type: `s3`.
 
@@ -533,5 +533,5 @@ Provider type: `s3`.
 - *extract* - *(Boolean)* default: `False`.
   > Whether CodePipeline should extract the contents of the object when
   > it deploys it.
-- *role* - *(String)* default: `arn:aws:iam::${target_account_id}:role/adf-cloudformation-role`.
+- *role* - *(String)* default: `arn:${partition}:iam::${target_account_id}:role/adf-cloudformation-role`.
   > The role you would like to use for this action.

--- a/samples/sample-rdk-rules/templates/lambda-role.json
+++ b/samples/sample-rdk-rules/templates/lambda-role.json
@@ -26,7 +26,7 @@
                             "Action": ["s3:GetObject"],
                             "Effect": "Allow",
                             "Resource": {
-                                "Fn::Sub": "arn:aws:s3:::${SourceBucket}/${SourceBucketFolder}/*"
+                                "Fn::Sub": "arn:${AWS::Partition}:s3:::${SourceBucket}/${SourceBucketFolder}/*"
                             }
                         },
                         {
@@ -68,7 +68,7 @@
         ],
         "ManagedPolicyArns": [
             {
-                "Fn::Sub": "arn:aws:iam::aws:policy/ReadOnlyAccess"
+                "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess"
             }
         ]
     }

--- a/src/lambda_codebase/account_processing/configure_account_alias.py
+++ b/src/lambda_codebase/account_processing/configure_account_alias.py
@@ -14,6 +14,7 @@ patch_all()
 
 LOGGER = configure_logger(__name__)
 ADF_ROLE_NAME = os.getenv("ADF_ROLE_NAME")
+AWS_PARTITION = os.getenv("AWS_PARTITION")
 
 
 def create_account_alias(account, iam_client):
@@ -39,7 +40,7 @@ def lambda_handler(event, _):
         sts = STS()
         account_id = event.get("account_id")
         role = sts.assume_cross_account_role(
-            f"arn:aws:iam::{account_id}:role/{ADF_ROLE_NAME}",
+            f"arn:{AWS_PARTITION}:iam::{account_id}:role/{ADF_ROLE_NAME}",
             "adf_account_alias_config",
         )
         create_account_alias(event, role.client("iam"))

--- a/src/lambda_codebase/account_processing/delete_default_vpc.py
+++ b/src/lambda_codebase/account_processing/delete_default_vpc.py
@@ -13,12 +13,13 @@ patch_all()
 
 LOGGER = configure_logger(__name__)
 ADF_ROLE_NAME = os.getenv("ADF_ROLE_NAME")
+AWS_PARTITION = os.getenv("AWS_PARTITION")
 
 
 def assume_role(account_id):
     sts = STS()
     return sts.assume_cross_account_role(
-        f"arn:aws:iam::{account_id}:role/{ADF_ROLE_NAME}",
+        f"arn:{AWS_PARTITION}:iam::{account_id}:role/{ADF_ROLE_NAME}",
         "adf_delete_default_vpc",
     )
 

--- a/src/lambda_codebase/account_processing/get_account_regions.py
+++ b/src/lambda_codebase/account_processing/get_account_regions.py
@@ -14,6 +14,7 @@ patch_all()
 
 LOGGER = configure_logger(__name__)
 ADF_ROLE_NAME = os.getenv("ADF_ROLE_NAME")
+AWS_PARTITION = os.getenv("AWS_PARTITION")
 
 
 def lambda_handler(event, _):
@@ -21,7 +22,7 @@ def lambda_handler(event, _):
     sts = STS()
     account_id = event.get("account_id")
     role = sts.assume_cross_account_role(
-        f"arn:aws:iam::{account_id}:role/{ADF_ROLE_NAME}",
+        f"arn:{AWS_PARTITION}:iam::{account_id}:role/{ADF_ROLE_NAME}",
         "adf_account_get_regions",
     )
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_chatbot.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_chatbot.py
@@ -38,8 +38,16 @@ class PipelineNotifications(core.Construct):
         **kwargs,
     ):  # pylint: disable=W0622
         super().__init__(scope, id, **kwargs)
-        slack_channel_arn = f"arn:aws:chatbot::{ADF_DEPLOYMENT_ACCOUNT_ID}:chat-configuration/slack-channel/{notification_config.get('target')}"
-        pipeline_arn = f"arn:aws:codepipeline:{ADF_DEPLOYMENT_REGION}:{ADF_DEPLOYMENT_ACCOUNT_ID}:{pipeline.ref}"
+        stack = core.Stack.of(self)
+        slack_channel_arn = (
+            f"arn:{stack.partition}:chatbot::{ADF_DEPLOYMENT_ACCOUNT_ID}:"
+            f"chat-configuration/slack-channel/"
+            f"{notification_config.get('target')}"
+        )
+        pipeline_arn = (
+            f"arn:{stack.partition}:codepipeline:{ADF_DEPLOYMENT_REGION}:"
+            "{ADF_DEPLOYMENT_ACCOUNT_ID}:{pipeline.ref}"
+        )
         cp_notifications.CfnNotificationRule(
             scope,
             "pipeline-notification",

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_pipeline_creation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_pipeline_creation.py
@@ -445,10 +445,14 @@ def test_pipeline_creation_outputs_as_expected_when_notification_endpoint_is_cha
     assert resources["pipelinenoti"]["Type"] == (
         "AWS::CodeStarNotifications::NotificationRule"
     )
-    assert target["TargetAddress"] == (
-        "arn:aws:chatbot::111111111111:"
-        "chat-configuration/slack-channel/fake-config"
-    )
+    assert target["TargetAddress"] == {
+        "Fn::Join": ["", [
+            "arn:",
+            {"Ref": "AWS::Partition"},
+            ":chatbot::111111111111:"
+            "chat-configuration/slack-channel/fake-config"
+        ]]
+    }
     assert target["TargetType"] == "AWSChatbotSlack"
     assert pipeline_notification["EventTypeIds"] == [
         "codepipeline-pipeline-stage-execution-succeeded",

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sts.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sts.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+if [ -z "$AWS_PARTITION" ]; then
+  AWS_PARTITION="aws"
+fi
+
 # Example usage sts 123456789012 adf-terraform-deployment-role
-export ROLE=arn:aws:iam::$1:role/$2
+export ROLE=arn:$AWS_PARTITION:iam::$1:role/$2
 temp_role=$(aws sts assume-role --role-arn $ROLE --role-session-name $2-$ADF_PROJECT_NAME)
 export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq -r .Credentials.AccessKeyId)
 export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r .Credentials.SecretAccessKey)

--- a/src/template.yml
+++ b/src/template.yml
@@ -357,6 +357,7 @@ Resources:
         - !Ref LambdaLayerVersion
       Environment:
         Variables:
+          AWS_PARTITION: !Ref AWS::Partition
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
           ADF_VERSION: !FindInMap ['Metadata', 'ADF', 'Version']
@@ -467,6 +468,7 @@ Resources:
         - !Ref LambdaLayerVersion
       Environment:
         Variables:
+          AWS_PARTITION: !Ref AWS::Partition
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
           ADF_VERSION: !FindInMap ['Metadata', 'ADF', 'Version']
@@ -501,6 +503,7 @@ Resources:
         - !Ref LambdaLayerVersion
       Environment:
         Variables:
+          AWS_PARTITION: !Ref AWS::Partition
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
           ORGANIZATION_ID: !GetAtt Organization.OrganizationId
           ADF_VERSION: !FindInMap ['Metadata', 'ADF', 'Version']


### PR DESCRIPTION
**Why?**

Some of the pull requests might have overlapped with the pull request that introduced support for the `aws-us-gov` partition.

By searching for `:aws:`, I found a number of references that were still hard coding the `aws` partition.

**What?**

Adding support for dynamic partitions where it was not supported yet.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
