### PR TITLE
Use unique policy names in adf-bootstrap example global-iam.yml files

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/example-global-iam.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/example-global-iam.yml
@@ -13,7 +13,7 @@ Resources:
     # for purposes other than testing.
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: "adf-cloudformation-deployment-role-policy"
+      PolicyName: "custom-adf-cloudformation-deployment-role-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-global-iam.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-global-iam.yml
@@ -19,7 +19,7 @@ Resources:
     # purposes other than testing.
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: "adf-cloudformation-deployment-role-policy"
+      PolicyName: "custom-adf-cloudformation-deployment-role-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
## Why?

With the current names defined in the example-global-iam.yml files, they would clash with the ADF policies defined on these roles.

## What?

* Add `custom-` prefix to the policy name so they are unique. This makes it easier to understand where policies are defined.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
