### PR TITLE
Add clean-up of stale deployment map files in the pipeline bucket

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -387,6 +387,8 @@ Resources:
               - s3:GetBucketPolicy
               - s3:List*
               - s3:PutObject
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
             Resource:
               - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}
               - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}/*
@@ -805,8 +807,8 @@ Resources:
             build:
               commands:
                 - python adf-build/helpers/describe_codepipeline_trigger.py --should-match StartPipelineExecution aws-deployment-framework-pipelines ${!CODEPIPELINE_EXECUTION_ID} && EXTRA_OPTS="--force" || EXTRA_OPTS=""
-                - python adf-build/helpers/sync_to_s3.py ${!EXTRA_OPTS} --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml
-                - python adf-build/helpers/sync_to_s3.py ${!EXTRA_OPTS} --extension .yml --extension .yaml  --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} --recursive deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps
+                - python adf-build/helpers/sync_to_s3.py ${!EXTRA_OPTS} --delete --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} deployment_map.yml s3://$ADF_PIPELINES_BUCKET/deployment_map.yml
+                - python adf-build/helpers/sync_to_s3.py ${!EXTRA_OPTS} --delete --extension .yml --extension .yaml  --metadata adf_version=${!ADF_VERSION} --upload-with-metadata execution_id=${!CODEPIPELINE_EXECUTION_ID} --recursive deployment_maps s3://$ADF_PIPELINES_BUCKET/deployment_maps
             post_build:
               commands:
                 - echo "Pipelines are updated in the AWS Step Functions ADFPipelineManagementStateMachine."


### PR DESCRIPTION
## Why?

The identify-out-of-date-pipelines process will iterate over the S3 files and delete the stale pipelines that are no longer defined.

However, if you delete a deployment map file, the old deployment map would still exist in the pipelines bucket. Which will put the identify-out-of-date-pipeline process in the wrong direction, as it will think that these pipelines are still active.

## What?

Instructing the sync to S3 process to delete stale files in the S3 bucket, so deleted deployment map files are also deleted in the pipeline bucket.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
