### PR TITLE
Add support for the CodeBuild provider to run inside a VPC

### DIFF
--- a/samples/sample-codebuild-vpc/README.md
+++ b/samples/sample-codebuild-vpc/README.md
@@ -1,0 +1,57 @@
+# Sample CodeBuild VPC usage showcasing ADF Pipelines
+
+This pipeline will demonstrate how-to setup CodeBuild to use a specific VPC.
+
+**Please note**: Before you can deploy CodeBuild in a VPC, you need to follow the
+instructions as described in the CodeBuild provider documentation at:
+[docs/providers-guide.md](../../docs/providers-guide.md#setup-permissions-for-codebuild-vpc-usage)
+This is only required once to allow the CodeBuild service to locate and create
+the required resources. Once configured, the permissions allow any pipeline to
+make use of VPCs when running CodeBuild steps.
+
+Back to the sample: The pipeline deploys a simple S3 bucket without granting
+any permissions. The point of this sample is to demonstrate how different
+build and deployment stages can use CodeBuild in a VPC to connect to internal
+resources.
+
+Create a new repository that will host the files that are contained inside
+this sample folder.
+
+Update the `vpc_id`, `subnet_ids`, and `security_group_ids` attributes to match
+your own VPC and subnets that are operational in the deployment account.
+
+### Deployment Map example
+
+```yaml
+  - name: sample-codebuild-vpc
+    default_providers:
+      source:
+        provider: codecommit
+        properties:
+          account_id: 111111111111
+      build:
+        provider: codebuild
+        properties:
+          image: "STANDARD_5_0"
+          vpc_id: vpc-01234567890abcdef
+          subnet_ids:
+            - subnet-1234567890abcdef1
+            - subnet-bcdef01234567890a
+      deploy:
+        provider: cloudformation
+    targets:
+      - /banking/testing
+      - name: integration-tests
+        provider: codebuild
+        properties:
+          image: "STANDARD_5_0"
+          spec_filename: testspec.yml
+          vpc_id: vpc-01234567890abcdef
+          subnet_ids:
+            - subnet-1234567890abcdef1
+            - subnet-bcdef01234567890a
+          security_group_ids:
+            - sg-234567890abcdef01
+            - sg-cdef01234567890ab
+      - /banking/production
+```

--- a/samples/sample-codebuild-vpc/buildspec.yml
+++ b/samples/sample-codebuild-vpc/buildspec.yml
@@ -1,0 +1,25 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.9
+    commands:
+      # It will connect through the VPC to fetch all the resources.
+      # Make sure the subnets and security groups are configured such that
+      # it is able to connect to S3 and fetch the requirements using pip.
+      #
+      # If you want to restrict public access, you can create a local copy
+      # of the pip required packages and use S3 private link.
+      - aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet
+      - pip install -r adf-build/requirements.txt -q
+
+  build:
+    commands:
+      - python adf-build/generate_params.py
+
+artifacts:
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml"'

--- a/samples/sample-codebuild-vpc/params/global.yml
+++ b/samples/sample-codebuild-vpc/params/global.yml
@@ -1,0 +1,3 @@
+Tags:
+  Repository: sample-codebuild-vpc-repo
+  App: Sample CodeBuild VPC application

--- a/samples/sample-codebuild-vpc/template.yml
+++ b/samples/sample-codebuild-vpc/template.yml
@@ -1,0 +1,22 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ADF CloudFormation Sample Template
+Metadata:
+  License: Apache-2.0
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true

--- a/samples/sample-codebuild-vpc/testspec.yml
+++ b/samples/sample-codebuild-vpc/testspec.yml
@@ -1,0 +1,12 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.9
+
+  build:
+    commands:
+      # A sample API call to an internal only service to perform the
+      # integration tests.
+      - curl https://integration-test-url.internal/test

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/example-global-iam.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/example-global-iam.yml
@@ -26,3 +26,66 @@ Resources:
               - "*"
       Roles:
         - adf-cloudformation-deployment-role
+
+  ##
+  # Begin of VPC CodeBuild support IAM permissions
+  ##
+  PipelineProvisionerResourcePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "adf-pipeline-provisioner-codebuild-role-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Sid: "CodeBuildVPC"
+            Action:
+              - "ec2:AuthorizeSecurityGroupEgress"
+              - "ec2:AuthorizeSecurityGroupIngress"
+              - "ec2:CreateSecurityGroup"
+              - "ec2:CreateTags"
+              - "ec2:DeleteSecurityGroup"
+              - "ec2:DeleteSecurityGroup"
+              - "ec2:DeleteTags"
+              - "ec2:Describe*"
+              - "ec2:List*"
+              - "ec2:RevokeSecurityGroupEgress"
+              - "ec2:RevokeSecurityGroupIngress"
+            Resource:
+              - "*"
+      Roles:
+        - adf-pipeline-provisioner-codebuild-role
+
+  CodeBuildResourcePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "adf-codebuild-role-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Sid: "CodeBuildVPC"
+            Action:
+              - "ec2:CreateNetworkInterface"
+              - "ec2:DescribeDhcpOptions"
+              - "ec2:DescribeNetworkInterfaces"
+              - "ec2:DeleteNetworkInterface"
+              - "ec2:DescribeSubnets"
+              - "ec2:DescribeSecurityGroups"
+              - "ec2:DescribeVpcs"
+            Resource:
+              - "*"
+          - Effect: Allow
+            Sid: "CodeBuildENI"
+            Action:
+              - "ec2:CreateNetworkInterfacePermission"
+            Resource:
+              - "*"
+            Condition:
+              StringEquals:
+                ec2:AuthorizedService: "codebuild.amazonaws.com"
+      Roles:
+        - adf-codebuild-role
+  ##
+  # End of VPC CodeBuild support IAM permissions
+  ##

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_stacks.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_stacks.py
@@ -26,7 +26,6 @@ ADF_LOG_LEVEL = os.environ["ADF_LOG_LEVEL"]
 def main():
     LOGGER.info("ADF Version %s", ADF_VERSION)
     LOGGER.info("ADF Log Level is %s", ADF_LOG_LEVEL)
-    _threads = []
     _templates = glob.glob("cdk_inputs/*.json")
     for template_path in _templates:
         with open(template_path, encoding="utf-8") as template:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
@@ -108,6 +108,9 @@ CODEBUILD_IMAGE_PROPS = {
     Optional("tag"): str,   # defaults to latest
 }
 CODEBUILD_PROPS = {
+    Optional("vpc_id"): str,
+    Optional("subnet_ids"): [str],
+    Optional("security_group_ids"): [str],
     Optional("image"): Or(str, CODEBUILD_IMAGE_PROPS),
     Optional("size"): Or('small', 'medium', 'large'),
     Optional("spec_filename"): str,


### PR DESCRIPTION
## Why?

To add support for build/deploy steps that use CodeBuild and need to connect to internal resources that are only available through a VPC.

This feature allows you to configure which VPC to connect to, using a specific list of subnets and security groups. The latter helps ensure that the connection is only allowed to connect when a specific security group is used.

## What?

Added three properties to the CodeBuild provider:
- vpc_id (string)
- subnet_ids (list of ids (strings))
- security_group_ids (list of ids (strings))

When you configure a pipeline to use a specific VPC, you need to specify the subnets to use as well.

In case you don't specify any security groups, they will be automatically created for you. These security groups allow all egress traffic by default. It is recommended to use a specific security group so you can strictly define what egress traffic is allowed.

__Please note__: When you configure a specific CodeBuild environment in a pipeline to use a VPC it cannot be removed easily. To remove the VPC from the CodeBuild environment, you need to remove the pipeline stack and instruct ADF to generate the pipelines again (release trigger on `aws-deployment-framework-pipelines` in CodePipeline).

Documentation has been added and a sample that shows how to setup a pipeline to use a specific VPC.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
