### PR TITLE
Add reference to state machine from CodeBuild on pipeline updates

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -771,6 +771,11 @@ Resources:
               commands:
                 - bash -c "[[ -e deployment_map.yml ]] && echo 'Copying deployment_map.yml' && aws s3 cp deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml || echo 'No deployment_map.yml, skipping copy'"
                 - bash -c "[[ -e deployment_maps ]] && echo 'Syncing deployment_maps folder' && aws s3 sync deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps || echo 'No deployment_maps folder, skipping sync'"
+            post_build:
+              commands:
+                - echo "Pipelines are updated in the AWS Step Functions ADFPipelineManagementStateMachine."
+                - echo "Please track their progress via:"
+                - echo "https://${AWS::Region}.console.aws.amazon.com/states/home?region=${AWS::Region}#/statemachines/view/arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:ADFPipelineManagementStateMachine"
       ServiceRole: !GetAtt PipelineProvisionerCodeBuildRole.Arn
       Tags:
         - Key: "Name"


### PR DESCRIPTION
**Why?**

In the past, the ADF Pipelines were updated from the CodeBuild step in the `aws-deployment-framework-pipelines` CodePipeline flow.

With the recent release of the Step Function Pipeline Management State Machine, this logic has moved.
To ensure that administrators still understand what happens and whether the pipelines are updated correctly, we should link them to the state machine from the CodeBuild execution.

**What?**

Doing exactly that, adding a reference to the state machine in the CodeBuild step.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
