### PR TITLE
Chore: Refactor CodeBuild readability

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -22,58 +22,110 @@ ADF_DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]
 DEFAULT_CODEBUILD_IMAGE = "UBUNTU_14_04_PYTHON_3_7_1"
 DEFAULT_BUILD_SPEC_FILENAME = 'buildspec.yml'
 DEFAULT_DEPLOY_SPEC_FILENAME = 'deployspec.yml'
+ADF_DEFAULT_BUILD_ROLE_NAME = 'adf-codebuild-role'
+ADF_DEFAULT_BUILD_TIMEOUT = 20
 
 
 class CodeBuild(core.Construct):
     # pylint: disable=no-value-for-parameter
 
-    def __init__(self, scope: core.Construct, id: str, shared_modules_bucket: str, deployment_region_kms: str, map_params: dict, target, **kwargs): #pylint: disable=W0622
+    # pylint: disable=W0622
+    def __init__(
+        self,
+        scope: core.Construct,
+        id: str,
+        shared_modules_bucket: str,
+        deployment_region_kms: str,
+        map_params: dict,
+        target,
+        **kwargs,
+    ):
         super().__init__(scope, id, **kwargs)
         stack = core.Stack.of(self)
 
-        ADF_DEFAULT_BUILD_ROLE = f'arn:{stack.partition}:iam::{ADF_DEPLOYMENT_ACCOUNT_ID}:role/adf-codebuild-role'
-        ADF_DEFAULT_BUILD_TIMEOUT = 20
-
-        # if CodeBuild is being used as a deployment action we want to allow target specific values.
+        # if CodeBuild is being used as a deployment action we want to allow
+        # target specific values.
         if target:
