### PR TITLE
Move from ACL enforced bucket ownership to Ownership Controls + megalinter prettier fix

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -30,9 +30,7 @@ FILEIO_REPORTER: false
 
 # Install plugin for list handling.
 JSON_PRETTIER_PRE_COMMANDS:
-  - command: |
-      npm install -g prettier-plugin-multiline-arrays@1.1.4
-      npm install --prefix /node-deps/ prettier-plugin-multiline-arrays@1.1.4
+  - command: "npm install prettier-plugin-multiline-arrays@3.0.0"
     cwd: "workspace"
 
 CLOUDFORMATION_CFN_LINT_CONFIG_FILE: '.cfnlintrc'

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,5 +4,5 @@ module.exports = {
   ],
   trailingComma: 'es5',
   semi: false,
-  singleQuote: true
-}
+  singleQuote: true,
+};

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -165,7 +165,6 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: BucketOwnerFullControl
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -1048,7 +1048,9 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: BucketOwnerFullControl
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -1073,7 +1075,9 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: BucketOwnerFullControl
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/src/template.yml
+++ b/src/template.yml
@@ -151,7 +151,9 @@ Resources:
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: BucketOwnerFullControl
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -169,7 +171,9 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: BucketOwnerFullControl
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -684,7 +688,9 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: BucketOwnerFullControl
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
# Why?

According to the S3 docs [0], it is recommended to enforce the bucket ownership via the Ownership Controls.

## What?

1. Upgraded the enforce bucket ownership from the ACL (AccessControl) to OwnershipControls.
2. Fixed MegaLinter to use Prettier with the multiline-arrays plugin.

---

* [0] https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-alternatives-guidelines.html

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
