### PR TITLE
Improvement: Only invoke pipeline deletion when needed

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
@@ -91,7 +91,10 @@ def lambda_handler(event, _):
     )
     delete_ssm_params(out_of_date_pipelines, parameter_store)
 
-    output = {"pipelines_to_be_deleted": out_of_date_pipelines}
+    output = {}
+    if len(out_of_date_pipelines) > 0:
+        output["pipelines_to_be_deleted"] = out_of_date_pipelines
+
     data_md5 = hashlib.md5(
         json.dumps(output, sort_keys=True).encode("utf-8")
     ).hexdigest()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -420,7 +420,18 @@ Resources:
                 "BackoffRate": 1.5,
                 "MaxAttempts": 10
               }],
-              "Next": "InvokeDeleteStateMachine"
+              "Next": "AnyPipelineToBeDeleted?"
+            },
+            "AnyPipelineToBeDeleted?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.pipelines_to_be_deleted",
+                  "IsPresent": true,
+                  "Next": "InvokeDeleteStateMachine"
+                }
+              ],
+              "Default": "Success"
             },
             "InvokeDeleteStateMachine": {
               "Type": "Task",


### PR DESCRIPTION
## Why?

At the moment, the InvokeDeleteStateMachine task is called even when no pipelines need to be deleted. This causes the actual state machine that deletes these tasks to fail. As it cannot iterate over an empty list.

## What?

Introducing a choice, that will only invoke the delete pipelines state machine when there is a need to do so.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
