### PR TITLE
Fix AttachRolePolicy on automation roles

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -497,8 +497,8 @@ Resources:
               - !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/adf-*
           - Effect: Allow
             Action:
+              - "iam:AttachRolePolicy"
               - "iam:CreateRole"
-              - "iam:CreateRolePolicy"
               - "iam:DeleteRole"
               - "iam:DeleteRolePolicy"
               - "iam:GetRole"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -307,8 +307,8 @@ Resources:
           - Effect: Allow
             Sid: "IAM"
             Action:
+              - "iam:AttachRolePolicy"
               - "iam:CreateRole"
-              - "iam:CreateRolePolicy"
               - "iam:DeleteRole"
               - "iam:DeleteRolePolicy"
               - "iam:GetRole"


### PR DESCRIPTION
## Why?

At the moment, the IAM policy was allowing `iam:CreateRolePolicy`. This action does not exist.

## What?

Changing it to: `iam:AttachRolePolicy` and changing order to be alphabetically.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
