### PR TITLE
Fix account creation wait for bootstrap to complete

### DIFF
--- a/src/lambda_codebase/account_processing/process_account_files.py
+++ b/src/lambda_codebase/account_processing/process_account_files.py
@@ -11,6 +11,7 @@ import json
 import os
 import tempfile
 import logging
+from typing import Any, TypedDict
 import yaml
 
 from yaml.error import YAMLError
@@ -29,7 +30,21 @@ ACCOUNT_MANAGEMENT_STATEMACHINE = os.getenv(
 )
 
 
-def get_details_from_event(event: dict):
+class S3ObjectLocation(TypedDict):
+    bucket_name: str
+    key: str
+
+
+class AccountFileData(TypedDict):
+    """
+    Class used to return YAML account file data and its related
+    metadata like the execution_id of the CodePipeline that uploaded it.
+    """
+    content: Any
+    execution_id: str
+
+
+def get_details_from_event(event: dict) -> S3ObjectLocation:
     s3_details = event.get("Records", [{}])[0].get("s3")
     if not s3_details:
         raise ValueError("No S3 Event details present in event trigger")
@@ -41,33 +56,40 @@ def get_details_from_event(event: dict):
     }
 
 
-def get_file_from_s3(s3_object: dict, s3_resource: boto3.resource):
+def get_file_from_s3(
+    s3_object_location: S3ObjectLocation,
+    s3_resource: boto3.resource,
+) -> AccountFileData:
     try:
         LOGGER.debug(
-            "Reading YAML from S3: %s",
-            json.dumps(s3_object, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--"
+            "Reading YAML from S3: %s from %s",
+            s3_object_location.get('object_key'),
+            s3_object_location.get('bucket_name'),
         )
-        s3_object = s3_resource.Object(**s3_object)
+        s3_object = s3_resource.Object(**s3_object_location)
         with tempfile.TemporaryFile(mode='w+b') as file_pointer:
             s3_object.download_fileobj(file_pointer)
 
             # Move pointer to the start of the file
             file_pointer.seek(0)
 
-            return yaml.safe_load(file_pointer)
+            return {
+                "content": yaml.safe_load(file_pointer),
+                "execution_id": s3_object.metadata.get("execution_id"),
+            }
     except ClientError as error:
         LOGGER.error(
             "Failed to download %s from %s, due to %s",
-            s3_object.get('object_key'),
-            s3_object.get('bucket_name'),
+            s3_object_location.get('object_key'),
+            s3_object_location.get('bucket_name'),
             error,
         )
         raise
     except YAMLError as yaml_error:
         LOGGER.error(
             "Failed to parse YAML file: %s from %s, due to %s",
-            s3_object.get('object_key'),
-            s3_object.get('bucket_name'),
+            s3_object_location.get('object_key'),
+            s3_object_location.get('bucket_name'),
             yaml_error,
         )
         raise
@@ -89,7 +111,9 @@ def process_account(account_lookup, account):
 
 
 def process_account_list(all_accounts, accounts_in_file):
-    account_lookup = {account["Name"]: account["Id"] for account in all_accounts}
+    account_lookup = {
+        account["Name"]: account["Id"] for account in all_accounts
+    }
     processed_accounts = list(map(
         lambda account: process_account(
             account_lookup=account_lookup,
@@ -100,24 +124,43 @@ def process_account_list(all_accounts, accounts_in_file):
     return processed_accounts
 
 
-def start_executions(sfn_client, processed_account_list):
+def start_executions(
+    sfn_client,
+    processed_account_list,
+    codepipeline_execution_id: str,
+    request_id: str,
+):
+    run_id = (
+        f"{codepipeline_execution_id, 'no-exec-id'}-"
+        f"{request_id}"
+    )
     LOGGER.info(
-        "Invoking Account Management State Machine (%s)",
+        "Invoking Account Management State Machine (%s) -> %s",
         ACCOUNT_MANAGEMENT_STATEMACHINE,
+        run_id,
     )
     for account in processed_account_list:
-        LOGGER.debug(f"Payload: {account}")
+        full_account_name = account.get('account_full_name', 'no-account-name')
+        sfn_execution_name = f"{full_account_name}-{run_id}"
+
+        LOGGER.debug(
+            "Payload for %s: %s",
+            sfn_execution_name,
+            account,
+        )
         sfn_client.start_execution(
             stateMachineArn=ACCOUNT_MANAGEMENT_STATEMACHINE,
+            name=sfn_execution_name,
             input=f"{json.dumps(account)}",
         )
 
 
-def lambda_handler(event, _):
+def lambda_handler(event, context):
     """Main Lambda Entry point"""
     LOGGER.debug(
         "Processing event: %s",
-        json.dumps(event, indent=2) if LOGGER.isEnabledFor(logging.DEBUG) else "--data-hidden--"
+        json.dumps(event, indent=2) if LOGGER.isEnabledFor(logging.DEBUG)
+        else "--data-hidden--"
     )
     sfn_client = boto3.client("stepfunctions")
     s3_resource = boto3.resource("s3")
@@ -127,8 +170,13 @@ def lambda_handler(event, _):
 
     processed_account_list = process_account_list(
         all_accounts=all_accounts,
-        accounts_in_file=account_file.get("accounts"),
+        accounts_in_file=account_file.get("content", {}).get("accounts"),
     )
 
-    start_executions(sfn_client, processed_account_list)
+    start_executions(
+        sfn_client,
+        processed_account_list,
+        codepipeline_execution_id=account_file.get("execution_id"),
+        request_id=context.aws_request_id,
+    )
     return event

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -773,7 +773,7 @@ Resources:
             build:
               commands:
                 - python adf-build/helpers/sync_to_s3.py --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml
-                - python adf-build/helpers/sync_to_s3.py --extension .yml --extension .yaml  --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEBUILD_BUILD_NUMBER} --recursive deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps
+                - python adf-build/helpers/sync_to_s3.py --extension .yml --extension .yaml  --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} --recursive deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps
             post_build:
               commands:
                 - echo "Pipelines are updated in the AWS Step Functions ADFPipelineManagementStateMachine."

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
@@ -20,6 +20,8 @@ LOGGER = configure_logger(__name__)
 DEPLOYMENT_ACCOUNT_REGION = os.environ["AWS_REGION"]
 DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]
 PIPELINE_MANAGEMENT_STATEMACHINE = os.getenv("PIPELINE_MANAGEMENT_STATE_MACHINE")
+ADF_VERSION = os.getenv("ADF_VERSION")
+ADF_VERSION_METADATA_KEY = "adf_version"
 
 
 _cache = None
@@ -42,6 +44,19 @@ def get_file_from_s3(s3_details: dict, s3_resource: boto3.resource):
         s3_object = s3_resource.Object(
             s3_details.get("bucket_name"), s3_details.get("object_key")
         )
+        object_adf_version = s3_object.metadata.get(
+            ADF_VERSION_METADATA_KEY,
+            "n/a",
+        )
+        if object_adf_version != ADF_VERSION:
+            LOGGER.info(
+                "Skipping S3 object: %s as it is generated with "
+                "an older ADF version ('adf_version' metadata = '%s')",
+                s3_details,
+                object_adf_version,
+            )
+            return {}
+
         with tempfile.TemporaryFile() as file_pointer:
             s3_object.download_fileobj(file_pointer)
 
@@ -88,6 +103,7 @@ def lambda_handler(event, _):
     sfn_client = boto3.client("stepfunctions")
     s3_details = get_details_from_event(event)
     deployment_map = get_file_from_s3(s3_details, s3_resource)
-    deployment_map["definition_bucket"] = s3_details.get("object_key")
-    start_executions(sfn_client, deployment_map)
+    if deployment_map:
+        deployment_map["definition_bucket"] = s3_details.get("object_key")
+        start_executions(sfn_client, deployment_map)
     return output

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -10,8 +10,8 @@ import os
 import sys
 import time
 from math import floor
-from thread import PropagatingThread
 from datetime import datetime
+from thread import PropagatingThread
 
 import boto3
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
@@ -127,6 +127,7 @@ import hashlib
 import logging
 import base64
 import boto3
+from botocore.exceptions import ClientError
 from docopt import docopt
 
 
@@ -496,7 +497,9 @@ def _get_s3_object_data(s3_client, s3_bucket, key):
             "key": key,
             "metadata": obj_data.get("Metadata", {}),
         }
