### PR TITLE
Implementing resolve_ou_recursively for deployment maps; adding '/Roo…

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -195,10 +195,10 @@ class Organizations: # pylint: disable=R0904
         p = path.split('/')[1:]
         ou_id = self.get_ou_root_id()
 
-        while p:
-            if p[0] == 'Root':
-                break 
+        if p[0] == 'Root':
+            return self.get_accounts_for_parent(ou_id, recursive)
 
+        while p:
             for ou in self.get_child_ous(ou_id):
                 if ou['Name'] == p[0]:
                     p.pop(0)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/schema_validation.py
@@ -285,6 +285,7 @@ TARGET_SCHEMA = {
     Optional("tags"): {And(str, Regex(r"\A.{1,128}\Z")): And(str, Regex(r"\A.{0,256}\Z"))},
     Optional("target"): Or(str, int, TARGET_LIST_SCHEMA),
     Optional("name"): str,
+    Optional("resolve_ou_recursively"): bool,
     Optional("provider"): Or('lambda', 's3', 'codedeploy', 'cloudformation', 'service_catalog', 'approval', 'codebuild', 'jenkins'),
     Optional("properties"): Or(CODEBUILD_PROPS, JENKINS_PROPS, CLOUDFORMATION_PROPS, CODEDEPLOY_PROPS, S3_DEPLOY_PROPS, SERVICECATALOG_PROPS, LAMBDA_PROPS, APPROVAL_PROPS),
     Optional("regions"): REGION_SCHEMA

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/target.py
@@ -50,6 +50,7 @@ class Target:
     def __init__(self, path, target_structure, organizations, step, regions):
         self.path = path
         self.step_name = step.get('name', '')
+        self.resolve_ou_recursively = step.get('resolve_ou_recursively', False)
         self.provider = step.get('provider', {})
         self.properties = step.get('properties', {})
         self.regions = [regions] if not isinstance(regions, list) else regions
@@ -114,12 +115,12 @@ class Target:
         self._create_response_object(responses)
 
     def _target_is_ou_path(self):
-        responses = self.organizations.dir_to_ou(self.path)
+        responses = self.organizations.dir_to_ou(self.path, self.resolve_ou_recursively)
         self._create_response_object(responses)
 
     def _target_is_null_path(self):
         self.path = '/deployment' # TODO we will fetch this from parameter store
-        responses = self.organizations.dir_to_ou(self.path)
+        responses = self.organizations.dir_to_ou(self.path, False)
         self._create_response_object(responses)
 
     def fetch_accounts_for_target(self):


### PR DESCRIPTION
PLEASE NOTE THIS PR TARGETS tags/v3.1.2

Adding two features to deployment maps targets section:

- Deploy into Root OU by using '/Root' as target path;
- New parameter 'resolve_ou_recursively' (bool) to recursively deploy into OUs

Reason:
- Many customers use ADF to deploy security baseline CloudFormation templates. In this way, customers can be sure their baseline is always applied to all accounts, regardless of tags.