### PR TITLE
Fix store ADF config before it needs to be read the first time

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -390,7 +390,6 @@ def main():  # pylint: disable=R0915
 
     policies = OrganizationPolicy()
     config = Config()
-    config.store_config()
 
     try:
         parameter_store = ParameterStore(REGION_DEFAULT, boto3)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/store_config.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/store_config.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Store config entry point for storing the adfconfig.yml configuration
+into the Parameter Store such that the bootstrapping and account management
+steps can execute correctly when triggered.
+
+This gets executed from within AWS CodeBuild in the management account.
+"""
+import os
+from config import Config
+from logger import configure_logger
+
+ADF_VERSION = os.environ["ADF_VERSION"]
+ADF_LOG_LEVEL = os.environ["ADF_LOG_LEVEL"]
+LOGGER = configure_logger(__name__)
+
+
+def main():
+    """
+    Main entry point to store the configuration into AWS Systems
+    Manager Parameter Store
+    """
+    LOGGER.info("ADF Version %s", ADF_VERSION)
+    LOGGER.info("ADF Log Level is %s", ADF_LOG_LEVEL)
+
+    LOGGER.info(
+        "Storing configuration values in AWS Systems Manager Parameter Store."
+    )
+    config = Config()
+    config.store_config()
+    LOGGER.info("Configuration values stored successfully.")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/template.yml
+++ b/src/template.yml
@@ -1293,6 +1293,7 @@ Resources:
                 - >-
                     sam package --output-template-file adf-bootstrap/deployment/global.yml
                     --s3-prefix adf-bootstrap/deployment --s3-bucket $DEPLOYMENT_ACCOUNT_BUCKET
+                - python adf-build/store_config.py
                 # Shared Modules to be used with AWS CodeBuild:
                 - aws s3 sync ./adf-build/shared s3://$DEPLOYMENT_ACCOUNT_BUCKET/adf-build --quiet
                 # Base templates:


### PR DESCRIPTION
## Why?

After deploying ADF for the first time, it will need to store the `adfconfig.yml` values in the AWS Systems Manager Parameter Store. Such that the logic inside the account bootstrap and account management state machines can execute correctly.

At the moment, the config is written after the Step Functions are triggered by syncing account configurations to S3. This will fail on the read of the `config` parameter.

## What?

Adding another step that will only store the configuration values in the ADF Bootstrap CodeBuild execution. Before it copies the files that would trigger the account management and account bootstrapping state machines.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
