### PR TITLE
Add missing permission to assume Cross-Account-Org R/O role

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -6,36 +6,47 @@ Parameters:
   OrganizationID:
     Type: String
     MinLength: "1"
+
   ADFVersion:
     Type: String
     MinLength: "1"
+
   LambdaLayer:
     Type: String
     MinLength: "1"
+
   CrossAccountAccessRole:
     Type: String
     MinLength: "1"
+
   PipelineBucket:
     Type: String
     MinLength: "1"
+
   RootAccountId:
     Type: String
     MinLength: "1"
+
   CodeBuildImage:
     Type: String
     MinLength: "1"
+
   CodeBuildComputeType:
     Type: String
     MinLength: "1"
+
   SharedModulesBucket:
     Type: String
     MinLength: "1"
+
   PipelinePrefix:
     Type: String
     MinLength: "1"
+
   StackPrefix:
     Type: String
     MinLength: "1"
+
   ADFLogLevel:
     Type: String
     MinLength: "1"
@@ -98,6 +109,7 @@ Resources:
             Resource: !Sub "${ADFPipelineBucket.Arn}/*"
       Roles:
         - !Ref DeploymentMapProcessingLambdaRole
+
   CrossAccountCloudFormationPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -207,6 +219,7 @@ Resources:
                   - "ssm:PutParameter"
                 Resource:
                   - "*"
+
   StoreDefinitionLambdaRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -230,6 +243,7 @@ Resources:
                   - "s3:PutObject"
                 Resource:
                   - !Sub "${ADFDefinitionBucket.Arn}/*"
+
   IdentifyOutOfDatePipelinesLambdaRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -538,6 +552,7 @@ Resources:
                 - cdk synth --app adf-build/cdk/generate_pipeline_stacks.py -vv
                 - python adf-build/cdk/execute_pipeline_stacks.py
       ServiceRole: !GetAtt PipelineManagementCodeBuildProjectRole.Arn
+
   PipelineManagementCodeBuildProjectRole:
     Type: AWS::IAM::Role
     Properties:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -178,6 +178,7 @@ Resources:
     Type: "AWS::IAM::Role"
     Properties:
       Path: "/adf-automation/"
+      RoleName: "adf-pipeline-provisioner-generate-inputs"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
@@ -29,6 +29,7 @@ Resources:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/adf-codebuild-role"
                 - !Sub "arn:${AWS::Partition}:iam::${DeploymentAccountId}:role/adf-codebuild-role"
                 - !Sub "arn:${AWS::Partition}:iam::${DeploymentAccountId}:role/adf-pipeline-provisioner-codebuild-role"
+                - !Sub "arn:${AWS::Partition}:iam::${DeploymentAccountId}:role/adf-automation/adf-pipeline-provisioner-generate-inputs"
             Action:
               - sts:AssumeRole
       Path: /


### PR DESCRIPTION
## Why?

The Generate Pipeline Input lambda function tried to assume into the cross-account access role, to read the organization API.
This was not allowed, as it was not permitted by the cross-account access role as a trusted role that can assume into the read-only role in the management account.

## What?

Addressed by adding a specific role name for the role that is used by the Generate Input lambda function. Plus putting that role on the allowed list of roles that are allowed to assume the cross-account access role for read-only access to the organization API.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
