### PR TITLE
Add retries to account bootstrap process

### DIFF
--- a/src/template.yml
+++ b/src/template.yml
@@ -981,7 +981,7 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: CrossAccountExecuteFunction
       Role: !GetAtt LambdaRole.Arn
-      Timeout: 600
+      Timeout: 900
 
   RoleStackDeploymentFunction:
     Type: "AWS::Serverless::Function"
@@ -1515,7 +1515,8 @@ Resources:
                     "Lambda.ServiceException",
                     "Lambda.AWSLambdaException",
                     "Lambda.SdkClientException",
-                    "Lambda.TooManyRequestsException"
+                    "Lambda.TooManyRequestsException",
+                    "States.Timeout"
                   ],
                   "IntervalSeconds": 2,
                   "BackoffRate": 2,
@@ -1530,7 +1531,7 @@ Resources:
                 }
               ],
               "Next": "WaitUntilBootstrapComplete",
-              "TimeoutSeconds": 600
+              "TimeoutSeconds": 900
             },
             "MovedToRootAction": {
               "Type": "Task",


### PR DESCRIPTION
## Why?

Bootstrapping the deployment account can take long. After which it runs out of time in the Lambda function that is creating the bootstrap stacks failing the state machine execution.

## What?

Added retry logic to the state machine invoking the `CrossAccountExecuteFunction` Lambda.

Increased timeout for the `CrossAccountExecuteFunction` Lambda function and its invocation step in the state machine to 900 seconds.

Upon a retry, it needs to be able to recover and continue gracefully. Hence a waiter is added to wait for the current in progress execution until that is finished before attempting to create/update it again.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
