### PR TITLE
Fix resource untagging permissions

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -614,6 +614,7 @@ Resources:
               - "codecommit:PutRepositoryTriggers"
               - "codecommit:GetRepository"
               - "codecommit:TagResource"
+              - "codecommit:UntagResource"
             Resource:
               - "*"
           - Effect: Allow

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -796,6 +796,7 @@ Resources:
                   - "codepipeline:RegisterWebhookWithThirdParty"
                   - "codepipeline:StartPipelineExecution"
                   - "codepipeline:TagResource"
+                  - "codepipeline:UntagResource"
                   - "codepipeline:UpdatePipeline"
                 Resource:
                   - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:webhook:adf-webhook-*
@@ -817,6 +818,7 @@ Resources:
                   - "sns:SetTopicAttributes"
                   - "sns:GetTopicAttributes"
                   - "sns:TagResource"
+                  - "sns:UntagResource"
                   - "sns:ListSubscriptionsByTopic"
                 Resource:
                   - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${PipelinePrefix}*

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -301,6 +301,7 @@ Resources:
               - "codecommit:PutRepositoryTriggers"
               - "codecommit:GetRepository"
               - "codecommit:TagResource"
+              - "codecommit:UntagResource"
             Resource:
               - "*"
           - Effect: Allow

--- a/src/template.yml
+++ b/src/template.yml
@@ -402,6 +402,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - "organizations:TagResource"
+                  - "organizations:UntagResource"
                 Resource: "*"
 
   AccountTagConfigFunction:


### PR DESCRIPTION
**Why?**

The ADF Automation Role will need the CodeCommit:UntagResource permission when you change the tags that should be applied to a CodeCommit repository.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
