### PR TITLE
Remove CodeCommitRole from initial base stack

### DIFF
--- a/src/template.yml
+++ b/src/template.yml
@@ -1153,39 +1153,6 @@ Resources:
           RoleArn: !GetAtt AccountBootstrapStartExecutionRole.Arn
           Id: CreateStackLinkedAccountV1
 
-  CodeCommitRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "adf-codecommit-role-base"
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: codecommit.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: /
-
-  CodeCommitPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: "adf-organizations-codecommit-role-policy"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "codecommit:BatchGetRepositories"
-              - "codecommit:Get*"
-              - "codecommit:GitPull"
-              - "codecommit:List*"
-              - "codecommit:CancelUploadArchive"
-              - "codecommit:UploadArchive"
-            Resource: "*"
-      Roles:
-        - !Ref CodeCommitRole
-
   CodeBuildRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
The adf-codecommit-role-base role from the ADF CloudFormation Initial Base Stack for the Management Account in the us-east-1 region, with the trust policy being assumable from `codecommit.amazonaws.com` doesn't seem be used anywhere. I couldn't find it being used in ADF codebase, or the cloudformation template it comes in. I couldn't anything find you could do with codecommit that requires a role with `codecommit.amazonaws.com` being the trusted service principal to assume to it or even passing a role to codecommit.

In the organisation that I'm working with ADF deployed, this role doesn't seem to be ever used as well.

With that in mind I'm proposing to delete this role as it doesn't seem to be used.

# Why?

Describe why you are proposing these changes

*Issue #, if available:*

## What?

Description of changes:

- List
- What
- You
- Changed

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
