### PR TITLE
Generating input should not retry upon specific errors

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -437,6 +437,13 @@ Resources:
               "Retry": [
                 {
                   "ErrorEquals": [
+                    "NoAccountsFoundError",
+                    "InvalidDeploymentMapError"
+                  ],
+                  "MaxAttempts": 0
+                },
+                {
+                  "ErrorEquals": [
                     "States.TaskFailed"
                   ],
                   "IntervalSeconds": 1,


### PR DESCRIPTION
## Why?

The pipeline input generation would retry failures that would result in the same error.

For specific error classes thrown by this process, it should not attempt retries at all.

Albert Einstein:
> The definition of insanity is doing the same thing over and over
> and expecting different results.

## What?

* Abort retries if the error code is of these specific types.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
