### PR TITLE
Fix CloudFormation pipeline notification topic permissions

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -799,6 +799,7 @@ Resources:
                   - "sns:SetTopicAttributes"
                   - "sns:GetTopicAttributes"
                   - "sns:TagResource"
+                  - "sns:ListSubscriptionsByTopic"
                 Resource:
                   - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${PipelinePrefix}*
               - Effect: Allow


### PR DESCRIPTION
## Why?

When CloudFormation tries to update a pipeline notification topic, it will perform a list operation on the subscriptions for that topic. This action requires `sns:ListSubscriptionsByTopic` permissions which is not granted yet.

## What?

Added that permissions so it can update the notification topic when required.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
