### PR TITLE
Fix initial commit on fresh install

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
@@ -251,11 +251,14 @@ def generate_commits(event, repo_name, directory, parent_commit_id=None):
     version = event.ResourceProperties.Version
     default_branch_name = event.ResourceProperties.DefaultBranchName
     branch_name = version
-    CC_CLIENT.create_branch(
-        repositoryName=repo_name,
-        branchName=branch_name,
-        commitId=parent_commit_id
-    )
+    if parent_commit_id:
+        CC_CLIENT.create_branch(
+            repositoryName=repo_name,
+            branchName=branch_name,
+            commitId=parent_commit_id,
+        )
+    else:
+        branch_name = default_branch_name
 
     # CodeCommit only allows 100 files per commit, so we chunk them up here
     files_to_commit = get_files_to_commit(directory_path)
@@ -310,23 +313,24 @@ def generate_commits(event, repo_name, directory, parent_commit_id=None):
             ):
                 pass
 
-    if commits_created:
-        CC_CLIENT.create_pull_request(
-            title=f'ADF {version} Automated Update PR',
-            description=PR_DESCRIPTION.format(version),
-            targets=[
-                {
-                    'repositoryName': repo_name,
-                    'sourceReference': branch_name,
-                    'destinationReference': default_branch_name,
-                },
-            ],
-        )
-    else:
-        CC_CLIENT.delete_branch(
-            repositoryName=repo_name,
-            branchName=branch_name,
-        )
+    if branch_name != default_branch_name:
+        if commits_created:
+            CC_CLIENT.create_pull_request(
+                title=f'ADF {version} Automated Update PR',
+                description=PR_DESCRIPTION.format(version),
+                targets=[
+                    {
+                        'repositoryName': repo_name,
+                        'sourceReference': branch_name,
+                        'destinationReference': default_branch_name,
+                    },
+                ],
+            )
+        else:
+            CC_CLIENT.delete_branch(
+                repositoryName=repo_name,
+                branchName=branch_name,
+            )
 
     return commits_created
 


### PR DESCRIPTION
## Why?

When the repository is created, there are no commits in the repository yet. The process tried to create a branch where the parent commit id was empty. This is not allowed.

## What?

Instead, it should only create the branch when there is a commit to branch off from. Otherwise it should only create the new commits on the main branch directly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
