### PR TITLE
Improve variable precedence in terraform global.auto.tfvars

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
@@ -16,7 +16,7 @@ tfinit(){
         cp -R "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}"/* "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
     fi
     if [ -f "${CURRENT}/tfvars/global.auto.tfvars" ]; then
-        cp -R "${CURRENT}/tfvars/global.auto.tfvars" "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
+        cp -R "${CURRENT}/tfvars/global.auto.tfvars" "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}/0-global.auto.tfvars"
     fi
     terraform init \
         -backend-config "bucket=$S3_BUCKET_REGION_NAME" \

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
@@ -16,7 +16,7 @@ tfinit(){
         cp -R "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}"/* "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
     fi
     if [ -f "${CURRENT}/tfvars/global.auto.tfvars" ]; then
-        cp -R "${CURRENT}/tfvars/global.auto.tfvars" "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}/0-global.auto.tfvars"
+        cp -R "${CURRENT}/tfvars/*global.auto.tfvars" "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
     fi
     terraform init \
         -backend-config "bucket=$S3_BUCKET_REGION_NAME" \


### PR DESCRIPTION
# Why?

For the sake of convenience in managing variables within a multi-project and multi-environment setting, there's a need to utilize multiple `*.tvars` in `tfvars/TARGET_ACCOUNT_ID/`.

For example:

* `tfvars/TARGET_ACCOUNT_ID/environment.auto.tfvars`
* `tfvars/TARGET_ACCOUNT_ID/local.auto.tfvars`
* `tfvars/TARGET_ACCOUNT_ID/project.auto.tfvars`

The file `tfvars/global.auto.tfvars` is structured as follows:

```hcl
project_name = "default"
project_env = "test"
```

The file `tfvars/TARGET_ACCOUNT_ID/environment.auto.tfvars`:

```hcl
project_env = "prod"
```

The file `tfvars/TARGET_ACCOUNT_ID/project.auto.tfvars`:

```hcl
project_name = "mybrand"
```

### Issue

When running the `terraform plan` on this code:

```hcl
variable "project_name" {
  description = "Project name"
  type        = string
}

variable "project_env" {
  description = "Project environment"
  type        = string
}

output "project_name" {
  value = var.project_name
}

output "project_env" {
  value = var.project_env
}
```

I get:

```
Changes to Outputs:
  + project_env  = "test"
  + project_name = "mybrand"
```

Instead of what I would expect:

```
Changes to Outputs:
  + project_env  = "prod"
  + project_name = "mybrand"
```

This happens because the `*.auto.tfvars` files are processed in the lexical order of their filenames. See [Variable Definition Precedence](https://developer.hashicorp.com/terraform/language/values/variables#variable-definition-precedence)

## What?

Description of changes:

To address this issue, I suggest modifying the file naming convention. Specifically, adding a numeric prefix (e.g., `0-`) to the `global.auto.tfvars` file when it's copied from `${CURRENT}/tfvars/global.auto.tfvars` to `${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}/0-global.auto.tfvars`.

By doing this, we can ensure (at least for file that not start with a number) that all variables defined in `tfvars/TARGET_ACCOUNT_ID/` take precedence over those in `global.auto.tfvars`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