-            _role_name = target.get('properties', {}).get('role')
-            _build_role = f'arn:{stack.partition}:iam::{ADF_DEPLOYMENT_ACCOUNT_ID}:role/{_role_name}' if _role_name else ADF_DEFAULT_BUILD_ROLE
-            _timeout = target.get('properties', {}).get('timeout') or map_params['default_providers']['deploy'].get('properties', {}).get('timeout') or ADF_DEFAULT_BUILD_TIMEOUT
-            _env = _codebuild.BuildEnvironment(
+            role_name = (
+                target
+                .get('properties', {})
+                .get('role', ADF_DEFAULT_BUILD_ROLE_NAME)
+            )
+            role_arn = (
+                f'arn:{stack.partition}:iam::{ADF_DEPLOYMENT_ACCOUNT_ID}:'
+                f'role/{role_name}'
+            )
+            timeout = (
+                target
+                .get('properties', {})
+                .get('timeout', (
+                    map_params['default_providers']['deploy']
+                    .get('properties', {})
+                    .get('timeout', ADF_DEFAULT_BUILD_TIMEOUT)
+                ))
+            )
+            build_env = _codebuild.BuildEnvironment(
                 build_image=CodeBuild.determine_build_image(
                     codebuild_id=id,
                     scope=scope,
                     target=target,
                     map_params=map_params,
                 ),
-                compute_type=target.get(
-                    'properties', {}).get(
-                        'size') or getattr(
-                            _codebuild.ComputeType,
-                            map_params['default_providers']['deploy'].get(
-                                'properties', {}).get(
-                                    'size', "SMALL").upper()),
-                environment_variables=CodeBuild.generate_build_env_variables(_codebuild, shared_modules_bucket, map_params, target),
-                privileged=target.get('properties', {}).get(
-                    'privileged',
-                    map_params['default_providers']['deploy'].get(
-                        'properties', {}).get('privileged', False),
-                )
+                compute_type=getattr(
+                    _codebuild.ComputeType,
+                    (
+                        target
+                        .get('properties', {})
+                        .get('size', (
+                            map_params['default_providers']['deploy']
+                            .get('properties', {})
+                            .get('size', "SMALL")
+                        ))
+                        .upper()
+                    ),
+                ),
+                environment_variables=CodeBuild.generate_build_env_variables(
+                    _codebuild,
+                    shared_modules_bucket,
+                    map_params,
+                    target,
+                ),
+                privileged=(
+                    target
+                    .get('properties', {})
+                    .get('privileged', (
+                        map_params['default_providers']['deploy']
+                        .get('properties', {})
+                        .get('privileged', False)
+                    ))
+                ),
             )
             build_spec = CodeBuild.determine_build_spec(
                 id,
-                map_params['default_providers']['deploy'].get('properties', {}),
+                (
+                    map_params['default_providers']['deploy']
+                    .get('properties', {})
+                ),
                 target,
             )
             self.pipeline_project = _codebuild.PipelineProject(
                 self,
                 'project',
-                environment=_env,
-                encryption_key=_kms.Key.from_key_arn(self, 'default_deployment_account_key', key_arn=deployment_region_kms),
+                environment=build_env,
+                encryption_key=_kms.Key.from_key_arn(
+                    self,
+                    'default_deployment_account_key',
+                    key_arn=deployment_region_kms,
+                ),
                 description=f"ADF CodeBuild Project for {id}",
                 project_name=f"adf-deploy-{id}",
-                timeout=core.Duration.minutes(_timeout),
-                role=_iam.Role.from_role_arn(self, 'build_role', role_arn=_build_role, mutable=False),
+                timeout=core.Duration.minutes(timeout),
+                role=_iam.Role.from_role_arn(
+                    self,
+                    'build_role',
+                    role_arn=role_arn,
+                    mutable=False,
+                ),
                 build_spec=build_spec,
             )
             self._setup_vpc(
@@ -91,23 +143,47 @@ class CodeBuild(core.Construct):
                 action_name=id,
             ).config
         else:
-            _role_name = map_params['default_providers']['build'].get(
-                'properties', {}).get('role')
-            _build_role = f'arn:{stack.partition}:iam::{ADF_DEPLOYMENT_ACCOUNT_ID}:role/{_role_name}' if _role_name else ADF_DEFAULT_BUILD_ROLE
-            _timeout = map_params['default_providers']['build'].get('properties', {}).get('timeout') or ADF_DEFAULT_BUILD_TIMEOUT
-            _env = _codebuild.BuildEnvironment(
+            role_name = (
+                map_params['default_providers']['build']
+                .get('properties', {})
+                .get('role', ADF_DEFAULT_BUILD_ROLE_NAME)
+            )
+            role_arn = (
+                f'arn:{stack.partition}:iam::{ADF_DEPLOYMENT_ACCOUNT_ID}:'
+                f'role/{role_name}'
+            )
+            timeout = (
+                map_params['default_providers']['build']
+                .get('properties', {})
+                .get('timeout', ADF_DEFAULT_BUILD_TIMEOUT)
+            )
+            build_env = _codebuild.BuildEnvironment(
                 build_image=CodeBuild.determine_build_image(
                     codebuild_id=id,
                     scope=scope,
                     target=target,
                     map_params=map_params
                 ),
-                compute_type=getattr(_codebuild.ComputeType, map_params['default_providers']['build'].get('properties', {}).get('size', "SMALL").upper()),
-                environment_variables=CodeBuild.generate_build_env_variables(_codebuild, shared_modules_bucket, map_params),
-                privileged=map_params['default_providers']['build'].get('properties', {}).get('privileged', False)
+                compute_type=getattr(
+                    _codebuild.ComputeType,
+                    (
+                        map_params['default_providers']['build']
+                        .get('properties', {})
+                        .get('size', "SMALL")
+                        .upper()
+                    ),
+                ),
+                environment_variables=CodeBuild.generate_build_env_variables(
+                    _codebuild,
+                    shared_modules_bucket,
+                    map_params,
+                ),
+                privileged=(
+                    map_params['default_providers']['build']
+                    .get('properties', {})
+                    .get('privileged', False)
+                ),
             )
-            if _role_name:
-                ADF_DEFAULT_BUILD_ROLE = f'arn:{stack.partition}:iam::{ADF_DEPLOYMENT_ACCOUNT_ID}:role/{_role_name}'
             build_spec = CodeBuild.determine_build_spec(
                 id,
                 map_params['default_providers']['build'].get('properties', {})
@@ -115,13 +191,22 @@ class CodeBuild(core.Construct):
             self.pipeline_project = _codebuild.PipelineProject(
                 self,
                 'project',
-                environment=_env,
-                encryption_key=_kms.Key.from_key_arn(self, 'DefaultDeploymentAccountKey', key_arn=deployment_region_kms),
+                environment=build_env,
+                encryption_key=_kms.Key.from_key_arn(
+                    self,
+                    'DefaultDeploymentAccountKey',
+                    key_arn=deployment_region_kms,
+                ),
                 description=f"ADF CodeBuild Project for {map_params['name']}",
                 project_name=f"adf-build-{map_params['name']}",
-                timeout=core.Duration.minutes(_timeout),
+                timeout=core.Duration.minutes(timeout),
                 build_spec=build_spec,
-                role=_iam.Role.from_role_arn(self, 'default_build_role', role_arn=_build_role, mutable=False)
+                role=_iam.Role.from_role_arn(
+                    self,
+                    'default_build_role',
+                    role_arn=role_arn,
+                    mutable=False,
+                ),
             )
             self._setup_vpc(map_params['default_providers']['build'])
             self.build = _codepipeline.CfnPipeline.StageDeclarationProperty(
@@ -196,7 +281,12 @@ class CodeBuild(core.Construct):
             )
 
     @staticmethod
-    def _determine_stage_build_spec(codebuild_id, props, stage_name, default_filename):
+    def _determine_stage_build_spec(
+        codebuild_id,
+        props,
+        stage_name,
+        default_filename,
+    ):
         filename = props.get('spec_filename')
         spec_inline = props.get('spec_inline', {})
         if filename and spec_inline:
@@ -217,7 +307,10 @@ class CodeBuild(core.Construct):
     def determine_build_spec(codebuild_id, default_props, target=None):
         if target:
             target_props = target.get('properties', {})
-            if 'spec_inline' in target_props or 'spec_filename' in target_props:
+            if (
+                'spec_inline' in target_props
+                or 'spec_filename' in target_props
+            ):
                 return CodeBuild._determine_stage_build_spec(
                     codebuild_id=codebuild_id,
                     props=target_props,
@@ -238,13 +331,19 @@ class CodeBuild(core.Construct):
 
     @staticmethod
     def get_image_by_name(specific_image: str):
-        if hasattr(_codebuild.LinuxBuildImage,
-            (specific_image or DEFAULT_CODEBUILD_IMAGE).upper()):
-            return getattr(_codebuild.LinuxBuildImage,
-                (specific_image or DEFAULT_CODEBUILD_IMAGE).upper())
+        image_name = (
+            (
+                specific_image
+                or DEFAULT_CODEBUILD_IMAGE
+            ).upper()
+        )
+        if hasattr(_codebuild.LinuxBuildImage, image_name):
+            return getattr(_codebuild.LinuxBuildImage, image_name)
         if specific_image.startswith('docker-hub://'):
             specific_image = specific_image.split('docker-hub://')[-1]
-            return _codebuild.LinuxBuildImage.from_docker_registry(specific_image)
+            return _codebuild.LinuxBuildImage.from_docker_registry(
+                specific_image,
+            )
         raise Exception(
             f"The CodeBuild image {specific_image} could not be found."
         )
@@ -254,14 +353,18 @@ class CodeBuild(core.Construct):
         specific_image = None
         if target:
             specific_image = (
-                target.get('properties', {}).get('image') or
-                map_params['default_providers']['deploy'].get(
-                    'properties', {}).get('image')
+                target.get('properties', {}).get('image')
+                or (
+                    map_params['default_providers']['deploy']
+                    .get('properties', {})
+                    .get('image')
+                )
             )
         else:
             specific_image = (
-                map_params['default_providers']['build'].get(
-                    'properties', {}).get('image')
+                map_params['default_providers']['build']
+                .get('properties', {})
+                .get('image')
             )
         if isinstance(specific_image, dict):
             repo_arn = _ecr.Repository.from_repository_arn(
@@ -276,27 +379,58 @@ class CodeBuild(core.Construct):
         return CodeBuild.get_image_by_name(specific_image)
 
     @staticmethod
-    def generate_build_env_variables(codebuild, shared_modules_bucket, map_params, target=None):
-        _output = {
-            "PYTHONPATH": codebuild.BuildEnvironmentVariable(value='./adf-build/python'),
-            "ADF_PROJECT_NAME": codebuild.BuildEnvironmentVariable(value=map_params['name']),
-            "S3_BUCKET_NAME": codebuild.BuildEnvironmentVariable(value=shared_modules_bucket),
-            "ACCOUNT_ID": codebuild.BuildEnvironmentVariable(value=core.Aws.ACCOUNT_ID)
+    def generate_build_env_variables(
+        codebuild,
+        shared_modules_bucket,
+        map_params,
+        target=None,
+    ):
+        build_env_vars = {
+            "PYTHONPATH": "./adf-build/python",
+            "ADF_PROJECT_NAME": map_params['name'],
+            "S3_BUCKET_NAME": shared_modules_bucket,
+            "ACCOUNT_ID": core.Aws.ACCOUNT_ID,
+            **(
+                map_params
+                .get('default_providers', {})
+                .get(
+                    (
+                        'deploy'
+                        if target
+                        else 'build'
+                    ),
+                    {},
+                )
+                .get('properties', {})
+                .get('environment_variables', {})
+            ),
+            **(
+                # Target should go second, as this overwrites any
+                # existing key/value, so it overrides the defaults
+                (
+                    target or {}
+                )
+                .get('properties', {})
+                .get('environment_variables', {})
+            )
         }
-        _build_env_vars = map_params.get('default_providers', {}).get('build', {}).get('properties', {}).get('environment_variables', {})
-        for _env_var in _build_env_vars.items():
-            _output[_env_var[0]] = codebuild.BuildEnvironmentVariable(value=str(_env_var[1]))
-        if target:
-            _deploy_env_vars = map_params.get('default_providers', {}).get('deploy', {}).get('properties', {}).get('environment_variables', {})
-            for _env_var in _deploy_env_vars.items():
-                _output[_env_var[0]] = codebuild.BuildEnvironmentVariable(value=str(_env_var[1]))
 
-            _target_env_vars = target.get('properties', {}).get('environment_variables', {})
-            for _target_env_var in _target_env_vars.items():
-                _output[_target_env_var[0]] = codebuild.BuildEnvironmentVariable(value=_target_env_var[1])
-            _output["TARGET_NAME"] = codebuild.BuildEnvironmentVariable(value=target['name'])
-            _output["TARGET_ACCOUNT_ID"] = codebuild.BuildEnvironmentVariable(value=target['id'])
-            _role = map_params['default_providers']['deploy'].get('properties', {}).get('role') or target.get('properties', {}).get('role')
-            if _role:
-                _output["DEPLOYMENT_ROLE"] = codebuild.BuildEnvironmentVariable(value=_role)
-        return _output
+        if target:
+            build_env_vars['TARGET_NAME'] = target['name']
+            build_env_vars["TARGET_ACCOUNT_ID"] = target['id']
+            deploy_role_name = (
+                target
+                .get('properties', {})
+                .get('role', (
+                    map_params['default_providers']['deploy']
+                    .get('properties', {})
+                    .get('role')
+                ))
+            )
+            if deploy_role_name:
+                build_env_vars["DEPLOYMENT_ROLE"] = deploy_role_name
+
+        return {
+            key: codebuild.BuildEnvironmentVariable(value=value)
+            for key, value in build_env_vars.items()
+        }


### PR DESCRIPTION
## Why?

The CodeBuild class had similar issues as the CodePipeline class where the line length requirement was not met. Plus code readability was not terrific either.

## What?

Fixed the readability by properly breaking the lines. Another pass of refactoring code too.

I don't like the large if / else in the constructor + large code overlap between the two branches. This requires more refactoring later.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
