### PR TITLE
Fixing broken Travis link (and build badge)

### DIFF
--- a/docs/serverless-application-repo.md
+++ b/docs/serverless-application-repo.md
@@ -1,6 +1,6 @@
 # AWS Deployment Framework
 
-[![Build Status](https://travis-ci.org/awslabs/aws-deployment-framework.svg?branch=master)](https://travis-ci.org/awslabs/aws-deployment-framework)
+[![Build Status](https://github.com/awslabs/aws-deployment-framework/workflows/ADF%20CI/badge.svg?branch=master)](https://github.com/awslabs/aws-deployment-framework/actions?query=workflow%3AADF%20CI+branch%3Amaster)
 
 The [AWS Deployment Framework](https://github.com/awslabs/aws-deployment-framework)
 *(ADF)* is an extensive and flexible framework to manage and deploy resources


### PR DESCRIPTION
# Why?

SAR readme file has broken link to our old CI.

## What?

Description of changes:

- Updated link to our GitHub build badge

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
