### PR TITLE
Fix account bootstrap on OU move

### DIFF
--- a/src/template.yml
+++ b/src/template.yml
@@ -1049,7 +1049,7 @@ Resources:
             - MoveAccount
       Targets:
         - Arn: !Ref AccountBootstrappingStateMachine
-          RoleArn: !GetAtt StatesExecutionRole.Arn
+          RoleArn: !GetAtt AccountBootstrapStartExecutionRole.Arn
           Id: CreateStackLinkedAccountV1
 
   CodeCommitRole:
@@ -1428,8 +1428,6 @@ Resources:
           - Effect: "Allow"
             Principal:
               Service:
-                - events.amazonaws.com
-                - lambda.amazonaws.com
                 - states.amazonaws.com
             Action: "sts:AssumeRole"
       Path: "/aws-deployment-framework/account-bootstrapping/"
@@ -1441,7 +1439,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - "lambda:InvokeFunction"
-                  - "states:StartExecution"
                 Resource:
                   - !GetAtt DetermineEventFunction.Arn
                   - !GetAtt CrossAccountExecuteFunction.Arn
@@ -1449,6 +1446,29 @@ Resources:
                   - !GetAtt StackWaiterFunction.Arn
                   - !GetAtt RoleStackDeploymentFunction.Arn
                   - !GetAtt UpdateResourcePoliciesFunction.Arn
+
+  AccountBootstrapStartExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: "/aws-deployment-framework/account-bootstrapping/"
+      Policies:
+        - PolicyName: "adf-start-state-machine"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "states:StartExecution"
+                Resource:
+                  - !Ref AccountBootstrappingStateMachine
 
   AccountBootstrappingStateMachine:
     Type: "AWS::StepFunctions::StateMachine"


### PR DESCRIPTION
## Why?

When you move an account from the root to an organization unit (OU), an event is emitted that should trigger the Account Bootstrap state machine.

However, the task role that was configured did not have the necessary permissions to invoke the state machine.

## What?

A new role is created that will enable the event to trigger the Account Bootstrap state machine.

While investigating the issue, it was also noticed that the original task role had permissions that were no longer required. Those stale permissions are removed too.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
