### PR TITLE
Add account creation in progress retry logic

### DIFF
--- a/src/lambda_codebase/account_bootstrap.py
+++ b/src/lambda_codebase/account_bootstrap.py
@@ -13,7 +13,11 @@ import boto3
 
 from botocore.exceptions import ClientError
 from logger import configure_logger
-from errors import GenericAccountConfigureError, ParameterNotFoundError
+from errors import (
+    AccountCreationNotFinishedError,
+    GenericAccountConfigureError,
+    ParameterNotFoundError,
+)
 from parameter_store import ParameterStore
 from cloudformation import CloudFormation
 from s3 import S3
@@ -109,6 +113,17 @@ def is_inter_ou_account_move(event):
 
 
 def lambda_handler(event, context):
+    try:
+        return _lambda_handler(event, context)
+    except ClientError as error:
+        if error.response['Error']['Code'] == 'SubscriptionRequiredException':
+            raise AccountCreationNotFinishedError(
+                f"The AWS Account is not ready yet. Error thrown: {error}"
+            ) from error
+        raise
+
+
+def _lambda_handler(event, context):
     sts = STS()
 
     account_id = event["account_id"]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -372,9 +372,10 @@ def _sfn_execution_exists_with(
         )
         if filtered:
             LOGGER.info(
-                "Found %d state machine %s that are running.",
+                "Found %d state machine %s that %s running.",
                 len(filtered),
                 "executions" if len(filtered) > 1 else "execution",
+                "are" if len(filtered) > 1 else "is",
             )
             return True
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/errors.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/errors.py
@@ -41,6 +41,15 @@ class GenericAccountConfigureError(Exception):
     pass
 
 
+class AccountCreationNotFinishedError(Exception):
+    """
+    When we interact with a Boto3 API call and it fails with the
+    SubscriptionRequiredException error code. This implies that the
+    account is still being created behind the scenes. To ease troubleshooting
+    we raise this Exception class instead. To clarify what is happening.
+    """
+
+
 class RootOUIDError(Exception):
     """
     Raised when an account is moved to the root of the organization

--- a/src/template.yml
+++ b/src/template.yml
@@ -1511,6 +1511,13 @@ Resources:
                   "MaxAttempts": 45
                 }, {
                   "ErrorEquals": [
+                    "AccountCreationNotFinishedError"
+                  ],
+                  "IntervalSeconds": 10,
+                  "BackoffRate": 1.1,
+                  "MaxAttempts": 45
+                }, {
+                  "ErrorEquals": [
                     "Lambda.Unknown",
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",


### PR DESCRIPTION
Issue: #519.

## Why?

When an account is created, the API call will return but behind the scenes the process to provision the account fully is still in progress.

When the account bootstrap process tries to on-board one of these newly created accounts, it will fail with a `SubscriptionRequiredException` being thrown.

This will cause the account bootstrap process to fail.

## What?

Introducing a new error class: `AccountCreationNotFinishedError`. This is added to explain what the `SubscriptionRequiredException` implies.

The Step Function that performs the Account Bootstrap process will catch the error and retry several times with a longer duration in between intervals to ensure the system has sufficient time to create the account.

Plus one minor change to the `main.py` wait for state machine message.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
