### PR TITLE
Upload SCP policies with spaces removed

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -194,7 +194,7 @@ class Organizations:  # pylint: disable=R0904
     def get_policy_body(path):
         bootstrap_path = f"./adf-bootstrap/{path}"
         with open(bootstrap_path, mode="r", encoding="utf-8") as policy:
-            return json.dumps(json.load(policy))
+            return json.dumps(json.load(policy), separators=(',', ':'))
 
     def list_policies(self, name, policy_type="SERVICE_CONTROL_POLICY"):
         response = list(paginator(self.client.list_policies, Filter=policy_type))


### PR DESCRIPTION
By default Python's `json.dumps` adds a space after `,` and `:` characters. This commit removes those spaces so they don't count against SCP policy limits.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
