### PR TITLE
Add support for CodeStar CodeBuild clone ref and update CodeStar setup

### DIFF
--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -211,6 +211,11 @@ Provider type: `codestar`.
     web hook as part of the pipeline. Read the CodeStar Connections
     documentation for more
     [information](https://docs.aws.amazon.com/dtconsole/latest/userguide/connections.html).
+- *output_artifact_format* - *(String)* default: `CODE_ZIP`
+  - The output artifact format. Values can be either `CODEBUILD_CLONE_REF` or
+    `CODE_ZIP`. If unspecified, the default is `CODE_ZIP`.
+  - NB: The `CODEBUILD_CLONE_REF` value can only be used by CodeBuild
+    downstream actions.
 
 ## Build
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
@@ -73,9 +73,9 @@ def lambda_handler(event, _):
         )
     parameter_store = ParameterStore(DEPLOYMENT_ACCOUNT_REGION, boto3)
     current_pipelines = {
-            parameter.get("Name").split("/")[-2]
-            for parameter in get_current_pipelines(parameter_store)
-        }
+        parameter.get("Name").split("/")[-2]
+        for parameter in get_current_pipelines(parameter_store)
+    }
 
     pipeline_names = {
         p.get("name") for p in deployment_map.map_contents["pipelines"]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -819,6 +819,15 @@ Resources:
                 Resource:
                   - !Sub arn:${AWS::Partition}:iam::*:role/*
               - Effect: Allow
+                Sid: "AllowCodeStarConnection"
+                Action:
+                  - "codestar-connections:PassConnection"
+                Resource:
+                  - !Sub arn:${AWS::Partition}:codestar-connections:${AWS::Region}:${AWS::AccountId}:connection/*
+                Condition:
+                  StringEquals:
+                    'codestar-connections:PassedToService': 'codepipeline.amazonaws.com'
+              - Effect: Allow
                 Action:
                   - "events:PutRule"
                   - "events:PutTargets"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
@@ -12,7 +12,7 @@ LOGGER = configure_logger(__name__)
 
 NOTIFICATION_PROPS = {
     Optional("target"): str,
-    Optional("type") : Or("lambda", "chat_bot")
+    Optional("type"): Or("lambda", "chat_bot")
 }
 
 # Pipeline Params
@@ -47,6 +47,12 @@ AWS_ACCOUNT_ID_SCHEMA = Schema(
     )
 )
 
+SOURCE_OUTPUT_ARTIFACT_FORMAT = Or(
+    "CODEBUILD_CLONE_REF",
+    "CODE_ZIP",
+    None,
+)
+
 # CodeCommit Source
 CODECOMMIT_SOURCE_PROPS = {
     "account_id": AWS_ACCOUNT_ID_SCHEMA,
@@ -56,7 +62,9 @@ CODECOMMIT_SOURCE_PROPS = {
     Optional("owner"): str,
     Optional("role"): str,
     Optional("trigger_on_changes"): bool,
-    Optional("output_artifact_format", default=None): Or("CODEBUILD_CLONE_REF", "CODE_ZIP", None)
+    Optional("output_artifact_format", default=None): (
+        SOURCE_OUTPUT_ARTIFACT_FORMAT
+    ),
 }
 CODECOMMIT_SOURCE = {
     "provider": 'codecommit',
@@ -82,7 +90,10 @@ CODESTAR_SOURCE_PROPS = {
     Optional("repository"): str,
     Optional("branch"): str,
     "owner": str,
-    "codestar_connection_path": str
+    "codestar_connection_path": str,
+    Optional("output_artifact_format", default=None): (
+        SOURCE_OUTPUT_ARTIFACT_FORMAT
+    ),
 }
 
 CODESTAR_SOURCE = {
@@ -114,7 +125,9 @@ CODEBUILD_PROPS = {
     Optional("image"): Or(str, CODEBUILD_IMAGE_PROPS),
     Optional("size"): Or('small', 'medium', 'large'),
     Optional("spec_filename"): str,
-    Optional("environment_variables"): {Optional(str): Or(str, bool, int, object)},
+    Optional("environment_variables"): {
+        Optional(str): Or(str, bool, int, object)
+    },
     Optional("role"): str,
     Optional("timeout"): int,
     Optional("privileged"): bool,
@@ -273,7 +286,8 @@ PROVIDER_SCHEMA = {
             'provider': Or('codecommit', 'github', 's3', 'codestar'),
             'properties': dict,
         },
-        lambda x: PROVIDER_SOURCE_SCHEMAS[x['provider']].validate(x),  #pylint: disable=W0108
+        # pylint: disable=W0108
+        lambda x: PROVIDER_SOURCE_SCHEMAS[x['provider']].validate(x),
     ),
     Optional('build'): And(
         {
@@ -281,7 +295,10 @@ PROVIDER_SCHEMA = {
             Optional('enabled'): bool,
             Optional('properties'): dict,
         },
-        lambda x: PROVIDER_BUILD_SCHEMAS[x.get('provider', 'codebuild')].validate(x),  #pylint: disable=W0108
+        # pylint: disable=W0108
+        lambda x: PROVIDER_BUILD_SCHEMAS[
+            x.get('provider', 'codebuild')
+        ].validate(x),
     ),
     Optional('deploy'): And(
         {
@@ -292,7 +309,8 @@ PROVIDER_SCHEMA = {
             Optional('enabled'): bool,
             Optional('properties'): dict,
         },
-        lambda x: PROVIDER_DEPLOY_SCHEMAS[x['provider']].validate(x),  #pylint: disable=W0108
+        # pylint: disable=W0108
+        lambda x: PROVIDER_DEPLOY_SCHEMAS[x['provider']].validate(x),
     ),
 }
 REGION_SCHEMA = Or(
@@ -313,11 +331,31 @@ TARGET_WAVE_SCHEME = {
 
 TARGET_SCHEMA = {
     Optional("path"): Or(str, int, TARGET_LIST_SCHEMA),
-    Optional("tags"): {And(str, Regex(r"\A.{1,128}\Z")): And(str, Regex(r"\A.{0,256}\Z"))},
+    Optional("tags"): {
+        And(str, Regex(r"\A.{1,128}\Z")): And(str, Regex(r"\A.{0,256}\Z"))
+    },
     Optional("target"): Or(str, int, TARGET_LIST_SCHEMA),
     Optional("name"): str,
-    Optional("provider"): Or('lambda', 's3', 'codedeploy', 'cloudformation', 'service_catalog', 'approval', 'codebuild', 'jenkins'),
-    Optional("properties"): Or(CODEBUILD_PROPS, JENKINS_PROPS, CLOUDFORMATION_PROPS, CODEDEPLOY_PROPS, S3_DEPLOY_PROPS, SERVICECATALOG_PROPS, LAMBDA_PROPS, APPROVAL_PROPS),
+    Optional("provider"): Or(
+        'lambda',
+        's3',
+        'codedeploy',
+        'cloudformation',
+        'service_catalog',
+        'approval',
+        'codebuild',
+        'jenkins',
+    ),
+    Optional("properties"): Or(
+        CODEBUILD_PROPS,
+        JENKINS_PROPS,
+        CLOUDFORMATION_PROPS,
+        CODEDEPLOY_PROPS,
+        S3_DEPLOY_PROPS,
+        SERVICECATALOG_PROPS,
+        LAMBDA_PROPS,
+        APPROVAL_PROPS,
+    ),
     Optional("regions"): REGION_SCHEMA,
     Optional("exclude", default=[]): [str],
     Optional("wave", default={"size": 50}): TARGET_WAVE_SCHEME
@@ -348,8 +386,9 @@ PIPELINE_SCHEMA = {
 }
 TOP_LEVEL_SCHEMA = {
     "pipelines": [PIPELINE_SCHEMA],
-    # Allow any toplevel key starting with "x-" or "x_".
-    # ADF will ignore these, but users can use them to define anchors in one place.
+    # Allow any top level key starting with "x-" or "x_".
+    # ADF will ignore these, but users can use them to define anchors
+    # in one place.
     Optional(Regex('^[x][-_].*')): object
 }
 


### PR DESCRIPTION
## Why?

The CodeStar provider did not support the `CODEBUILD_CLONE_REF` artifact mode yet. This is useful if you would like to access the git repository, for example to analyze the history or checkout a different branch.

For CodeStar Connections, it was trying to resolve the CodeStar Connection Arn from SSM Parameter Store at the pipeline stack generation. However, resolving parameters should be performed in the input generation step.

## What?

* Added support to define the `output_artifact_format` in the CodeStar source provider. Allowing `CODEBUILD_CLONE_REF` to be defined as the output format.
* Moved resolving the `codestar_connection_path` in SSM Parameter Store to the pipeline input generation. As this is where it should be performed. The Lambda function resolving these parameters has the required permissions already.
* Added support for our CloudFormation role to perform `codestar-connections:PassConnection`, such that CodeStar connections can be configured in the CodePipeline stack that it generates.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
