### PR TITLE
Fix pipeline generation policies

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -784,6 +784,12 @@ Resources:
                 Resource:
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/adf-pipeline-*
               - Effect: Allow
+                Sid: "AllowPassRole"
+                Action:
+                  - "iam:PassRole"
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::*:role/*
+              - Effect: Allow
                 Action:
                   - "events:PutRule"
                   - "events:PutTargets"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -688,12 +688,24 @@ Resources:
                 Action:
                   - cloudformation:CreateStack
                   - cloudformation:UpdateStack
-                  - cloudformation:UpdateTerminationProtection
                 Resource:
                   - "*"
                 Condition:
                   StringEquals:
                     'aws:RequestTag/createdBy': "ADF"
+        - PolicyName: "adf-deploy-cloudformation-delete"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:DeleteStack
+                  - cloudformation:UpdateTerminationProtection
+                Resource:
+                  - "*"
+                Condition:
+                  StringEquals:
+                    'aws:ResourceTag/createdBy': "ADF"
         - PolicyName: "adf-deploy-cloudformation-template"
           PolicyDocument:
             Version: "2012-10-17"
@@ -813,7 +825,8 @@ Resources:
                 Resource: "*"
               - Effect: Allow
                 Action:
-                  - "iam:TagResource"
+                  - "iam:TagPolicy"
+                  - "iam:TagRole"
                 Resource: "*"
 
   DeploymentMapProcessingFunction:


### PR DESCRIPTION
**Why?**

1. With a recent PR, an attempt was made to restrict the `iam:PassRole` permissions for the pipeline generator. However, since ADF supports configuring which role to use, this would introduce a breaking change.
2. The policy in the pipeline management attached to the CloudFormation role does not allow it to `DeleteStack` or `UpdateTerminationProtection.` As those were using the RequestTag condition that is not compatible with these API calls.
3. Additionally, the `iam:TagResource` action does not exist.

**What?**

1. Reverting to the previous policy of `iam:PassRole`. Plan is to address this in the next major ADF release.
2. For the `DeleteStack` and `UpdateTerminationProtection` actions, it is updated to use the `iam:ResourceTag` condition instead.
3. While the `iam:TagResource` action got replaced with `iam:TagPolicy` and `iam:TagRole` actions.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
