### PR TITLE
Fix stale pipeline deletion

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
@@ -50,21 +50,12 @@ def get_current_pipelines(parameter_store):
 
 def identify_out_of_date_pipelines(pipeline_names, current_pipelines):
     return [
-        {"pipeline": f"{ADF_PIPELINE_PREFIX}{d}"}
-        for d in current_pipelines.difference(pipeline_names)
+        {
+            "full_pipeline_name": f"{ADF_PIPELINE_PREFIX}{name}",
+            "pipeline_name": name,
+        }
+        for name in current_pipelines.difference(pipeline_names)
     ]
-
-
-def delete_ssm_params(out_of_date_pipelines, parameter_store):
-    for pipeline in out_of_date_pipelines:
-        LOGGER.debug(
-            "Deleting SSM regions parameter of stale pipeline: /deployment/%s/regions - %s",
-            pipeline.get('name'),
-            pipeline,
-        )
-        parameter_store.delete_parameter(
-            f"{S3_BACKED_DEPLOYMENT_PREFIX}{pipeline.get('pipeline').removeprefix(ADF_PIPELINE_PREFIX)}/regions"
-        )
 
 
 def lambda_handler(event, _):
@@ -92,7 +83,6 @@ def lambda_handler(event, _):
     out_of_date_pipelines = identify_out_of_date_pipelines(
         pipeline_names, current_pipelines
     )
-    delete_ssm_params(out_of_date_pipelines, parameter_store)
 
     output = {}
     if len(out_of_date_pipelines) > 0:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -579,7 +579,7 @@ Resources:
               },
               "MaxConcurrency": 10,
               "Next": "Success",
-              "ItemsPath": "$.pipelines_to_be_deleted"
+              "ItemsPath": "$"
             },
             "Success": {
               "Type": "Succeed"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -362,6 +362,11 @@ Resources:
                 Condition:
                   StringEquals:
                     'aws:ResourceTag/createdBy': "ADF"
+              - Effect: Allow
+                Action:
+                  - "ssm:DeleteParameter"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/deployment/*"
 
   PipelineManagementStateMachine:
     Type: "AWS::StepFunctions::StateMachine"
@@ -570,9 +575,19 @@ Resources:
                   "DeleteStack": {
                     "Type": "Task",
                     "Parameters": {
-                      "StackName.$": "$.pipeline"
+                      "StackName.$": "$.full_pipeline_name"
                     },
                     "Resource": "arn:${AWS::Partition}:states:::aws-sdk:cloudformation:deleteStack",
+                    "ResultPath": "$.cfn_delete_stack.result",
+                    "Next": "DeletePipelineParams"
+                  },
+                  "DeletePipelineParams": {
+                    "Type": "Task",
+                    "Parameters": {
+                      "Name.$": "States.Format('/deployment/{}/regions', $.pipeline_name)"
+                    },
+                    "Resource": "arn:${AWS::Partition}:states:::aws-sdk:ssm:deleteParameter",
+                    "ResultPath": "$.ssm_delete_param.result",
                     "End": true
                   }
                 }


### PR DESCRIPTION
Two blockers with the stale pipeline deletion process:

1. Fix iterating over pipelines that need to be deleted:

    **Why?**

    At the moment, the input of the State Machine invocation that is handling
    delete operations is unwrapping the `pipelines_to_be_deleted` from the input.

    While the pipeline deletion State Machine also tries to do that.

    **What?**

    Iterating over the input elements directly instead in the pipeline deletion
    State Machine.

2. Delete pipeline regions SSM Parameters after successful CloudFormation delete stack operation:

    **Why?**

    At the moment, when it determines which pipelines need to be deleted, it will
    also delete the parameters.

    However, if the deletion fails, the parameters have been deleted and it will
    not be able to detect that the stack needs to be deleted still.

    **What?**

    Moved the deletion of the SSM Parameters to the pipeline deletion state
    machine.
---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.