### PR TITLE
Fix management account config alias through ADF account management

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
@@ -99,6 +99,9 @@ Resources:
           - Effect: Allow
             Action:
               - cloudformation:ValidateTemplate
+              - iam:CreateAccountAlias
+              - iam:DeleteAccountAlias
+              - iam:ListAccountAliases
               - ssm:PutParameter
               - ssm:GetParameters
               - ssm:GetParameter

--- a/src/template.yml
+++ b/src/template.yml
@@ -359,15 +359,6 @@ Resources:
                 - lambda.amazonaws.com
             Action: "sts:AssumeRole"
       Path: "/aws-deployment-framework/account-management/"
-      Policies:
-        - PolicyName: "adf-lambda-create-account-alias-policy"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "iam:CreateAccountAlias"
-                Resource: "*"
 
   AccountAliasConfigFunction:
     Type: 'AWS::Serverless::Function'


### PR DESCRIPTION
Issue: #595

## Why?

The management account alias cannot be configured by the account management state machine, as the cross account access role does not have enough permissions to create, list, or delete the aliases of the management account.

## What?

The cross-account access role that is deployed in the management account gets the required permissions.

These will only be applied if the management account is bootstrapped by ADF.

It assumes into the cross-account access role to list, create, and/or delete the account aliases. Hence, this change removes the permissions from the Lambda function role itself. As those are not used and would only apply to the deployment account.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.