### PR TITLE
Linter fixes

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -5,10 +5,6 @@ name: MegaLinter
 
 on: [push, pull_request]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 env:
   APPLY_FIXES: none
   APPLY_FIXES_EVENT: pull_request

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -5,6 +5,10 @@ name: MegaLinter
 
 on: [push, pull_request]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 env:
   APPLY_FIXES: none
   APPLY_FIXES_EVENT: pull_request

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -28,7 +28,7 @@ SARIF_REPORTER: true
 SHOW_ELAPSED_TIME: true
 FILEIO_REPORTER: false
 
-# Install pluging for list handling.
+# Install plugin for list handling.
 JSON_PRETTIER_PRE_COMMANDS:
   - command: |
       npm install -g prettier-plugin-multiline-arrays@1.1.4
@@ -44,3 +44,6 @@ SPELL_CSPELL_ARGUMENTS: '--gitignore --no-progress --show-suggestions'
 SPELL_CSPELL_FILE_EXTENSIONS: ["*"]
 TERRAFORM_TFLINT_UNSECURED_ENV_VARIABLES:
   - GITHUB_TOKEN
+
+GITHUB_STATUS_REPORTER: true
+GITHUB_COMMENT_REPORTER: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,4 +5,5 @@ This project has adopted the
 
 For more information see the
 [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
+[opensource-codeofconduct@amazon.com](mailto:opensource-codeofconduct@amazon.com)
+with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,8 @@ This project has adopted the
 [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the
 [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
+[opensource-codeofconduct@amazon.com](mailto:opensource-codeofconduct@amazon.com)
+with any additional questions or comments.
 
 ## Security issue notifications
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -97,6 +97,8 @@ Resources:
 
   KMSKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       Description: Used by Assumed Roles in Accounts accounts to Encrypt/Decrypt code
       EnableKeyRotation: true

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml
@@ -58,6 +58,8 @@ Resources:
 
   DeploymentFrameworkRegionalKMSKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       Description: Used by Assumed Roles in Accounts accounts to Encrypt/Decrypt code
       EnableKeyRotation: true


### PR DESCRIPTION
# Why?

2 linter errors emerged:
- New version of `cfn-lint` enforces the use of `UpdateReplacePolicy` / `DeletionPolicy`.
- e-mail address was missing a hyperlink. 

## What?

Description of changes:

- Explicitly set the default `Delete` policy.
- Created hyperlinks for the e-mail address. 
- Explicitly set GH reporters, fixed a type in the linter yaml. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
