### PR TITLE
Adding SARIF report support

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -43,29 +43,8 @@ jobs:
             megalinter-reports
             mega-linter.log
 
-      # Create pull request if applicable (this only works on PRs from the same repository, not from forks)
-      - name: Create Pull Request with applied fixes
-        id: cpr
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@v4
+      - name: Upload MegaLinter scan results to GitHub Security tab
+        if: ${{ success() }} || ${{ failure() }}
+        uses: github/codeql-action/upload-sarif@v2
         with:
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          commit-message: "[MegaLinter] Apply linters automatic fixes"
-          title: "[MegaLinter] Apply linters automatic fixes"
-          labels: bot
-      - name: Create PR output
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
-      # Push new commit if applicable (this only works on PRs from the same repository, not from forks)
-      - name: Prepare commit
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        run: sudo chown -Rc $UID .git/
-      - name: Commit and push applied linter fixes
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
-          commit_message: "[MegaLinter] Apply linters fixes"
+          sarif_file: 'megalinter-reports/megalinter-report.sarif'

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -29,6 +29,7 @@ ENABLE_LINTERS:
 #   - COPYPASTE # Comment to enable checks of excessive copy-pastes
 #   - SPELL # Comment to enable checks of spelling mistakes
 
+SARIF_REPORTER: true
 SHOW_ELAPSED_TIME: true
 FILEIO_REPORTER: false
 # DISABLE_ERRORS: true # Uncomment if you want MegaLinter to detect errors but not block CI to pass

--- a/linters/custom-adf-dict.txt
+++ b/linters/custom-adf-dict.txt
@@ -16,6 +16,7 @@ chsh
 cicd
 codepipelinecodeartifactpipelinetriggermytestrepoall
 codepipelinecodeartifactpipelinetriggermytestrepomytestpackage
+codeql
 corretto
 crhelper
 datacls
@@ -42,6 +43,7 @@ rcfile
 releasever
 rexec
 runas
+sarif
 sdkman
 stefanzweifel
 stubber


### PR DESCRIPTION
# Why?

1. There is code in the GitHub workflow for MegaLinter to support submitting pull requests with linter fixes. We are not using this functionality (also it doesn't work through forks), hence removing that code. 

2. Some linters like `hadolint` and `eslint` support Sarif reporting. GitHub can display results from a third-party static analysis tool in your repository on GitHub. This requires results stored in a SARIF file that supports a specific subset of the SARIF 2.1.0 JSON schema for code scanning.

MegaLinter supports this for the linters that support it. Results will display in the repository on GitHub automatically and this is very useful, see the below example: 

![sarif](https://megalinter.io/6.1.0/assets/images/SarifReporter_2.jpg)

*Issue #, if available:*

## What?

Description of changes:

- Cleaned up the MegaLinter GH Actions workflow
- Added Sarif support!

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
