### PR TITLE
Temporarily disble cfn-lint for #619

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -10,7 +10,8 @@ APPLY_FIXES: none
 # If you use ENABLE_LINTERS variable, all other linters will be disabled by default
 ENABLE_LINTERS:
   - BASH_EXEC
-  - CLOUDFORMATION_CFN_LINT
+  # Temporarely disable cfn-lint until megalinter v7 release.
+  # - CLOUDFORMATION_CFN_LINT
   - DOCKERFILE_HADOLINT
   - EDITORCONFIG_EDITORCONFIG_CHECKER
   - JSON_JSONLINT


### PR DESCRIPTION
# Why?

We have a linter failure in #619 because the latest MegaLinter release did not yet update CFN Lint. 

## What?

Temporarily disabling cfn-lint to un-block, I've created #629 for tracking
