### PR TITLE
Add kms_encryption_key_arn and cache_control parameters for s3 deploy

### DIFF
--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -647,3 +647,11 @@ Provider type: `s3`.
 - *role* - *(String)* default:
   `arn:${partition}:iam::${target_account_id}:role/adf-cloudformation-role`.
   - The role you would like to use for this action.
+- *kms_encryption_key_arn* - *(String)*
+  - The ARN of the AWS KMS encryption key for the host bucket. The
+    `kms_encryption_key_arn` parameter encrypts uploaded artifacts with the
+    provided AWS KMS key. For a KMS key, you can use the key ID, the key ARN,
+    or the alias ARN.
+- *cache_control* - *(String)*
+  - The `cache_control` parameter controls caching behavior for
+    requests/responses for objects in the bucket.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -188,6 +188,28 @@ class Action:
                         .get('object_key')
                     ))
                 ),
+                "KMSEncryptionKeyARN": (
+                    self.target
+                    .get('properties', {})
+                    .get('kms_encryption_key_arn', (
+                        self.map_params
+                        .get('default_providers', {})
+                        .get('deploy', {})
+                        .get('properties', {})
+                        .get('kms_encryption_key_arn')
+                    ))
+                ),
+                "CacheControl": (
+                    self.target
+                    .get('properties', {})
+                    .get('cache_control', (
+                        self.map_params
+                        .get('default_providers', {})
+                        .get('deploy', {})
+                        .get('properties', {})
+                        .get('cache_control')
+                    ))
+                ),
             }
         if self.provider == "CodeStarSourceConnection":
             default_source_props = (


### PR DESCRIPTION
# Why?

Wanted to set kms_encryption_key_arn but it wasn't available. So decided add the two missing useful properties.

## What?

Description of changes:

- Add kms_encryption_key_arn and cache_control parameters for s3 deploy provider

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
