### PR TITLE
Fix updating account alias when needed

### DIFF
--- a/src/lambda_codebase/account_processing/configure_account_alias.py
+++ b/src/lambda_codebase/account_processing/configure_account_alias.py
@@ -17,9 +17,19 @@ ADF_ROLE_NAME = os.getenv("ADF_ROLE_NAME")
 AWS_PARTITION = os.getenv("AWS_PARTITION")
 
 
+def delete_account_aliases(account, iam_client, current_aliases):
+    for alias in current_aliases:
+        LOGGER.info(
+            "Account %s, removing alias %s",
+            account.get('account_full_name'),
+            alias,
+        )
+        iam_client.delete_account_alias(AccountAlias=alias)
+
+
 def create_account_alias(account, iam_client):
     LOGGER.info(
-        "Ensuring Account: %s has alias %s",
+        "Adding alias to: %s alias %s",
         account.get('account_full_name'),
         account.get('alias'),
     )
@@ -28,11 +38,33 @@ def create_account_alias(account, iam_client):
     except iam_client.exceptions.EntityAlreadyExistsException as error:
         LOGGER.error(
             f"The account alias {account.get('alias')} already exists."
-            "The account alias must be unique across all Amazon Web Services products."
-            "Refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#AboutAccountAlias"
+            "The account alias must be unique across all Amazon Web Services "
+            "products. Refer to "
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/"
+            "console_account-alias.html#AboutAccountAlias"
         )
         raise error
-    return account
+
+
+def ensure_account_has_alias(account, iam_client):
+    LOGGER.info(
+        "Ensuring Account: %s has alias %s",
+        account.get('account_full_name'),
+        account.get('alias'),
+    )
+    current_aliases = iam_client.list_account_aliases().get('AccountAliases')
+    if account.get('alias') in current_aliases:
+        LOGGER.info(
+            "Account: %s already has alias %s",
+            account.get('account_full_name'),
+            account.get('alias'),
+        )
+        return
+
+    # Since you can only have one alias per account, lets
+    # remove all old aliases (is at most one)
+    delete_account_aliases(account, iam_client, current_aliases)
+    create_account_alias(account, iam_client)
 
 
 def lambda_handler(event, _):
@@ -43,7 +75,7 @@ def lambda_handler(event, _):
             f"arn:{AWS_PARTITION}:iam::{account_id}:role/{ADF_ROLE_NAME}",
             "adf_account_alias_config",
         )
-        create_account_alias(event, role.client("iam"))
+        ensure_account_has_alias(event, role.client("iam"))
     else:
         LOGGER.info(
             "Account: %s does not need an alias",

--- a/src/template.yml
+++ b/src/template.yml
@@ -661,7 +661,7 @@ Resources:
                   "ErrorEquals": ["States.TaskFailed"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 1.5,
-                  "MaxAttempts": 30
+                  "MaxAttempts": 10
                 }, {
                   "ErrorEquals": [
                     "Lambda.Unknown",
@@ -685,7 +685,7 @@ Resources:
                   "ErrorEquals": ["States.TaskFailed"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 1.5,
-                  "MaxAttempts": 30
+                  "MaxAttempts": 10
                 }, {
                   "ErrorEquals": [
                     "Lambda.Unknown",
@@ -714,7 +714,7 @@ Resources:
                   "ErrorEquals": ["States.TaskFailed"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 1.5,
-                  "MaxAttempts": 30
+                  "MaxAttempts": 10
                 }, {
                   "ErrorEquals": [
                     "Lambda.Unknown",
@@ -738,7 +738,7 @@ Resources:
                   "ErrorEquals": ["States.TaskFailed"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 1.5,
-                  "MaxAttempts": 30
+                  "MaxAttempts": 10
                 }, {
                   "ErrorEquals": [
                     "Lambda.Unknown",
@@ -762,7 +762,7 @@ Resources:
                   "ErrorEquals": ["States.TaskFailed"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 1.5,
-                  "MaxAttempts": 30
+                  "MaxAttempts": 10
                 }, {
                   "ErrorEquals": [
                     "Lambda.Unknown",
@@ -797,7 +797,7 @@ Resources:
                   "ErrorEquals": ["States.TaskFailed"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 1.5,
-                  "MaxAttempts": 30
+                  "MaxAttempts": 10
                 }, {
                   "ErrorEquals": [
                     "Lambda.Unknown",


### PR DESCRIPTION
## Why?

At the moment, the account management state machine will attempt to add the specified alias to the account whether it is present or not.

In case the alias already exists, it will fail.

## What?

This change will ensure the aliases configured on the account are removed when they are no longer configured (you can only have one, but the API supports multiple). It will then add the alias if the alias that needs to be present is
missing.

Updated maximum number of attempts in the State Machines to max 10, as 30 would imply multiple days of retries.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
