### PR TITLE
docs: documentation-enhancements-controltower

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -278,6 +278,13 @@ ensures the existence of AWS Accounts defined in `.yml` files within the
 or alternatively in the bootstrap repository you can find it in the
 `adf-accounts` directory.
 
+**Note on Provisioning AWS Accounts via AWS ControlTower**
+ADF is fully compatible with [AWS ControlTower](https://aws.amazon.com/de/controltower/).
+If you deployed ADF and AWS ControlTower in your AWS Organization and if you opted for 
+vending AWS Accounts via AWS ControlTower, you can ignore the ADF Account Provisioning 
+feature. Any AWS Account vended via AWS ControlTower will go through the regular ADF 
+bootstrap process described below.
+
 ### Bootstrapping Accounts
 
 #### Bootstrapping Overview

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-accounts/README.md
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-accounts/README.md
@@ -7,6 +7,12 @@ Organization. This process enables to end-to-end bootstrapping and associated
 pipeline generation for new AWS Accounts and is the recommended way to provision
 and setup AWS Accounts via ADF.
 
+**Note on Provisioning AWS Accounts via AWS ControlTower**
+ADF is fully compatible with [AWS ControlTower](https://aws.amazon.com/de/controltower/).
+If you deployed ADF and AWS ControlTower in your AWS Organization and if you opted for 
+vending AWS Accounts via AWS ControlTower, you can ignore the ADF Account Provisioning 
+feature. 
+
 ## Overview
 
 When setting ADF for the first time you will have an auto-generated `adf.yml`


### PR DESCRIPTION
# Why?

Various enterprise customers use AWS ControlTower together with ADF. 
To allow for an easy setup, some ADF installation steps need slight adjustments to be compatible with AWS ControlTower.

## What?

This change adds AWS ControlTower specific installation steps and notes where needed to allow for an easy setup with AWS ControlTower.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
