### PR TITLE
Fix ChatBot channel ref + add notification management permissions

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -865,6 +865,19 @@ Resources:
                   StringEquals:
                     'codestar-connections:PassedToService': 'codepipeline.amazonaws.com'
               - Effect: Allow
+                Sid: "AllowChatBotOperations"
+                Action:
+                  - "codestar-notifications:CreateNotificationRule"
+                  - "codestar-notifications:DeleteNotificationRule"
+                  - "codestar-notifications:DescribeNotificationRule"
+                  - "codestar-notifications:ListNotificationRules"
+                  - "codestar-notifications:Subscribe"
+                  - "codestar-notifications:TagResource"
+                  - "codestar-notifications:Unsubscribe"
+                  - "codestar-notifications:UntagResource"
+                  - "codestar-notifications:UpdateNotificationRule"
+                Resource: "*"
+              - Effect: Allow
                 Action:
                   - "events:PutRule"
                   - "events:PutTargets"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_chatbot.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_chatbot.py
@@ -47,7 +47,7 @@ class PipelineNotifications(Construct):
         )
         pipeline_arn = (
             f"arn:{stack.partition}:codepipeline:{ADF_DEPLOYMENT_REGION}:"
-            "{ADF_DEPLOYMENT_ACCOUNT_ID}:{pipeline.ref}"
+            f"{ADF_DEPLOYMENT_ACCOUNT_ID}:{pipeline.ref}"
         )
         cp_notifications.CfnNotificationRule(
             scope,


### PR DESCRIPTION
## Why?

The AWS Chatbot integration had an error that was introduced with the refactoring in v3.2.0 release. This prevented ChatBot configurations to be applied correctly.

Additionally, the pipeline creation process did not have the required permissions to manage the pipeline notifications yet.

## What?

Both issues are addressed in this change request.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
