### PR TITLE
Fix permission to update termination protection on pipeline stacks

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -523,7 +523,6 @@ Resources:
               runtime-versions:
                 python: 3.9
                 nodejs: 14
-            pre_build:
               commands:
                 - npm install cdk@1.169 -g -y --quiet --no-progress
                 - aws s3 cp s3://$SHARED_MODULES_BUCKET/adf-build/ ./adf-build/ --recursive --quiet
@@ -583,6 +582,7 @@ Resources:
                 Action:
                   - cloudformation:CreateStack
                   - cloudformation:UpdateStack
+                  - cloudformation:UpdateTerminationProtection
                 Resource:
                   - "*"
                 Condition:


### PR DESCRIPTION
## Why?

After updating the CloudFormation template for a ADF pipeline, it tries to update the termination protection flag on the stack. This will fail as the permissions are not configured yet. The failure it returned was:

> 2022-08-30 14:22:24,295 | ERROR | cloudformation | 111111111111 | adf-pipeline-some-pipeline, Error: An error occurred (AccessDenied) when calling the UpdateTerminationProtection operation: User: arn:aws:sts::111111111111:assumed-role/adf-global-base-deploymen-PipelineManagementCodeBu-xxxxxxxxxxxxx/AWSCodeBuild-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx is not authorized to perform: cloudformation:UpdateTerminationProtection on resource: arn:aws:cloudformation:eu-west-1:111111111111:stack/adf-pipeline-some-pipeline/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx because no identity-based policy allows the cloudformation:UpdateTerminationProtection action | (cloudformation.py:230)

## What?

Adding permission to call the CloudFormation UpdateTerminationProtection API.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
