### PR TITLE
fix: create repository bug

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/repo.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/repo.py
@@ -38,19 +38,22 @@ class Repo:
             f'create_repo_{account_id}'
         )
 
-    def repo_exists(self):
+    def repo_exists(self) -> bool:
         try:
             codecommit = self.session.client(
                 'codecommit',
                 DEPLOYMENT_ACCOUNT_REGION,
             )
             repository = codecommit.get_repository(repositoryName=self.name)
-            if repository['repositoryMetadata']['Arn']:
+            if repository.get('repositoryMetadata', {}).get('Arn'):
+                LOGGER.debug("Found Repository: %s", repository)
                 return True
-        except Exception:  # pylint: disable=broad-except
+        except codecommit.exceptions.RepositoryDoesNotExistException as err: # Let any other exception raise
+            LOGGER.debug("Exception Caught: %s", err)
             LOGGER.debug(
-                'Attempted to find the repo %s but it failed.',
-                self.name,
+                "The Repository: %s doesn't exist within account: %s returning repo_exists=False", 
+                self.name, 
+                self.account_id
             )
         return False  # Return False if the repository does not exist
 
@@ -82,13 +85,22 @@ class Repo:
         )
 
         _repo_exists = self.repo_exists()
-        _stack_exists = cloudformation.get_stack_status()
-        if _repo_exists and not _stack_exists:
-            # No need to create or update the CloudFormation stack to
-            # deploy the repository if the repo exists already and it was not
-            # created with the ADF CodeCommit Repository stack.
-            return
-
+        
+        _stack_status = cloudformation.get_stack_status()
+        if _repo_exists:
+            if _stack_status == "ROLLBACK_COMPLETE":
+                # Theres some manual cleanup necessary here so lets log a warning and continue.
+                LOGGER.info(
+                    "Stack %s in ROLLBACK_COMPLETE but the repository still exists, manual intervention maybe necessary", 
+                    self.stack_name
+                )
+                return
+            if not _stack_status:
+                # No need to create or update the CloudFormation stack to
+                # deploy the repository if the repo exists already and it was not
+                # created with the ADF CodeCommit Repository stack.
+                return
+        
         LOGGER.info(
             "Ensuring State for CodeCommit Repository Stack %s on Account %s",
             self.name,


### PR DESCRIPTION
# Why?

There is a scenario where the ADF stack for a given codecommit repository is in state 'rollback complete' but the Repository still exists. In such a scenario ADF shouldn't attempt to recreate the repository until some manual intervention is applied.

*Issue #, if available:*

## What?

repo module in core codebase needs some minor error handling changes.

Description of changes:

- repo.py updates repo_exists and create_update method

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
