### PR TITLE
Feat: added support for distinct variable files per region per account in terraform pipelines

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1194,7 +1194,7 @@ pipelines:
    Terraform apply. Confirm to proceed.
 
 **Note**:
-The pipeline leverages the terraform behaviour on reading *.local.tfvars files,
+The pipeline leverages the terraform behavior on reading *.local.tfvars files,
 so the latter file in lexicographical order overrides variables already defined
 in preceding files.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1179,7 +1179,7 @@ pipelines:
      │   └──────│   local.auto.tfvars <-- this file contains variables
      │          │                         related to the account
      │          └───eu-west-1
-     │              └────── region.auto.tfvars <-- this file containes
+     │              └────── region.auto.tfvars <-- this file contains
      │                      variables related to the account and the region
      │
      └───222222222222

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1164,7 +1164,7 @@ pipelines:
 4. Add variable definition to `tf/variables.tf` file and variable values to
    `tfvars/global.auto.tfvars`.
 
-   - Local variables (per account) can be configured using the following
+   - Local variables (per account and per region) can be configured using the following
      naming convention
 
      ```txt
@@ -1178,6 +1178,9 @@ pipelines:
      │   │                the account
      │   └──────│   local.auto.tfvars <-- this file contains variables related
      │          │                         to the account
+     │          └───eu-west-1
+     │              └────── region.auto.tfvars <-- this file containes variables
+     │                                             related to the account and the region
      │
      └───222222222222
          └──────│   local.auto.tfvars
@@ -1189,6 +1192,16 @@ pipelines:
 6. Push to your Terraform ADF repository, for example the sample-terraform one.
 7. Pipeline contains a manual approval step between Terraform plan and
    Terraform apply. Confirm to proceed.
+
+**Note**:
+The pipeline leverages the terraform behaviour on reading *.local.tfvars files, so the latter file in lexicographical order overrides variables already defined in preceding files.
+Given the structure above, terraform can possibly find 3 files:
+
+* `global.auto.tfvars`
+* `local.auto.tfvars`
+* `region.auto.tfvars`
+
+and it means that `region.auto.tfvars` can override variables passed in `local.auto.tfvars`, that in turn can override variables passed in `global.auto.tfvars`.
 
 Terraform state files are stored in the regional S3 buckets in the deployment
 account. One state file per account/region/module is created.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1176,11 +1176,11 @@ pipelines:
      │
      └───111111111111 <-- this folders contains variable files related to
      │   │                the account
-     │   └──────│   local.auto.tfvars <-- this file contains variables related
-     │          │                         to the account
+     │   └──────│   local.auto.tfvars <-- this file contains variables
+     │          │                         related to the account
      │          └───eu-west-1
-     │              └────── region.auto.tfvars <-- this file containes variables
-     │                                             related to the account and the region
+     │              └────── region.auto.tfvars <-- this file containes
+     │                      variables related to the account and the region
      │
      └───222222222222
          └──────│   local.auto.tfvars
@@ -1194,14 +1194,19 @@ pipelines:
    Terraform apply. Confirm to proceed.
 
 **Note**:
-The pipeline leverages the terraform behaviour on reading *.local.tfvars files, so the latter file in lexicographical order overrides variables already defined in preceding files.
+The pipeline leverages the terraform behaviour on reading *.local.tfvars files,
+so the latter file in lexicographical order overrides variables already defined
+in preceding files.
+
 Given the structure above, terraform can possibly find 3 files:
 
-* `global.auto.tfvars`
-* `local.auto.tfvars`
-* `region.auto.tfvars`
+- `global.auto.tfvars`
+- `local.auto.tfvars`
+- `region.auto.tfvars`
 
-and it means that `region.auto.tfvars` can override variables passed in `local.auto.tfvars`, that in turn can override variables passed in `global.auto.tfvars`.
+and it means that `region.auto.tfvars` can override variables passed in
+`local.auto.tfvars`, that in turn can override variables passed in 
+`global.auto.tfvars`.
 
 Terraform state files are stored in the regional S3 buckets in the deployment
 account. One state file per account/region/module is created.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1205,7 +1205,7 @@ Given the structure above, terraform can possibly find 3 files:
 - `region.auto.tfvars`
 
 and it means that `region.auto.tfvars` can override variables passed in
-`local.auto.tfvars`, that in turn can override variables passed in 
+`local.auto.tfvars`, that in turn can override variables passed in
 `global.auto.tfvars`.
 
 Terraform state files are stored in the regional S3 buckets in the deployment

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
@@ -16,7 +16,7 @@ tfinit(){
         cp -R "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}"/* "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
     fi
     if [ -d "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}/${AWS_REGION}" ]; then
-        cp -R "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}/${AWS_REGION}"/* "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
+        cp -R "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}/${AWS_REGION}"/. "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
     fi
     if [ -f "${CURRENT}/tfvars/global.auto.tfvars" ]; then
         cp -R "${CURRENT}/tfvars/global.auto.tfvars" "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
@@ -15,6 +15,9 @@ tfinit(){
     if [ -d "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}" ]; then
         cp -R "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}"/* "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
     fi
+    if [ -d "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}/${AWS_REGION}" ]; then
+        cp -R "${CURRENT}/tfvars/${TF_VAR_TARGET_ACCOUNT_ID}/${AWS_REGION}"/* "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
+    fi
     if [ -f "${CURRENT}/tfvars/global.auto.tfvars" ]; then
         cp -R "${CURRENT}/tfvars/global.auto.tfvars" "${CURRENT}/tmp/${TF_VAR_TARGET_ACCOUNT_ID}-${AWS_REGION}"
     fi


### PR DESCRIPTION
# Why?

The current solution doesn't support different variable values per region in an account.

*Issue #661 

## What?

Description of changes:

- adf_terraform.sh, added the region folder management
- docs/user-guide.md, added documentation regarding the new feature

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