-    except s3_client.exceptions.NoSuchKey:
+    except ClientError as client_error:
+        if int(client_error.response["Error"]["Code"]) != 404:
+            raise
         LOGGER.debug(
             "Could not find s3://%s/%s",
             s3_bucket,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
@@ -23,6 +23,41 @@ Usage:
 
     sync_to_s3.py --version
 
+Arguments:
+    SOURCE_PATH
+                The source path where the original files are stored that should
+                by synced to the destination bucket. When you specify a
+                directory as the source path it will copy the files inside the
+                directory to the S3 bucket if you also specify the recursive
+                flag. Otherwise it will treat the source path as a file, when a
+                directory is detected instead it will abort with an error.
+                If the source path is a directory, the object keys that are
+                derived from the files inside the directory will be relative to
+                the <source_path>. For example, if the <source_path> equals
+                `./adf-accounts`, which contains a file named
+                `adf-accounts/adf.yml`, it will copy the file as `adf.yml`.
+                If the prefix of the s3 bucket is set to `adf-s3-accounts`, the
+                final key of that specific file will be:
+                `adf-s3-accounts/adf.yml`.
+                If the <source_path> is a file and
+                the recursive flag is not specified, it will expect that the
+                s3 prefix is the new object name instead. In this case, if
+                <source_path> equals `./deployment_map.yml` and the s3 prefix
+                is `root_deployment_map.yml`, it will copy the file to the s3
+                prefix key.
+
+    DESTINATION_S3_URL
+                The destination bucket and its prefix where the files should be
+                copied to. The s3 bucket and its optional prefix should be
+                specified as: s3://your-bucket-name/your-optional-prefix.
+                In this case, `your-bucket-name` is the name of the bucket.
+                While `your-optional-prefix` is the name of the prefix used for
+                all files that are copied to S3. If a directory is copied, i.e.
+                recursive is set, it will prepend the prefix to the object
+                keys of the files that are synced. If a file is copied instead,
+                i.e. no --recurdive, it will use the s3 prefix as the target
+                object key to use for that file.
+
 Options:
     -d, --delete
                 Delete stale files that are located in the destination bucket
@@ -66,40 +101,6 @@ Options:
     -v, --verbose
                 Show verbose logging information.
 
-    <source_path>
-                The source path where the original files are stored that should
-                by synced to the destination bucket. When you specify a
-                directory as the source path it will copy the files inside the
-                directory to the S3 bucket if you also specify the recursive
-                flag. Otherwise it will treat the source path as a file, when a
-                directory is detected instead it will abort with an error.
-                If the source path is a directory, the object keys that are
-                derived from the files inside the directory will be relative to
-                the <source_path>. For example, if the <source_path> equals
-                `./adf-accounts`, which contains a file named
-                `adf-accounts/adf.yml`, it will copy the file as `adf.yml`.
-                If the prefix of the s3 bucket is set to `adf-s3-accounts`, the
-                final key of that specific file will be:
-                `adf-s3-accounts/adf.yml`.
-                If the <source_path> is a file and
-                the recursive flag is not specified, it will expect that the
-                s3 prefix is the new object name instead. In this case, if
-                <source_path> equals `./deployment_map.yml` and the s3 prefix
-                is `root_deployment_map.yml`, it will copy the file to the s3
-                prefix key.
-
-    <destination_s3_url>
-                The destination bucket and its prefix where the files should be
-                copied to. The s3 bucket and its optional prefix should be
-                specified as: s3://your-bucket-name/your-optional-prefix.
-                In this case, `your-bucket-name` is the name of the bucket.
-                While `your-optional-prefix` is the name of the prefix used for
-                all files that are copied to S3. If a directory is copied, i.e.
-                recursive is set, it will prepend the prefix to the object
-                keys of the files that are synced. If a file is copied instead,
-                i.e. no --recurdive, it will use the s3 prefix as the target
-                object key to use for that file.
-
 Examples:
 
     Copy the deployment_map.yml file to an S3 bucket as
@@ -115,17 +116,6 @@ Examples:
 
         $ python sync_to_s3.py -d -e .yml -r deployment_maps \\
             s3://deploy-bucket/deployment_maps
-
-    Copy all .yml files from folder source_folder to the to an S3 bucket where
-    the objects are prefixed with the `object_folder/`, deleting the .yml
-    objects inside the YAML files that no longer exist locally. Additionally,
-    all files will get the metadata set to include `adf_version`. And if the
-    file is uploaded/updated, it will also apply the `execution_id` metadata.
-
-        $ python sync_to_s3.py -d -e .yml -r source_folder \\
-            --metadata "adf_version=x.y.z" \\
-            --upload-with-metadata "execution_id=$EXEC_ID" \\
-            s3://deploy-bucket/object_folder
 """
 
 import os

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/tests/test_sync_to_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/tests/test_sync_to_s3.py
@@ -7,6 +7,7 @@ import pytest
 from base64 import b64encode
 from hashlib import sha256
 import tempfile
+from botocore.exceptions import ClientError
 from sync_to_s3 import *
 
 # pylint: skip-file
@@ -375,8 +376,14 @@ def test_get_s3_objects_non_recursive_missing_object():
     s3_object_key = f"{S3_PREFIX}/missing-file.yml"
     file_extensions = []
 
-    s3_client.exceptions.NoSuchKey = Exception
-    s3_client.head_object.side_effect = s3_client.exceptions.NoSuchKey()
+    s3_client.head_object.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": 404,
+            },
+        },
+        "HeadObject",
+    )
 
     assert get_s3_objects(
         s3_client,

--- a/src/template.yml
+++ b/src/template.yml
@@ -1299,6 +1299,9 @@ Resources:
                 - aws s3 sync . s3://$S3_BUCKET --quiet --delete
                 # Upload account files to the ACCOUNT_BUCKET
                 - python adf-build/shared/helpers/sync_to_s3.py --extension .yml --extension .yaml --metadata adf_version=${ADF_VERSION} --upload-with-metadata execution_id=${CODEPIPELINE_EXECUTION_ID} --recursive adf-accounts s3://$ACCOUNT_BUCKET
+                # Sleep for 10 seconds so the state machine is able to kick start the processing
+                # of these newly uploaded files if any.
+                - sleep 10
                 # Updates config, updates (or creates) base stacks:
                 - python adf-build/main.py
         Type: CODEPIPELINE

--- a/src/template.yml
+++ b/src/template.yml
@@ -1284,7 +1284,7 @@ Resources:
                 python: 3.9
             pre_build:
               commands:
-                - pip install -r adf-build/requirements.txt --quiet
+                - pip install -r adf-build/requirements.txt -r adf-build/shared/helpers/requirements.txt --quiet
                 - pytest -vvv
             build:
               commands:

--- a/src/template.yml
+++ b/src/template.yml
@@ -1171,6 +1171,12 @@ Resources:
             Resource: "*"
           - Effect: "Allow"
             Action:
+              - "states:ListExecutions"
+            Resource:
+              - !Ref AccountManagementStateMachine
+              - !Ref AccountBootstrappingStateMachine
+          - Effect: "Allow"
+            Action:
               - "cloudformation:CreateStack"
               - "cloudformation:DescribeChangeSet"
               - "cloudformation:DeleteStack"
@@ -1262,6 +1268,10 @@ Resources:
             Value: !GetAtt Organization.OrganizationId
           - Name: ADF_LOG_LEVEL
             Value: !Ref LogLevel
+          - Name: ACCOUNT_MANAGEMENT_STATE_MACHINE_ARN
+            Value: !Ref AccountManagementStateMachine
+          - Name: ACCOUNT_BOOTSTRAPPING_STATE_MACHINE_ARN
+            Value: !Ref AccountBootstrappingStateMachine
         Type: LINUX_CONTAINER
       Name: "aws-deployment-framework-base-templates"
       ServiceRole: !Ref BootstrapCodeBuildRole


### PR DESCRIPTION
This PR implements steps 2 to 4 of issue #518. Since all these code changes are related, I put them in one PR:

1. Forward CodePipeline Execution Id to Account Mgmt Creation SFN

    Step 2 of fixing #518.

    **Why?**

    As explained in #518, we need to forward the execution id of the CodePipeline
    that triggered the Account Management state machine so we can wait for to
    complete.

    **What?**

    Adding the CodePipeline execution identifier to the Step Functions
    State Machine invocation to enable tracing state machines in progress at
    CodeBuild execution time.

2. Only process account and deployment maps generated by same ADF version

    **Why?**

    When an account file or deployment map is updated, it should only be processed
    when the version equals the current ADF version. Otherwise it should skip the
    file.

    This will ensure we don't get into compatibility issues, where a file structure
    update will make the processing of the file fail.

    **What?**

    Checking the version number attached to the S3 object metadata against the
    current ADF version number. If those mismatch, it will skip the file.
    
3. Minor updates to sync_to_s3.py:
    * Update docstring help to include the arguments correctly.
    * Update helper requirements to be installed when sync_to_s3.py is called.
    * Use CodePipeline execution id instead of CodeBuild for sync_to_s3 ops.
    * Catch low-level error thrown by S3 Head Object.
    
4. Await SFN executions before bootstrapping continues

    **Why?**

    As described in issue #518, the bootstrap pipeline fails to perform the main.py
    code when the account creation or bootstrapping process is still in progress.

    **What?**

    The code changes ensure the script will wait for any Step Function executions
    that are triggered by the sync_to_s3.py process. It will wait for 30 seconds in
    a loop until they succeeded.
    
5. Abort bootstrap pipeline when SFN error occurred

    **Why?**

    As the account management and bootstrapping steps are performed in Step
    Function State Machines, the errors might not be noticed until a follow-up error
    occurs when trying to interact with one of the failing accounts.

    **What?**

    Modified the bootstrap pipeline to check if these state machines do not have
    any aborted, timed out, or failed executions. If they do, it will log the error
    and instruct the user to look into the fault first.
    
---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
