### PR TITLE
Fix: Adding hash to pipelines processing step function execution names to …

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
@@ -11,6 +11,7 @@ import json
 import tempfile
 from typing import Any, TypedDict
 import yaml
+import hashlib
 from yaml.error import YAMLError
 
 import boto3
@@ -173,9 +174,11 @@ def start_executions(
         # AWS Step Functions supports max 80 characters.
         # Since the run_id equals 49 characters plus the dash, we have 30
         # characters available. To ensure we don't run over, lets use a
-        # truncated version instead:
-        truncated_pipeline_name = full_pipeline_name[:30]
-        sfn_execution_name = f"{truncated_pipeline_name}-{run_id}"
+        # truncated version concatenated with an hash generated from
+        # the pipeline name
+        truncated_pipeline_name = full_pipeline_name[:24]
+        truncated_pipeline_name_hash = hashlib.md5( bytes(full_pipeline_name, 'utf-8') ).hexdigest()[:5]
+        sfn_execution_name = f"{truncated_pipeline_name}-{truncated_pipeline_name_hash}-{run_id}"
         sfn_client.start_execution(
             stateMachineArn=PIPELINE_MANAGEMENT_STATEMACHINE,
             name=sfn_execution_name,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
@@ -10,8 +10,8 @@ import os
 import json
 import tempfile
 from typing import Any, TypedDict
-import yaml
 import hashlib
+import yaml
 from yaml.error import YAMLError
 
 import boto3
@@ -177,7 +177,8 @@ def start_executions(
         # truncated version concatenated with an hash generated from
         # the pipeline name
         truncated_pipeline_name = full_pipeline_name[:24]
-        execution_unique_hash = hashlib.md5( bytes(full_pipeline_name + run_id, 'utf-8') ).hexdigest()[:5]
+        name_bytes_to_hash = bytes(full_pipeline_name + run_id, 'utf-8')
+        execution_unique_hash = hashlib.md5(name_bytes_to_hash).hexdigest()[:5]
         sfn_execution_name = f"{truncated_pipeline_name}-{execution_unique_hash}-{run_id}"
         sfn_client.start_execution(
             stateMachineArn=PIPELINE_MANAGEMENT_STATEMACHINE,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
@@ -177,8 +177,8 @@ def start_executions(
         # truncated version concatenated with an hash generated from
         # the pipeline name
         truncated_pipeline_name = full_pipeline_name[:24]
-        truncated_pipeline_name_hash = hashlib.md5( bytes(full_pipeline_name, 'utf-8') ).hexdigest()[:5]
-        sfn_execution_name = f"{truncated_pipeline_name}-{truncated_pipeline_name_hash}-{run_id}"
+        execution_unique_hash = hashlib.md5( bytes(full_pipeline_name + run_id, 'utf-8') ).hexdigest()[:5]
+        sfn_execution_name = f"{truncated_pipeline_name}-{execution_unique_hash}-{run_id}"
         sfn_client.start_execution(
             stateMachineArn=PIPELINE_MANAGEMENT_STATEMACHINE,
             name=sfn_execution_name,


### PR DESCRIPTION
…prevent collisions

# Why?

Addresses #640 

## What?

Adds a 5 characters long hash to state machine execution name in order to prevent collisions that led to wrong parsing of deployment maps and pipelines from being created.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
