### PR TITLE
fix: Handle wave calculation for Cloudformation provider and multi-region targets

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -291,7 +291,13 @@ However, in some situations, you would like to limit the rate at which an
 update is rolled out to the list of accounts/regions.
 
 This can be configured using the `wave/size` target property. Setting these to
-`30` as shown above, will introduce a new stage for every 30 accounts/regions.
+`30` as shown above, will introduce a new stage for every 30 accounts collated within this target
+
+Note: Each account defined within a stage may consist of several actions depending on the 
+specific provider action type defined aswell as how many regions are selected for the target stage.
+This should be taken into consideration when utilizing custom wave sizes.
+
+The minimum wave size should not be set less than the amount of actions necessary to deploy a single target.
 
 If the `/my_ou/production/some_path` OU would contain 25 accounts (actually 26,
 but account `9999999999` is excluded by the setup above), multiplied by the two
@@ -388,12 +394,12 @@ pipelines:
   - name: ami-builder
     # Default providers and parameters are the same as defined above.
     # Only difference: instead of using `triggers` it uses the
-    # `completion_triggers`
+    # `completion_trigger`
     params:
       schedule: rate(7 days)
     # What should trigger this pipeline
     # and what should be triggered when it completes
-    completion_triggers:
+    completion_trigger:
       pipelines:
         - my-web-app-pipeline  # Start this pipeline
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/generate_pipeline_inputs.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/generate_pipeline_inputs.py
@@ -20,7 +20,6 @@ DEPLOYMENT_ACCOUNT_REGION = os.environ["AWS_REGION"]
 DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]
 ROOT_ACCOUNT_ID = os.environ["ROOT_ACCOUNT_ID"]
 
-
 def store_regional_parameter_config(
     pipeline,
     parameter_store,
@@ -136,8 +135,17 @@ def generate_pipeline_inputs(
         # For the sake of consistency we should probably think of a target
         # consisting of multiple "waves". So if you see any reference to
         # a wave going forward it will be the individual batch of account ids.
+        actions_per_target_account = target_structure.get_actions_per_target_account(
+            regions=pipeline_object.get_all_regions(),
+            provider=pipeline_target.provider,
+            action=pipeline_target.properties.get("action")
+        )
         pipeline_object.template_dictionary["targets"].append(
-            list(target_structure.generate_waves()),
+            list(
+                target_structure.generate_waves(
+                    actions_per_target_account=actions_per_target_account
+                )
+            ),
         )
 
     if DEPLOYMENT_ACCOUNT_REGION not in regions:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/errors.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/errors.py
@@ -81,3 +81,10 @@ class NoAccountsFoundError(Exception):
     """
 
     pass
+
+class WaveSizeInsufficientError(Exception):
+    """
+    Raised when the defined wave size is less than the calculated minimum actions
+    """
+
+    pass


### PR DESCRIPTION
# Why?

CodePipeline has a hard limit of 50 actions per Stage... the Account wave mechanism is based on accounts not actions. Pipeline deployment creation fails when too many accounts are included within the target list. Splitting them manually into seperate stages in the deployment map is not feasible as they use OU paths.

## What?
When using the default deploy provider( cloudformation) each target will have 2 actions (one for CHANGE_SET_REPLACE and one for CHANGE_SET_EXECUTE), these are not consider in the existing generate_waves method. 

Additionally when multiple regions are declared for a given target then the cloudformation actions will be multiplied per region within the stage, this is also not considered in the wave calculation.



Description of changes:

- A new static method in the TargetStructure to calculate the number of actions each account in a target will need
- Updates to the generate_waves method to consume the actions_per_account
- Updated Docs (also including typo in complete_on_trigger)
- New Test cases which validate multi-region and cloud-formation wave generation

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
