### PR TITLE
Fix pip requirements typo

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/requirements.txt
@@ -1,4 +1,4 @@
 pyyaml==5.4.1
 wrapt==1.14.1 # https://github.com/aws/aws-lambda-builders/issues/302
 schema==0.7.5
-tenacity=8.0.1
+tenacity==8.0.1


### PR DESCRIPTION
## Why?

A typo slipped into the main branch, where it tries to install `tenacity=8.0.1`.
It should be `==`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
