### PR TITLE
Fix pipeline management logical id typo

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -63,7 +63,7 @@ Globals:
       - !Ref LambdaLayer
 
 Resources:
-  ADFPipelineMangementLambdaBasePolicy:
+  ADFPipelineManagementLambdaBasePolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
       Description: "Base policy for all ADF pipeline management lambdas"
@@ -634,7 +634,7 @@ Resources:
           - Name: ORGANIZATION_ID
             Value: !Ref OrganizationId
           - Name: CLOUDFORMATION_ROLE_ARN
-            Value: !GetAtt ADFPipelineMangementCloudFormationRole.Arn
+            Value: !GetAtt ADFPipelineManagementCloudFormationRole.Arn
         Type: LINUX_CONTAINER
       Source:
         Type: NO_SOURCE
@@ -743,13 +743,13 @@ Resources:
                 Action:
                   - 'iam:PassRole'
                 Resource:
-                  - !GetAtt ADFPipelineMangementCloudFormationRole.Arn
+                  - !GetAtt ADFPipelineManagementCloudFormationRole.Arn
                 Condition:
                   StringEqualsIfExists:
                     'iam:PassedToService':
                       - cloudformation.amazonaws.com
 
-  ADFPipelineMangementCloudFormationRole:
+  ADFPipelineManagementCloudFormationRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:


### PR DESCRIPTION
## Why?

There is a typo in the pipeline management resource names. This PR fixes that.
Instead of `Mangement` it should be `Management`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
