### PR TITLE
Fix bootstrap mirror pipelines

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
@@ -151,8 +151,14 @@ class Parameters:
     def _retrieve_pipeline_targets(self) -> PipelineTargets:
         pipeline_targets = {}
         pipeline_definition = self._retrieve_pipeline_definition()
+        pipeline_input_key = (
+            # Support to fallback to 'input' definition key.
+            # This is scheduled to be deprecated in v4.0
+            "pipeline_input" if "pipeline_input" in pipeline_definition
+            else "input"
+        )
         input_targets: TargetWavesWithNestedWaveTargets = (
-            pipeline_definition['pipeline_input']['environments']['targets']
+            pipeline_definition[pipeline_input_key]['environments']['targets']
         )
         # Since the input_targets returns a list of waves that each contain
         # a list of wave_targets, we need to flatten them to iterate:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_generate_params.py
@@ -343,6 +343,42 @@ def test_ensure_parameter_default_contents(cls, input_definition_targets):
         }
 
 
+def test_using_deprecated_input_attribute_key(cls, input_definition_targets):
+    cls.definition_s3.read_object.return_value = json.dumps({
+        'input': {
+            'environments': {
+                'targets': input_definition_targets,
+            }
+        }
+    })
+    shutil.copy(
+        f"{cls.cwd}/stub_cfn_global.json",
+        f"{cls.cwd}/params/global.json",
+    )
+    with patch.object(
+        ParameterStore,
+        'fetch_parameter',
+        return_value='something',
+    ):
+        cls.create_parameter_files()
+
+        parse = cls._parse(
+            cls.cwd,
+            "account_name1_us-east-1",
+        )
+        assert parse == {
+            'Parameters': {
+                'Environment': 'testing',
+                'MySpecialValue': 'something',
+            },
+            'Tags': {
+                'CostCenter': 'overhead',
+                'Department': 'unknown',
+                'Geography': 'world',
+            }
+        }
+
+
 def test_ensure_parameter_overrides(
     cls,
     input_wave_target_one,


### PR DESCRIPTION
## Why?

An error was generated when the `aws-deployment-framework-bootstrap` is mirrored from another location, via a pipeline that is deployed with ADF. For example, hosted in Github, where the pipeline connects to Github via a CodeStar Connection and pushes the code to the local CodeCommit repository.

In this case, the `generate_params.py` file will look for the new `pipeline_input` attribute in the pipeline definition. While the pipeline definition was generated with a previous version of ADF, thereby using the `input` attribute key instead.

## What?

Introduced backward compatibility to the `input` key if the `pipeline_input` key is missing in the pipeline definition.

Also added a comment that this support for backwards compatibility will be dropped in the next major release of ADF.


---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
