### PR TITLE
[Bug] Fix custom pipeline type configuration not loaded

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/main.py
@@ -40,7 +40,7 @@ class PipelineStack(core.Stack):
         pipeline_type = (
             stack_input['pipeline_input']
             .get('params', {})
-            .get('type', DEFAULT_PIPELINE)
+            .get('pipeline_type', DEFAULT_PIPELINE)
             .lower()
         )
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_pipeline_creation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_pipeline_creation.py
@@ -15,7 +15,7 @@ from cdk_stacks.main import PipelineStack
 def test_pipeline_generation_fails_if_pipeline_type_is_not_specified(mock):
     stack_input = {"pipeline_input": {"params": {}}}
     stack_input["pipeline_input"]["name"] = "test-stack"
-    stack_input["pipeline_input"]["params"]["type"] = "fail"
+    stack_input["pipeline_input"]["params"]["pipeline_type"] = "fail"
     app = core.App()
     with pytest.raises(ValueError):
         pipeline_stack = PipelineStack(app, stack_input)
@@ -35,7 +35,6 @@ def test_pipeline_generation_works_when_no_type_specified(mock):
 def test_pipeline_generation_works_when_no_type_specified(mock):
     stack_input = {"pipeline_input": {"params": {}}}
     stack_input["pipeline_input"]["name"] = "test-stack"
-    stack_input["pipeline_input"]["params"]["type"] = "Default"
 
     app = core.App()
     PipelineStack(app, stack_input)


### PR DESCRIPTION

# Why?
This is the configuration in the deployment map file for custom pipeline:
```
    params:
      pipeline_type: "yourCustomTypeHere"
```
However, it was never loaded as it was getting an invalid property name so it always sets it to DEFAULT_PIPELINE

## What?

Description of changes:

- Change `type` to `pipeline_type` as set in the deployment map

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
