### PR TITLE
Fix syncing to S3 without a prefix

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
@@ -416,7 +416,9 @@ def _get_recursive_s3_objects(
     s3_list_objects_paginator = s3_client.get_paginator("list_objects_v2")
     s3_object_iterator = s3_list_objects_paginator.paginate(
         Bucket=s3_bucket,
-        Prefix=f"{s3_prefix}/",
+        Prefix=(
+            f"{s3_prefix}/" if s3_prefix else ""
+        ),
     )
     s3_objects = {}
     for response_data in s3_object_iterator:


### PR DESCRIPTION
## Why?

When the `sync_to_s3.py` script is asked to sync files without a prefix set, it will instruct the S3 list-objects-v2 API to list all objects with the prefix `"/"`. This does not return anything. Hence the script thinks it needs to upload the files as they are missing.

## What?

* Added logic to only add the prefix if set.
* Added test to validate that the lookup without a prefix works as instructed.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
