### PR TITLE
Trigger pipeline regeneration upon organization changes

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -514,6 +514,11 @@ Resources:
               - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${PipelinePrefix}*
           - Effect: Allow
             Action:
+              - "codepipeline:ListPipelineExecutions"
+            Resource:
+              - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:aws-deployment-framework-pipelines
+          - Effect: Allow
+            Action:
               - "codestar-connections:GetConnection"
               - "codestar-connections:GetHost"
               - "codestar-connections:ListConnections"
@@ -775,8 +780,9 @@ Resources:
                 - mkdir -p deployment_maps
             build:
               commands:
-                - python adf-build/helpers/sync_to_s3.py --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml
-                - python adf-build/helpers/sync_to_s3.py --extension .yml --extension .yaml  --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} --recursive deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps
+                - python adf-build/helpers/describe_codepipeline_trigger.py --should-match StartPipelineExecution aws-deployment-framework-pipelines ${!CODEPIPELINE_EXECUTION_ID} && EXTRA_OPTS="--force" || EXTRA_OPTS=""
+                - python adf-build/helpers/sync_to_s3.py ${!EXTRA_OPTS} --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml
+                - python adf-build/helpers/sync_to_s3.py ${!EXTRA_OPTS} --extension .yml --extension .yaml  --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} --recursive deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps
             post_build:
               commands:
                 - echo "Pipelines are updated in the AWS Step Functions ADFPipelineManagementStateMachine."

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/describe_codepipeline_trigger.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/describe_codepipeline_trigger.py
@@ -1,0 +1,155 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+Describe CodePipeline trigger.
+
+This script will retrieve the trigger for the given CodePipeline execution.
+It also allows you to match it against a specific trigger that you expect and
+return an exit code if it did not match.
+
+Usage:
+    describe_codepipeline_trigger.py
+            [--should-match <trigger_type>]
+            [--json]
+            [-v... | --verbose...]
+            CODEPIPELINE_NAME
+            EXECUTION_ID
+
+    describe_codepipeline_trigger.py -h | --help
+
+    describe_codepipeline_trigger.py --version
+
+Arguments:
+    CODEPIPELINE_NAME
+                The CodePipeline name of the pipeline to check.
+
+    EXECUTION_ID
+                The CodePipeline Execution Id that we want to check.
+
+Options:
+    -h, --help  Show this help message.
+
+    --json      Return the trigger type and details as a JSON object.
+                An example object:
+                {
+                    "trigger_type": "StartPipelineExecution or other",
+                    "trigger_detail": "..."
+                }
+
+    --should-match <trigger_type>
+                When set, it will stop with exit code 0 if it matches the
+                expected trigger. If it does not match the trigger, it will
+                stop with exit code 1.
+                Trigger type can be: 'CreatePipeline',
+                'StartPipelineExecution', 'PollForSourceChanges', 'Webhook',
+                'CloudWatchEvent', or 'PutActionRevision'.
+
+    -v, --verbose
+                Show verbose logging information.
+"""
+
+import os
+import sys
+from typing import Any, Optional, TypedDict
+import json
+import logging
+import boto3
+from docopt import docopt
+
+
+ADF_VERSION = os.environ.get("ADF_VERSION")
+ADF_LOG_LEVEL = os.environ.get("ADF_LOG_LEVEL", "INFO")
+
+logging.basicConfig(level=logging.ERROR)
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(ADF_LOG_LEVEL)
+
+
+class TriggerData(TypedDict):
+    """
+    Trigger Data Class.
+    """
+    trigger_type: str
+    trigger_detail: str
+
+
+def fetch_codepipeline_execution_trigger(
+    cp_client: Any,
+    codepipeline_name: str,
+    execution_id: str,
+) -> Optional[TriggerData]:
+    """
+    Fetch the CodePipeline Execution Trigger that matches
+    the requested parameters.
+
+    Args:
+        cp_client (boto3.client): The CodePipeline Boto3 client.
+
+        codepipeline_name (str): The CodePipeline name.
+
+        execution_id (str): The CodePipeline Execution id.
+
+    Returns:
+        TriggerData: The trigger type and trigger detail if found.
+
+        None: if it was not found.
+    """
+    paginator = cp_client.get_paginator('list_pipeline_executions')
+    response_iterator = paginator.paginate(pipelineName=codepipeline_name)
+    for page in response_iterator:
+        for execution in page['pipelineExecutionSummaries']:
+            if execution['pipelineExecutionId'] == execution_id:
+                return {
+                    "trigger_type": execution['trigger']['triggerType'],
+                    "trigger_detail": execution['trigger']['triggerDetail'],
+                }
+    return None
+
+
+def main():
+    """Main function to describe the codepipeline trigger """
+    options = docopt(__doc__, version=ADF_VERSION, options_first=True)
+
+    # In case the user asked for verbose logging, increase
+    # the log level to debug.
+    if options["--verbose"] > 0:
+        LOGGER.setLevel(logging.DEBUG)
+    if options["--verbose"] > 1:
+        logging.basicConfig(level=logging.INFO)
+    if options["--verbose"] > 2:
+        # Also enable DEBUG mode for other libraries, like boto3
+        logging.basicConfig(level=logging.DEBUG)
+
+    LOGGER.debug("Input arguments: %s", options)
+
+    codepipeline_name = options.get('CODEPIPELINE_NAME')
+    execution_id = options.get('EXECUTION_ID')
+    should_match_type = options.get('--should-match')
+    output_in_json = options.get('--json')
+
+    cp_client = boto3.client("codepipeline")
+    trigger = fetch_codepipeline_execution_trigger(
+        cp_client,
+        codepipeline_name,
+        execution_id,
+    )
+
+    if trigger is None:
+        LOGGER.error(
+            "Could not find execution %s in the %s pipeline.",
+            execution_id,
+            codepipeline_name,
+        )
+        sys.exit(2)
+
+    if output_in_json:
+        print(json.dumps(trigger))
+    else:
+        print(trigger['trigger_type'])
+
+    if should_match_type and trigger['trigger_type'] != should_match_type:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why?

As described in issue #549. When an account is moved in or out of an organization unit (OU), the pipelines that include that OU are not updated accordingly.

## What?

By checking the type of trigger that started this CodePipeline execution, it will force the upload process of the deployment map files when the pipeline was triggered using a StartPipelineExecution API Call. As these are used when the pipeline is instructed to start by a Lambda function that detected an organization unit change.

* Add support for --force to the `sync_to_s3.py` helper.
* Add `describe_codepipeline_trigger.py` helper to fetch the trigger type of a specific execution.
* Set the `--force` as `$EXTRA_OPTS` that are passed to the `sync_to_s3.py` helper if needed.
* Allow `aws-deployment-framework-pipelines` CodeBuild container to fetch the `aws-deployment-framework-pipelines` executions.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
