### PR TITLE
Fix ADF State Machines

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -1231,6 +1231,9 @@ Resources:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:
       StateMachineName: "EnableCrossAccountAccess"
+      RoleArn: !GetAtt StatesExecutionRole.Arn
+      TracingConfiguration:
+        Enabled: true
       DefinitionString: !Sub |-
         {
           "Comment": "Enable Cross Account Access from Deployment Account",
@@ -1277,7 +1280,7 @@ Resources:
                           "Lambda.Unknown",
                           "Lambda.ServiceException",
                           "Lambda.AWSLambdaException",
-                          "Lambda.SdkClientException"
+                          "Lambda.SdkClientException",
                           "Lambda.TooManyRequestsException"
                         ],
                         "IntervalSeconds": 2,
@@ -1314,7 +1317,7 @@ Resources:
                     "Lambda.Unknown",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
                     "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
@@ -1363,7 +1366,6 @@ Resources:
             }
           }
         }
-      RoleArn: !GetAtt StatesExecutionRole.Arn
 
   DetermineDefaultBranchName:
     Type: Custom::DetermineDefaultBranchName

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml==5.4.1
 wrapt==1.14.1 # https://github.com/aws/aws-lambda-builders/issues/302
 schema==0.7.5
+tenacity=8.0.1

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -388,7 +388,7 @@ Resources:
                     "Lambda.Unknown",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
                     "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
@@ -414,7 +414,7 @@ Resources:
                     "Lambda.Unknown",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
                     "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
@@ -440,7 +440,7 @@ Resources:
                     "Lambda.Unknown",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
                     "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
@@ -466,7 +466,7 @@ Resources:
                     "Lambda.Unknown",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
                     "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
@@ -502,7 +502,7 @@ Resources:
                     "Lambda.Unknown",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException"
+                    "Lambda.SdkClientException",
                     "Lambda.TooManyRequestsException"
                   ],
                   "IntervalSeconds": 2,
@@ -554,6 +554,9 @@ Resources:
   PipelineDeletionStateMachine:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:
+      RoleArn: !GetAtt DeletionStateMachineExecutionRole.Arn
+      TracingConfiguration:
+        Enabled: true
       DefinitionString: !Sub |-
         {
           "Comment": "Delete Stacks",
@@ -583,9 +586,6 @@ Resources:
             }
           }
         }
-      RoleArn: !GetAtt DeletionStateMachineExecutionRole.Arn
-      TracingConfiguration:
-        Enabled: true
 
   PipelineManagementCodeBuildProject:
     Type: AWS::CodeBuild::Project

--- a/src/template.yml
+++ b/src/template.yml
@@ -673,7 +673,7 @@ Resources:
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
                   "MaxAttempts": 6
-                },
+                }
               ],
               "Next": "ConfigureAccountTags"
             },
@@ -697,7 +697,7 @@ Resources:
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
                   "MaxAttempts": 6
-                },
+                }
               ],
               "Next": "WaitFor10Seconds"
             },
@@ -726,7 +726,7 @@ Resources:
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
                   "MaxAttempts": 6
-                },
+                }
               ],
               "Next": "ConfigureAccountAlias"
             },
@@ -750,7 +750,7 @@ Resources:
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
                   "MaxAttempts": 6
-                },
+                }
               ],
               "Next": "ConfigureAccountOU"
             },
@@ -774,7 +774,7 @@ Resources:
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
                   "MaxAttempts": 6
-                },
+                }
               ],
               "Next": "DeleteDefaultVPCChoice"
             },
@@ -809,7 +809,7 @@ Resources:
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
                   "MaxAttempts": 6
-                },
+                }
               ],
               "Next": "DeleteDefaultVPCMap"
             },
@@ -832,7 +832,7 @@ Resources:
                             "Lambda.Unknown",
                             "Lambda.ServiceException",
                             "Lambda.AWSLambdaException",
-                            "Lambda.SdkClientException"
+                            "Lambda.SdkClientException",
                             "Lambda.TooManyRequestsException"
                           ],
                           "IntervalSeconds": 2,
@@ -1048,7 +1048,7 @@ Resources:
           eventName:
             - MoveAccount
       Targets:
-        - Arn: !Ref StateMachine
+        - Arn: !Ref AccountBootstrappingStateMachine
           RoleArn: !GetAtt StatesExecutionRole.Arn
           Id: CreateStackLinkedAccountV1
 
@@ -1422,9 +1422,12 @@ Resources:
                   - "states:StartExecution"
                 Resource: "*"
 
-  StateMachine:
+  AccountBootstrappingStateMachine:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:
+      RoleArn: !GetAtt StatesExecutionRole.Arn
+      TracingConfiguration:
+        Enabled: true
       DefinitionString: !Sub |-
         {
           "Comment": "ADF Account Bootstrapping Process",
@@ -1620,7 +1623,6 @@ Resources:
             }
           }
         }
-      RoleArn: !GetAtt StatesExecutionRole.Arn
 
   DetermineDefaultBranchName:
     Type: Custom::DetermineDefaultBranchName


### PR DESCRIPTION
## Why?

In PR #513, an error was introduced which broke the syntax of the State Machine definition.

While investigating, I discovered a number of other improvements that might help, addressing these in this change.

## What?

* Fixing missing and redundant commas in retry logic.
* Moving roles and other properties of State Machines to the beginning, so they
  don't float around at the end of the state machine definition.
* Enabled tracing on state machines.
* Updated name of Account Bootstrapping state machine.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
