### PR TITLE
Fix GitHub Pipeline secret token usage

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -891,6 +891,11 @@ Resources:
                   - "iam:TagPolicy"
                   - "iam:TagRole"
                 Resource: "*"
+              - Effect: Allow
+                Action:
+                  - "secretsmanager:GetSecretValue"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/adf/github_token-*"
 
   DeploymentMapProcessingFunction:
     Type: 'AWS::Serverless::Function'


### PR DESCRIPTION
**Why?**

No access was provided to pipelines that rely on GitHub repositories as their source, using the GitHub OAuth token stored in the `/adf/github_token` secret in Secrets Manager.

This issue was introduced with the refactoring to the separate pipeline management stack in ADF v3.2.0.

**What?**

Added access rights for the pipeline creation stack to fetch the GitHub OAuth secret.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
