### PR TITLE
Fix syncing deployment_map files to s3

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -762,15 +762,14 @@ Resources:
               runtime-versions:
                 python: 3.9
                 nodejs: 14
-            pre_build:
               commands:
                 - npm install cdk@1.169 -g -y --quiet --no-progress
                 - aws s3 cp s3://$SHARED_MODULES_BUCKET/adf-build/ ./adf-build/ --recursive --quiet
                 - pip install -r adf-build/requirements.txt -q -t ./adf-build
             build:
               commands:
-                - aws s3 cp deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml
-                - aws s3 sync deployment_maps/* s3://$ADF_PIPELINES_BUCKET
+                - bash -c "[[ -e deployment_map.yml ]] && echo 'Copying deployment_map.yml' && aws s3 cp deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml || echo 'No deployment_map.yml, skipping copy'"
+                - bash -c "[[ -e deployment_maps ]] && echo 'Syncing deployment_maps folder' && aws s3 sync deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps || echo 'No deployment_maps folder, skipping sync'"
       ServiceRole: !GetAtt PipelineProvisionerCodeBuildRole.Arn
       Tags:
         - Key: "Name"


### PR DESCRIPTION
**Why?**

When it tried to sync a deployment_map.yml file that did not exist in the
pipelines repo, it would fail with exit code 1.

Additionally, the files directly inside the deployment_maps folder were not
synced, only nested folders were synced correctly.

**What?**

* Moved install commands to the install phase in the CodeBuild buildspec.
* Added a check to test whether the folder/file exists before syncing.
* Added echo messages to explain what and why it does or doesn't sync.
* Added or statement to ensure that it will succeed with exit 0 when
  files/folders are missing.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
