### PR TITLE
Fix permissions to allow CodeBuild as a deployment provider

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -790,6 +790,7 @@ Resources:
                   - "codebuild:UpdateProject"
                 Resource:
                   - !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/adf-build-*
+                  - !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/adf-deploy-*
               - Effect: Allow
                 Action:
                   - "sns:DeleteTopic"


### PR DESCRIPTION
## Why?

The CloudFormation role that is used to deploy the pipelines was only allowing CodeBuild projects which name started with `adf-build-`. However, it should also allow `adf-deploy-` resources, as that is how the CodeBuild project is named when it is used as a deployment provider.

## What?

Added the `adf-deploy-*` project name for CodeBuild projects deployed by the pipeline generation process.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
