### PR TITLE
Limit adf-state-machine-role to what is needed

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -1199,9 +1199,6 @@ Resources:
           - Effect: "Allow"
             Principal:
               Service:
-                - events.amazonaws.com
-                - lambda.amazonaws.com
-                - sns.amazonaws.com
                 - states.amazonaws.com
             Action: "sts:AssumeRole"
       Path: "/"
@@ -1214,8 +1211,10 @@ Resources:
                 Action:
                   - "lambda:InvokeFunction"
                   - "sns:Publish"
-                  - "states:StartExecution"
-                Resource: "*"
+                Resource:
+                  - !GetAtt EnableCrossAccountAccess.Arn
+                  - !GetAtt CheckPipelineStatus.Arn
+                  - !GetAtt PipelineSNSTopic.TopicArn
 
   LambdaInvokePermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
# Why?

Following security best practices and fixing things Aquasec/Cloudsploit is complaining about!

## What?

- Reduced trust policy to only states services as it's only passed to a state machine
- Reduced permissions to only invoke Lambda and publish SNS with only the resources that it uses 
---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
