### PR TITLE
Retry run cdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,17 @@ init:
 
 test:
 	# Run unit tests
-	pytest src/lambda_codebase/account -vvv -s -c src/lambda_codebase/account/pytest.ini
-	pytest src/lambda_codebase/account_processing -vvv -s -c src/lambda_codebase/account_processing/pytest.ini
-	pytest src/lambda_codebase/initial_commit -vvv -s -c src/lambda_codebase/initial_commit/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/pytest.ini
-	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini
+	pytest src/lambda_codebase/account -vvv -s -c src/lambda_codebase/account/pytest.ini --cov=./src/ --cov-branch
+	pytest src/lambda_codebase/account_processing -vvv -s -c src/lambda_codebase/account_processing/pytest.ini --cov=./src/ --cov-branch
+	pytest src/lambda_codebase/initial_commit -vvv -s -c src/lambda_codebase/initial_commit/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/pytest.ini --cov=./src/ --cov-branch --cov-append
+	pytest src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared -vvv -s -c src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini --cov=./src/ --cov-branch --cov-append
 
 lint:
 	# Linter performs static analysis to catch latent bugs

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tox==3.27.1
 yamllint==1.28.0
 cfn-lint==0.72.2
 docutils==0.16
+pytest-cov==4.0.0

--- a/src/lambda_codebase/account/handler.py
+++ b/src/lambda_codebase/account/handler.py
@@ -17,17 +17,19 @@ except Exception as err:  # pylint: disable=broad-except
     LOGGER = logging.getLogger(__name__)
     LOGGER.setLevel(os.environ.get("ADF_LOG_LEVEL", logging.INFO))
 
-    def lambda_handler(event, _context, prior_error=err):
+    def create_payload_from_event(event, reason):
         payload = dict(
             LogicalResourceId=event["LogicalResourceId"],
-            PhysicalResourceId=event.get(
-                "PhysicalResourceId",
-                "NOT_YET_CREATED"),
+            PhysicalResourceId=event.get("PhysicalResourceId", "NOT_YET_CREATED"),
             Status="FAILED",
             RequestId=event["RequestId"],
             StackId=event["StackId"],
-            Reason=str(prior_error),
+            Reason=reason,
         )
+        return payload
+
+    def lambda_handler(event, _context, prior_error=err):
+        payload = create_payload_from_event(event, str(prior_error))
         with urlopen(
             Request(
                 event["ResponseURL"],

--- a/src/lambda_codebase/account_processing/pytest.ini
+++ b/src/lambda_codebase/account_processing/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 testpaths = tests
+
+[coverage:run]
+omit = tests/

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = tests
 norecursedirs = pipelines_repository
+
+[coverage:run]
+omit = tests/*

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -491,6 +491,16 @@ Resources:
                 "SourceTypeOverride": "S3",
                 "SourceLocationOverride.$": "$.definition_location"
               },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "CodeBuild.AWSCodeBuildException"
+                  ],
+                  "BackoffRate": 1.05,
+                  "IntervalSeconds": 150,
+                  "MaxAttempts": 12
+                }
+              ],
               "Next": "IdentifyOutOfDatePipelines"
             },
             "IdentifyOutOfDatePipelines": {

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = adf-build/tests adf-bootstrap/deployment/lambda_codebase/tests
 norecursedirs = adf-bootstrap/deployment/lambda_codebase/initial_commit adf-bootstrap/deployment/lambda_codebase/determine_default_branch adf-build/shared
+
+[coverage:run]
+omit = tests/

--- a/src/lambda_codebase/initial_commit/pytest.ini
+++ b/src/lambda_codebase/initial_commit/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = tests
 norecursedirs = bootstrap_repository
+
+[coverage:run]
+omit = tests/


### PR DESCRIPTION
# Why?

If CodeBuild is throttled or encounters an error. We don't retry currently. 

*Issue #, if available:*

## What?

Description of changes:

- Added in retry logic to the pipeline management statemachine to retry on CodeBuild exceptions. Time between attempts is 
150 seconds and the backoff rate is 1.05. Up to 12 times. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
