### PR TITLE
Remove Unused SAM Build

### DIFF
--- a/src/template.yml
+++ b/src/template.yml
@@ -1304,7 +1304,6 @@ Resources:
                 - pytest -vvv
             build:
               commands:
-                - sam build -t adf-bootstrap/deployment/pipeline_management.yml
                 - sam build -t adf-bootstrap/deployment/global.yml
                 - >-
                     sam package --output-template-file adf-bootstrap/deployment/global.yml


### PR DESCRIPTION
# Why?

When uploading the deployment account bootstrap templates to S3 as part of the CodeBuild in the management account, `sam build` is run twice - once for `adf-bootstrap/deployment/pipeline_management.yml` and once for `adf-bootstrap/deployment/global.yml`. Running `sam build` outputs the packaged code and templates to `.aws-sam/`. However, running this a second time simply overwrites the code/templates in `.aws-sam/`

Therefore, the code/templates built by running `sam build -t adf-bootstrap/deployment/pipeline_management.yml` are never referenced, never uploaded to S3 and never deployed.

The `pipeline_management.yml` SAM application is actually included within the `global.yml`, so the build of this application is included in the SAM build for the `global.yml`.
https://github.com/awslabs/aws-deployment-framework/blob/66aec8e11161a4a44f154d10d6136ded8098405e/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml#L179

### First SAM Build
Running ```sam build -t adf-bootstrap/deployment/pipeline_management.yml``` outputs the following to `.aws-sam/`. At this point there would be no `.aws-sam` directory; so one will be created and the build files and `build.toml` will be written to it.

![image](https://user-images.githubusercontent.com/47723399/222927958-cc8acb2d-2e32-45d8-88dd-1435abb8f3a5.png)

### Second SAM Build
Running ```sam build -t adf-bootstrap/deployment/global.yml``` outputs the below to `.aws-sam/`. The SAM CLI will **_delete_** the files inside `.aws-sam/build`, write new ones, and will **_update_** the existing `build.toml`.

![image](https://user-images.githubusercontent.com/47723399/222928008-6fec6705-0323-4bff-a64d-3ff5030dc1a7.png)

### Is the output changed by not running the first `sam build`?

The directory structure inside `.aws-sam/build` will be exactly the same, and the `.aws-sam/build.toml` will include the same data, however:
- The hashes of the functions will be different, which is expected.
- The order of the functions will be different (explained below).

When running the second `sam build` above, the contents of `.aws-sam/build` are removed here:

https://github.com/aws/aws-sam-cli/blob/a2a4540427806b11e2a508d4d118d517d296efef/samcli/commands/build/build_context.py#L433

However, given that the `build.toml` already exists, the SAM CLI has some logic that determines whether or not the function it is trying to append already exists. If it does exist, it is just updated if necessary - if not, it is added.

https://github.com/aws/aws-sam-cli/blob/a2a4540427806b11e2a508d4d118d517d296efef/samcli/lib/build/build_graph.py#L254-L272

As a result, using the two existing `sam build` commands, the `pipeline_management` application ends up being the top of the list in the `build.toml` as it is built first. However, when built without the first `sam build`, the `pipeline_management` application ends up being at the end of the list as it is the last to be built as part of the `global.yml. This has no effect on behaviour as it only affects TOML ordering, but is a side effect of the SAM CLI's logic to determine updates.

## What?

Description of changes:

- Remove the `sam build` for the `pipeline_management.yml` application, of which the built code/templates are never used.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
