### PR TITLE
Fix CodeDeploy sample to work in gov-cloud

### DIFF
--- a/samples/sample-ec2-with-codedeploy/scripts/install-codedeploy.sh
+++ b/samples/sample-ec2-with-codedeploy/scripts/install-codedeploy.sh
@@ -36,7 +36,7 @@ function platformize(){
 function execute(){
   if [ ${PLAT} = "ubuntu" ]; then
     cd /tmp/
-    wget https://aws-codedeploy-${REGION}.s3.amazonaws.com/latest/install
+    wget https://aws-codedeploy-${REGION}.s3.${REGION}.amazonaws.com/latest/install
     chmod +x ./install
 
     if ./install auto; then
@@ -56,7 +56,7 @@ function execute(){
 
   elif [ ${PLAT} = "amz" ]; then
     cd /tmp/
-    wget https://aws-codedeploy-${REGION}.s3.amazonaws.com/latest/install
+    wget https://aws-codedeploy-${REGION}.s3.${REGION}.amazonaws.com/latest/install
     chmod +x ./install
 
     if ./install auto; then


### PR DESCRIPTION
**Why?**

At the moment, the install script for CodeDeploy would install CodeDeploy using the global S3 URL to fetch the file from the S3 bucket.

As such:
```
https://aws-codedeploy-${REGION}.s3.amazonaws.com/latest/install
```

However, the CodeDeploy Gov cloud buckets are not available through this global URL. So when the REGION=`us-gov-east-1` or `us-gov-west-1` it would fail.

Please note:
The gov-cloud buckets exist, as can be found here: https://docs.aws.amazon.com/codedeploy/latest/userguide/resource-kit.html#resource-kit-bucket-names

**What?**

To fix the install script, we should use the regional URL instead:

```
https://aws-codedeploy-${REGION}.s3.${REGION}.amazonaws.com/latest/install
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
