### PR TITLE
feat: Adding support for AWS-CN partition on cn-north-1 region.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ Launch ADF via the
 [Serverless Application Repository](https://console.aws.amazon.com/lambda/home?region=us-east-1#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:112893979820:applications/aws-deployment-framework)
 within the AWS Console.
 
+## Enabling ADF for GovCloud and China Regions
+
+To deploy ADF in GovCloud or China regions, follow these steps:
+
+### GovCloud
+
+1. Launch the ADF installation from an account with a base region on GovCloud (us-gov-west-1).
+2. Update your AWS CLI configuration to use the AWS GovCloud endpoint.
+
+### China
+
+1. Launch the ADF installation from an account with a base region on China (cn-north-1).
+2. Update your AWS CLI configuration to use the AWS China endpoint.
+
+### Considerations
+Be mindful that AWS Products and Services available may differ from the Global partition
+Ensure that you follow the specific guidelines and compliance requirements for deploying in GovCloud and China regions.
+
 - Refer to the [Installation Guide](docs/installation-guide.md) for
   Installation steps.
 - Refer to the [User Guide](docs/user-guide.md) for using ADF once it is setup.

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -63,6 +63,9 @@ The `adfconfig.yml` file resides on the
 and defines the general high-level configuration for the AWS Deployment
 Framework.
 
+For Govcloud and China deployments, `adfconfig.yml` file resides on the
+[management account](#management-account) CodeCommit Repository (in us-gov-west-1 and cn-north-1 respectively)
+
 The configuration properties are synced into AWS Systems Manager Parameter
 Store and are used for certain orchestration options throughout your
 Organization.
@@ -917,8 +920,9 @@ To determine the current version, follow these steps:
 ### ADF version you have deployed
 
 To check the current version of ADF that you have deployed, go to the management
-account in us-east-1. Check the CloudFormation stack output or tag of the
-`serverlessrepo-aws-deployment-framework` Stack.
+account in us-east-1 for global partition deployments. For Govcloud and China
+deployments go to us-gov-west-1 and cn-north-1 respectively. Check the CloudFormation
+stack output or tag of the `serverlessrepo-aws-deployment-framework` Stack.
 
 - In the outputs tab, it will show the version as the `ADFVersionNumber`.
 - In the tags on the CloudFormation stack, it is presented as
@@ -927,7 +931,8 @@ account in us-east-1. Check the CloudFormation stack output or tag of the
 ### Latest ADF version that is available
 
 If you want to check which version is the latest one available, go to the
-management account in `us-east-1`:
+management account in `us-east-1` for global partition deployments. For Govcloud and China
+deployments go to us-gov-west-1 or cn-north-1 respectively :
 
 1. Navigate to the AWS Deployment Framework Serverless Application Repository
    _(SAR)_, it can be found
@@ -937,7 +942,8 @@ management account in `us-east-1`:
 
 ## Updating Between Versions
 
-Go to the management account in `us-east-1`:
+Go to the management account in `us-east-1` for global partition deployments. For Govcloud and China
+deployments go to us-gov-west-1 or cn-north-1 respectively:
 
 1. Navigate to the AWS Deployment Framework Serverless Application Repository
    _(SAR)_, it can be found
@@ -948,7 +954,8 @@ Go to the management account in `us-east-1`:
    `aws-deployment-framework-bootstrap` repository in the `adfconfig.yml`
    file. Or by looking up the values that were specified the last time ADF got
    installed/updated via the CloudFormation template parameters of the
-   `serverlessrepo-aws-deployment-framework` stack in `us-east-1`.
+   `serverlessrepo-aws-deployment-framework` stack in `us-east-1` for global
+   partition deployments. For Govcloud and China deployments go to us-gov-west-1 or cn-north-1 respectively.
 3. Tick the box at the bottom that states: _"I acknowledge that this app creates
    custom IAM roles and resource policies."_
 4. Click the _Deploy_ button.
@@ -959,8 +966,8 @@ CloudFormation. Leave the browser window open until it changes pages.
 Your `serverlessrepo-aws-deployment-framework` stack is updating
 with new changes that were included in that release of ADF.
 
-To check the progress in the management account in `us-east-1`, follow these
-steps:
+To check the progress in the management account in `us-east-1` for global partition deployments; for Govcloud and China
+deployments go to us-gov-west-1 or cn-north-1 respectively, follow these steps:
 
 1. Go to the [CloudFormation
    console](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filteringStatus=active&filteringText=serverlessrepo-aws-deployment-framework&viewNested=true&hideStacks=false)
@@ -1002,7 +1009,8 @@ Which branch is used is determined by:
 
    Alternatively, you can also perform the update using the AWS CLI.
 
-In the management account in `us-east-1`:
+In the management account in `us-east-1` for global partition deployments; For Govcloud and China
+deployments in us-gov-west-1 or cn-north-1 respectively:
 
 1. Go to the Pull Request section of the `aws-deployment-framework-bootstrap`
    [CodeCommit
@@ -1017,7 +1025,8 @@ In the management account in `us-east-1`:
    changes that it proposes. Once reviewed, merge the pull request to continue.
 
 Confirm the `aws-deployment-framework-bootstrap` pipeline in the management
-account in `us-east-1`:
+account in `us-east-1` for global partition deployments; For Govcloud and China
+deployments go to us-gov-west-1 or cn-north-1 respectively:
 
 1. Go to the [CodePipeline console for the aws-deployment-framework-bootstrap
    pipeline](https://console.aws.amazon.com/codesuite/codepipeline/pipelines/aws-deployment-framework-bootstrap-pipeline/view?region=us-east-1).
@@ -1112,7 +1121,9 @@ Alternatively, you can also perform the update using the AWS CLI.
 
 If you wish to remove ADF you can delete the CloudFormation stack named
 `serverlessrepo-aws-deployment-framework` in the management account in
-the `us-east-1` region. This will move into a `DELETE_FAILED` at some stage because
+the `us-east-1` region for global partition deployments; For Govcloud and China
+deployments go to us-gov-west-1 or cn-north-1 respectively.
+This will move into a `DELETE_FAILED` at some stage because
 there is an S3 Bucket that is created via a custom resource _(cross region)_.
 After it moves into `DELETE_FAILED`, you can right-click on the stack and hit
 delete again while selecting to skip the Bucket the stack will successfully
@@ -1129,11 +1140,12 @@ the base stack when the account is moved to the Root of the AWS Organization.
 
 One thing to keep in mind if you are planning to re-install ADF is that you
 will want to clean up the parameter from SSM Parameter Store named
-_deployment_account_id_ in `us-east-1` on the management account. AWS Step
-Functions uses this parameter to determine if ADF has already got a deployment
-account setup. If you re-install ADF with this parameter set to a value,
-ADF will attempt an assume role to the account to do some work, which will fail
-since that role will not be on the account at that point.
+_deployment_account_id_ in `us-east-1` on the management account for global 
+partition deployments; For Govcloud and China deployments go to us-gov-west-1 
+or cn-north-1 respectively. AWS Step Functions uses this parameter to determine 
+if ADF has already got a deployment account setup. If you re-install ADF with 
+this parameter set to a value, ADF will attempt an assume role to the account 
+to do some work, which will fail since that role will not be on the account at that point.
 
 There is also a CloudFormation stack named `adf-global-base-adf-build` which
 lives on the management account in your main deployment region. This stack
@@ -1168,7 +1180,9 @@ There are two ways to enable this:
    to deploy the latest version again, set the `Log Level` to `DEBUG` to get
    extra logging information about the issue you are experiencing.
 2. If you are running an older version of ADF, please navigate to the
-   CloudFormation Console in `us-east-1` of the AWS Management account.
+   CloudFormation Console in `us-east-1` of the AWS Management account for global 
+   partition deployments; For Govcloud and China deployments go to us-gov-west-1 
+   or cn-north-1 respectively.
 3. Update the stack.
 4. For any ADF deployment of `v3.2.0` and later, please change the `Log Level`
    parameter and set it to `DEBUG`. Deploy those changes and revert them after
@@ -1183,7 +1197,8 @@ Please trace the failed component and dive into/report the debug information.
 
 The main components to look at are:
 
-1. In the AWS Management Account in `us-east-1`:
+1. In the AWS Management Account in `us-east-1` for global partition deployments; For Govcloud and China
+deployments go to us-gov-west-1 or cn-north-1 respectively:
 2. The [CloudFormation aws-deployment-framework stack](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filteringStatus=active&filteringText=aws-deployment-framework&viewNested=true&hideStacks=false).
 3. The [CloudWatch Logs for the Lambda functions deployed by ADF](https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions?f0=true&n0=false&op=and&v0=ADF).
 4. Check if the [CodeCommit pull
@@ -1192,7 +1207,8 @@ The main components to look at are:
    branch for the `aws-deployment-framework-bootstrap` (ADF Bootstrap) repository.
 5. The [CodePipeline execution of the AWS Bootstrap pipeline](https://console.aws.amazon.com/codesuite/codepipeline/pipelines/aws-deployment-framework-bootstrap-pipeline/view?region=us-east-1).
 6. Navigate to the [AWS Step Functions service](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/statemachines)
-   in the management account in `us-east-1`. Check the state machines named
+   in the management account in `us-east-1`for global partition deployments; For Govcloud and China
+   deployments go to us-gov-west-1 or cn-north-1 respectively, check the state machines named
    `AccountManagementStateMachine...` and
    `AccountBootstrappingStateMachine...`. Look at recent executions only.
     - When you find one that has a failed execution, check the components that

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -6,7 +6,8 @@
 - [git](https://git-scm.com/)
   - [AWS CodeCommit Setup](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html)
 - [AWS CloudTrail configured](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-create-and-update-a-trail.html)
-  in the `us-east-1` region within the AWS Organizations Management AWS Account.
+  in the `us-east-1` region within the AWS Organizations Management AWS Account for global partition deployments; For Govcloud and China
+  deployments go to us-gov-west-1 or cn-north-1 respectively..
 
 ## ADF-Compability with AWS Control Tower
 
@@ -24,7 +25,8 @@ action, we call those out explicitly.
 It is okay to install ADF and AWS Control Tower in different regions. Example:
 
 - Install AWS Control Tower in eu-central-1.
-- Install ADF in us-east-1.
+- Install ADF in us-east-1 for global partition deployments; For Govcloud and China
+  deployments intall in us-gov-west-1 or cn-north-1 respectively.
 
 **If you want to use ADF and AWS Control Tower, we recommend that you setup
 AWS Control Tower prior to installing ADF.**
@@ -39,9 +41,10 @@ AWS Control Tower prior to installing ADF.**
    for AWS Organizations can only be acted upon in the US East (N. Virginia)
    Region.
 
-2. In the AWS Console from your management account within `us-east-1`, head
-   over to the Serverless Application Repository *(SAR)*. From there, search
-   for `aws-deployment-framework` *(or "adf")* (ensure the checkbox
+2. In the AWS Console from your management account within `us-east-1` for 
+   global partition deployments; For Govcloud and China deployments in 
+   us-gov-west-1 or cn-north-1 respectively, head over to the Serverless Application Repository *(SAR)*. 
+   From there, search for `aws-deployment-framework` *(or "adf")* (ensure the checkbox
    *"Show apps that create custom IAM roles or resource policies"* is checked).
 
    If you are deploying ADF for the first time, fill in the required parameters
@@ -82,8 +85,10 @@ AWS Control Tower prior to installing ADF.**
    When you have entered all required information press **'Deploy'**.
 
 3. As the stack `serverlessrepo-aws-deployment-framework` completes you can now
-   open AWS CodePipeline from within the management account in `us-east-1` and
-   see that there is an initial pipeline execution that has been started.
+   open AWS CodePipeline from within the management account in `us-east-1` for 
+   global partition deployments; For Govcloud and China deployments go to 
+   us-gov-west-1 or cn-north-1 respectively and see that there is an initial 
+   pipeline execution that has been started.
 
    When ADF is deployed for the first time, it will make the initial commit
    with the skeleton structure of the `aws-deployment-framework-bootstrap`
@@ -124,7 +129,8 @@ AWS Control Tower prior to installing ADF.**
    that started the bootstrap process for the deployment account. You can view
    the progress of this in the management account in the AWS Step Functions
    console for the step function `AccountBootstrappingStateMachine-` in the
-   `us-east-1` region.
+   `us-east-1` region for global partition deployments; For Govcloud and China
+   deployments go to us-gov-west-1 or cn-north-1 respectively.
 
 5. Once the Step Function has completed, switch roles over to the newly
    bootstrapped deployment account in the region you defined as your main

--- a/docs/samples-guide.md
+++ b/docs/samples-guide.md
@@ -70,7 +70,8 @@ Management Account. By default, there is a `global.yml` in the root of the
 be appended to as required.
 
 If we look at AWS Step Functions in the management account in `us-east-1`
-we can see the progress of the bootstrap process.
+we can see the progress of the bootstrap process for global partition deployments; 
+For Govcloud and China deployments go to us-gov-west-1 or cn-north-1 respectively.
 
 ![run-state-machine](./images/run-state-machine.png)
 

--- a/docs/serverless-application-repo.md
+++ b/docs/serverless-application-repo.md
@@ -7,8 +7,9 @@ The [AWS Deployment Framework](https://github.com/awslabs/aws-deployment-framewo
 across multiple AWS accounts and regions within an AWS Organization. This
 application should be deployed via the SAR in the [Management AWS
 account](admin-guide.md#management-account) of your AWS Organization within the
-`us-east-1` region. For more information on setting up ADF please see the
-[installation
+`us-east-1` region for global partition deployments; For Govcloud and China
+deployments go to us-gov-west-1 or cn-north-1 respectively. For more information 
+on setting up ADF please see the [installation
 guide](https://github.com/awslabs/aws-deployment-framework/tree/master/docs/installation-guide.md).
 
 - **Application Name:** The stack name of this application created via AWS
@@ -57,9 +58,11 @@ base level settings for how ADF operates.
 
 When deploying ADF for the first time, part of the installation process will
 automatically create an AWS CodeCommit repository on this AWS Account within the
-`us-east-1` region. It will also make the initial commit to the default branch
-of this repository with a default set of examples that act as a starting point
-to help define the AWS Account bootstrapping processes for your Organization.
+`us-east-1` region for global partition deployments; For Govcloud and China
+deployments in us-gov-west-1 or cn-north-1 respectively. It will also make the 
+initial commit to the default branch of this repository with a default set of 
+examples that act as a starting point to help define the AWS Account bootstrapping 
+processes for your Organization.
 
 When making this initial commit into the repository, these below settings are
 passed directly the `adfconfig.yml` file prior to it being committed.

--- a/src/lambda_codebase/account_bootstrap.py
+++ b/src/lambda_codebase/account_bootstrap.py
@@ -81,7 +81,8 @@ def configure_generic_account(sts, event, region, role):
 
 def configure_master_account_parameters(event):
     """
-    Update the management account parameter store in us-east-1 with the
+    Update the management account parameter store in the base region
+    of the partition (us-east-1, us-gov-west-1 or cn-north-1) with the
     deployment_account_id then updates the main deployment region
     with that same value
     """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -692,6 +692,11 @@ Resources:
                 python: 3.11
                 nodejs: 18
               commands:
+                - |
+                  if [ "${AWS::Region}" = "cn-north-1" ]; then
+                    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+                    npm config set registry https://registry.npmmirror.com
+                  fi
                 - aws s3 cp s3://$SHARED_MODULES_BUCKET/adf-build/ ./adf-build/ --recursive --quiet
                 - pip install -r adf-build/requirements.txt -r adf-build/helpers/requirements.txt -q -t ./adf-build
             pre_build:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/slack.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/slack.py
@@ -87,3 +87,87 @@ stub_failed_bootstrap_event = {
         }
     }]
 }
+
+stub_approval_event_cn = {
+    'Records': [{
+        'EventSource': 'aws:sns',
+        'EventVersion': '1.0',
+        'EventSubscriptionArn': 'arn:aws-cn:sns:cn-north-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+        'Sns': {
+            'Type': 'Notification',
+            'MessageId': '1',
+            'TopicArn': 'arn:aws-cn:sns:cn-north-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+            'Subject': 'APPROVAL NEEDED: AWS CodePipeline adf-pipeline-sample-vpc for action Approve',
+            'Message': '{"region":"cn-north-1","consoleLink":"https://console.amazonaws.cn","approval":{"pipelineName":"adf-pipeline-sample-vpc","stageName":"approval-stage-1","actionName":"Approve","token":"fa777887-41dc-4ac4-8455-a209a93c76b9","expires":"2019-03-17T11:08Z","externalEntityLink":null,"approvalReviewLink":"https://console.amazonaws.cn/codepipeline/"}}',
+            'Timestamp': '3000-03-10T11:08:34.673Z',
+            'SignatureVersion': '1',
+            'Signature': '1',
+            'SigningCertUrl': 'https://sns.opportunities/initiatives.amazonaws.com/SimpleNotificationService',
+            'UnsubscribeUrl': 'https://sns.cn-north-1.amazonaws.com',
+            'MessageAttributes': {}
+        }
+    }]
+}
+
+stub_bootstrap_event_cn = {
+    'Records': [{
+        'EventSource': 'aws:sns',
+        'EventVersion': '1.0',
+        'EventSubscriptionArn': 'arn:aws-cn:sns:cn-north-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+        'Sns': {
+            'Type': 'Notification',
+            'MessageId': '1',
+            'TopicArn': 'arn:aws-cn:sns:cn-north-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+            'Subject': 'AWS Deployment Framework Bootstrap',
+            'Message': 'Account 1111111 has now been bootstrapped into banking/production',
+            'Timestamp': '3000-03-10T11:08:34.673Z',
+            'SignatureVersion': '1',
+            'Signature': '1',
+            'SigningCertUrl': 'https://sns.cn-north-1.amazonaws.com/SimpleNotificationService',
+            'UnsubscribeUrl': 'https://sns.cn-north-1.amazonaws.com',
+            'MessageAttributes': {}
+        }
+    }]
+}
+
+stub_failed_pipeline_event_cn = {
+    'Records': [{
+        'EventSource': 'aws:sns',
+        'EventVersion': '1.0',
+        'EventSubscriptionArn': 'arn:aws-cn:sns:cn-north-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+        'Sns': {
+            'Type': 'Notification',
+            'MessageId': '1',
+            'TopicArn': 'arn:aws-cn:sns:cn-north-11:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+            'Subject': None,
+            'Message': '{"version":"0","id":"1","detail-type":"CodePipeline Pipeline Execution State Change","source":"aws.codepipeline","account":"2","time":"3000-03-10T11:09:38Z","region":"eu-central-1","resources":["arn:aws:codepipeline:eu-central-1:999999:adf-pipeline-sample-vpc"],"detail":{"pipeline":"adf-pipeline-sample-vpc","execution-id":"1","state":"FAILED","version":9.0}}',
+            'Timestamp': '2019-03-10T11:09:49.953Z',
+            'SignatureVersion': '1',
+            'Signature': '2',
+            'SigningCertUrl': 'https://sns.cn-north-1.amazonaws.com/SimpleNotificationService',
+            'UnsubscribeUrl': 'https://sns.cn-north-1.amazonaws.com',
+            'MessageAttributes': {}
+        }
+    }]
+}
+
+stub_failed_bootstrap_event_cn = {
+    'Records': [{
+        'EventSource': 'aws:sns',
+        'EventVersion': '1.0',
+        'EventSubscriptionArn': 'arn:aws-cn:sns:cn-north-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+        'Sns': {
+            'Type': 'Notification',
+            'MessageId': '1',
+            'TopicArn': 'arn:aws-cn:sns:cn-north-1:9999999:adf-pipeline-sample-vpc-PipelineSNSTopic-example',
+            'Subject': 'Failure - AWS Deployment Framework Bootstrap',
+            'Message': '{"Error":"Exception","Cause":"{\\"errorMessage\\": \\"CloudFormation Stack Failed - Account: 111 Region: eu-central-1 Status: ROLLBACK_IN_PROGRESS\\", \\"errorType\\": \\"Exception\\", \\"stackTrace\\": [[\\"/var/task/wait_until_complete.py\\", 99, \\"lambda_handler\\", \\"status))\\"]]}"}',
+            'Timestamp': '2019-03-10T11:09:49.953Z',
+            'SignatureVersion': '1',
+            'Signature': '2',
+            'SigningCertUrl': 'https://sns.cn-north-1.amazonaws.com/SimpleNotificationService',
+            'UnsubscribeUrl': 'https://sns.cn-north-1.amazonaws.com',
+            'MessageAttributes': {}
+        }
+    }]
+}

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/stub_iam_cn.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/stub_iam_cn.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file
+
+"""
+Stubs for testing iam.py
+"""
+
+get_role_policy = {
+    'RoleName': 'string',
+    'PolicyName': 'string',
+    'PolicyDocument': {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "KMS",
+                "Effect": "Allow",
+                "Action": ["iam:ChangePassword"],
+                "Resource": (
+                    "arn:aws-cn:kms:cn-north-1:111111111111:key/existing_key"
+                ),
+            },
+            {
+                "Sid": "S3",
+                "Effect": "Allow",
+                "Action": "s3:ListAllMyBuckets",
+                "Resource": [
+                    "arn:aws-cn:s3:::existing_bucket",
+                    "arn:aws-cn:s3:::existing_bucket/*",
+                ],
+            },
+            {
+                "Sid": "AssumeRole",
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Resource": ['something'],
+            },
+        ]
+    }
+}

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/test_slack.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/test_slack.py
@@ -2,14 +2,26 @@
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file
+import os
+from boto3.session import Session
 
 from pytest import fixture
 from ..slack import *
-from .stubs.slack import (
-    stub_approval_event,
-    stub_failed_pipeline_event,
-    stub_bootstrap_event,
-    stub_failed_bootstrap_event,
+
+REGION = os.getenv("AWS_REGION", "us-east-1")
+PARTITION = Session().get_partition_for_region(REGION)
+
+if PARTITION == "aws-cn":
+    from .stubs.slack import stub_approval_event_cn as stub_approval_event
+    from .stubs.slack import stub_failed_pipeline_event_cn as stub_failed_pipeline_event
+    from .stubs.slack import stub_bootstrap_event_cn as stub_bootstrap_event
+    from .stubs.slack import stub_failed_bootstrap_event_cn as stub_failed_bootstrap_event
+else:
+    from .stubs.slack import (
+        stub_approval_event,
+        stub_failed_pipeline_event,
+        stub_bootstrap_event,
+        stub_failed_bootstrap_event,
 )
 
 @fixture

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -674,6 +674,11 @@ Resources:
                 python: 3.11
                 nodejs: 18
               commands:
+                - |
+                  if [ "${AWS::Region}" = "cn-north-1" ]; then
+                    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+                    npm config set registry https://registry.npmmirror.com
+                  fi
                 - npm install aws-cdk@2.79 -g -y --quiet --no-progress
                 - aws s3 cp s3://$SHARED_MODULES_BUCKET/adf-build/ ./adf-build/ --recursive --quiet
                 - pip install -r adf-build/requirements.txt -q -t ./adf-build

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/china-forward-function/handler.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/china-forward-function/handler.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+The forward function will forward events to the target SFN.
+"""
+
+import logging
+import os
+
+import boto3
+from stepfunction_helper import Stepfunction
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(os.environ.get("ADF_LOG_LEVEL", logging.INFO))
+SFN_ARN = os.getenv("SFN_ARN", "")
+sfn_name = SFN_ARN.split(':')[-1]
+
+
+def lambda_handler(event, context):
+    LOGGER.debug(event)
+    if "source" in event and event["source"] == "aws.organizations":
+        session = boto3.session.Session(region_name="cn-north-1")
+        sfn_instance = Stepfunction(session, LOGGER)
+        _, state_name = sfn_instance.invoke_sfn_execution(
+            sfn_arn=SFN_ARN,
+            input=event,
+        )
+        LOGGER.info(f"Successfully invoke sfn {sfn_name} with statemachine name {state_name}.")

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/china-forward-function/stepfunction_helper.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/china-forward-function/stepfunction_helper.py
@@ -1,0 +1,55 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import json
+import uuid
+from decimal import Decimal
+
+
+def convert_decimals(obj):
+    if isinstance(obj, Decimal):
+        return str(obj)
+    elif isinstance(obj, list):
+        return [convert_decimals(item) for item in obj]
+    elif isinstance(obj, dict):
+        return {key: convert_decimals(value) for key, value in obj.items()}
+    else:
+        return obj
+
+
+class Stepfunction:
+    """Class to handle Custom Stepfunction methods"""
+
+    def __init__(
+        self,
+        session,
+        LOGGER
+    ):
+        self.logger = LOGGER
+        self.session = session
+
+    def get_stepfunction_client(self):
+        return self.session.client("stepfunctions")
+
+    def invoke_sfn_execution(
+            self,
+            sfn_arn,
+            input: dict,
+            execution_name=None):
+        try:
+            state_machine_arn = sfn_arn
+            sfn_client = self.get_stepfunction_client()
+
+            if not execution_name:
+                execution_name = str(uuid.uuid4())
+            event_body = json.dumps(convert_decimals(input), indent=2)
+            response = sfn_client.start_execution(
+                stateMachineArn=state_machine_arn,
+                name=execution_name,
+                input=event_body
+            )
+        except Exception as e:
+            msg = f"Couldn't invoke stepfunction {sfn_arn}, error: {e}."
+            self.logger.error(msg)
+            raise
+        return response, execution_name

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/cn_northwest_bucket.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/cn_northwest_bucket.yml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  ADF CloudFormation Template - Create S3 bucket for cn-northwest-1
+
+Parameters:
+  BucketName:
+    Type: String
+
+Resources:
+  BootstrapArtifactStorageBucket:
+    DeletionPolicy: Delete
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName 
+      AccessControl: BucketOwnerFullControl
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/cn_northwest_deploy.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/cn_northwest_deploy.yml
@@ -1,0 +1,83 @@
+# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: ADF CloudFormation Stack for deploy extra resources in China cn-northwest-1.
+
+Parameters:
+  AcoountBootstrapingStateMachineArn:
+    Type: String
+  AdfLogLevel:
+    Type: String
+
+Globals:
+  Function:
+    Architectures:
+      - arm64
+    CodeUri: china-forward-function
+    Runtime: python3.9
+    Timeout: 300
+    Tracing: Active
+
+Resources:
+  ForwardStateMachineFunctionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/adf-china-extra/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+
+  ForwardStateMachineFunctionRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "forward-state-machine-function-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "states:StartExecution"
+            Resource: !Ref AcoountBootstrapingStateMachineArn 
+          - Effect: Allow
+            Action:
+              - "logs:CreateLogGroup"
+              - "logs:CreateLogStream"
+              - "logs:PutLogEvents"
+              - "xray:PutTelemetryRecords"
+              - "xray:PutTraceSegments"
+              - "cloudwatch:PutMetricData"
+            Resource: "*"
+      Roles:
+        - !Ref ForwardStateMachineFunctionRole
+
+
+  ForwardStateMachineFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: handler.lambda_handler
+      Description: "ADF Lambda Function - Forward events to statemachine"
+      Environment:
+        Variables:
+          SFN_ARN: !Ref AcoountBootstrapingStateMachineArn
+          ADF_LOG_LEVEL: !Ref AdfLogLevel
+      FunctionName: ForwardStateMachineFunction
+      Role: !GetAtt ForwardStateMachineFunctionRole.Arn
+      Events:
+        RuleEvent:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source:
+                - aws.organizations
+              detail:
+                eventSource:
+                  - organizations.amazonaws.com
+                eventName:
+                  - MoveAccount

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/create_s3_cn.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/create_s3_cn.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Main entry point for create_s3_cn.py execution which
+is executed from within AWS CodeBuild in the management account
+"""
+import os
+import boto3
+from logger import configure_logger
+from cloudformation import CloudFormation
+
+REGION_DEFAULT = os.environ["AWS_REGION"]
+ACCOUNT_ID = os.environ["MASTER_ACCOUNT_ID"]
+LOGGER = configure_logger(__name__)
+
+def _create_s3_bucket(bucket_name):
+    try:
+        LOGGER.info(f"Deploy S3 bucket {bucket_name}...")
+        extra_deploy_region = "cn-northwest-1"
+        template_path = "adf-build/cn_northwest_bucket.yml"
+        stack_name = 'adf-regional-base-china-bucket'
+        parameters= [
+                {
+                    'ParameterKey': 'BucketName',
+                    'ParameterValue': bucket_name,
+                    'UsePreviousValue': False,
+                },          
+            ]
+        cloudformation = CloudFormation(
+            region=extra_deploy_region,
+            deployment_account_region=extra_deploy_region,
+            role=boto3,
+            wait=True,
+            stack_name=stack_name,
+            account_id=ACCOUNT_ID,
+            parameters = parameters,
+            local_template_path=template_path
+        )
+        cloudformation.create_stack()
+    except Exception as error:
+        LOGGER.error(f"Failed to process _create_s3_bucket, error:\n {error}")
+        exit(1)
+
+def main():
+    bucket_name = f"adf-china-bootstrap-cn-northwest-1-{ACCOUNT_ID}"
+    _create_s3_bucket(bucket_name)
+
+if __name__ == '__main__':
+    main()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -9,26 +9,24 @@ is executed from within AWS CodeBuild in the management account
 import os
 import sys
 import time
-from math import floor
 from datetime import datetime
-from thread import PropagatingThread
+from math import floor
 
 import boto3
-
 from botocore.exceptions import ClientError
-from logger import configure_logger
 from cache import Cache
 from cloudformation import CloudFormation
-from parameter_store import ParameterStore
-from organizations import Organizations
-from stepfunctions import StepFunctions
-from errors import GenericAccountConfigureError, ParameterNotFoundError
-from sts import STS
-from s3 import S3
-from partition import get_partition
 from config import Config
+from errors import GenericAccountConfigureError, ParameterNotFoundError
+from logger import configure_logger
 from organization_policy import OrganizationPolicy
-
+from organizations import Organizations
+from parameter_store import ParameterStore
+from partition import get_partition
+from s3 import S3
+from stepfunctions import StepFunctions
+from sts import STS
+from thread import PropagatingThread
 
 S3_BUCKET_NAME = os.environ["S3_BUCKET"]
 REGION_DEFAULT = os.environ["AWS_REGION"]
@@ -148,9 +146,18 @@ def prepare_deployment_account(sts, deployment_account_id, config):
     )
     deployment_account_parameter_store.put_parameter(
         'default_scm_branch',
-        config.config.get('scm', {}).get(
-            'default-scm-branch',
-            ADF_DEFAULT_SCM_FALLBACK_BRANCH,
+        (
+            config.config
+            .get('scm', {})
+            .get('default-scm-branch', ADF_DEFAULT_SCM_FALLBACK_BRANCH)
+        )
+    )
+    deployment_account_parameter_store.put_parameter(
+        '/adf/scm/default-scm-codecommit-account-id',
+        (
+            config.config
+            .get('scm', {})
+            .get('default-scm-codecommit-account-id', deployment_account_id)
         )
     )
     deployment_account_parameter_store.put_parameter(
@@ -211,7 +218,6 @@ def _store_extension_parameters(parameter_store, config):
             )
 
 
-# pylint: disable=too-many-locals
 def worker_thread(
     account_id,
     sts,
@@ -261,6 +267,15 @@ def worker_thread(
                 'bucket_name',
                 updated_kms_bucket_dict[region]['s3_regional_bucket'],
             )
+
+            # Ensuring the stage parameter on the target account is up-to-date
+            parameter_store.put_parameter(
+                '/adf/org/stage',
+                config.config.get('org', {}).get(
+                    'stage',
+                    ADF_DEFAULT_ORG_STAGE,
+                )
+            )
             cloudformation = CloudFormation(
                 region=region,
                 deployment_account_region=config.deployment_account_region,
@@ -285,7 +300,7 @@ def worker_thread(
                         'Unit within AWS Organizations.',
                         account_id,
                     )
-                raise LookupError from error
+                raise Exception from error
 
     except GenericAccountConfigureError as generic_account_error:
         LOGGER.info(generic_account_error)
@@ -316,14 +331,14 @@ def await_sfn_executions(sfn_client):
         ),
         status_filter=None,
     ):
+        DOMAIN = "amazonaws.cn" if PARTITION == "aws-cn" else "aws.amazon.com"
         LOGGER.error(
             "Account Management State Machine encountered a failed, "
             "timed out, or aborted execution. Please look into this problem "
             "before retrying the bootstrap pipeline. You can navigate to: "
-            "https://%s.console.aws.amazon.com/states/home?region=%s#/statemachines/view/%s",
-            REGION_DEFAULT,
-            REGION_DEFAULT,
-            ACCOUNT_MANAGEMENT_STATE_MACHINE_ARN,
+            f"https://{REGION_DEFAULT}.console.{DOMAIN}/states/home?"
+            f"region={REGION_DEFAULT}#/statemachines/"
+            f"view/{ACCOUNT_MANAGEMENT_STATE_MACHINE_ARN}"
         )
         sys.exit(1)
     if _sfn_execution_exists_with(
@@ -342,15 +357,14 @@ def await_sfn_executions(sfn_client):
             "Account Bootstrapping State Machine encountered a failed, "
             "timed out, or aborted execution. Please look into this problem "
             "before retrying the bootstrap pipeline. You can navigate to: "
-            "https://%(region)s.console.aws.amazon.com/states/home"
+            "https://%(region)s.console.%(domain)s/states/home"
             "?region=%(region)s#/statemachines/view/%(sfn_arn)s",
             {
                 "region": REGION_DEFAULT,
                 "sfn_arn": ACCOUNT_BOOTSTRAPPING_STATE_MACHINE_ARN,
+                "domain": "amazonaws.cn" if PARTITION == "aws-cn" else "aws.amazon.com"
             },
         )
-        sys.exit(2)
-
 
 def _await_running_sfn_executions(
     sfn_client,
@@ -401,6 +415,57 @@ def _sfn_execution_exists_with(
     return False
 
 
+def _china_region_extra_deploy(region: str):
+    if region != "cn-north-1":
+        return
+    else:
+        extra_deploy_region = "cn-northwest-1"
+
+        parameters = [
+            {
+                'ParameterKey': 'AcoountBootstrapingStateMachineArn',
+                'ParameterValue': ACCOUNT_BOOTSTRAPPING_STATE_MACHINE_ARN,
+                'UsePreviousValue': False,
+            },
+            {
+                'ParameterKey': 'AdfLogLevel',
+                'ParameterValue': ADF_LOG_LEVEL,
+                'UsePreviousValue': False,
+            },
+        ]
+
+        try:
+            s3_china = S3(
+                region=REGION_DEFAULT,
+                bucket=S3_BUCKET_NAME
+            )
+            cloudformation = CloudFormation(
+                region=extra_deploy_region,
+                deployment_account_region=extra_deploy_region,
+                role=boto3,
+                wait=True,
+                stack_name='adf-regional-base-china-extra',
+                s3=s3_china,
+                s3_key_path='adf-build',
+                account_id=ACCOUNT_ID,
+                template_file_prefix='cn_northwest_deploy',
+                parameters=parameters
+
+            )
+            cloudformation.create_stack()
+
+        except Exception as error:
+            LOGGER.error(
+                "China extra stack adf-regional-base-china-extra deployment failed in region %(region)s, please check following error: "
+                "%(error)s",
+                {
+                    "region": extra_deploy_region,
+                    "error": str(error),
+                },
+            )
+            sys.exit(2)
+
+
 def main():  # pylint: disable=R0915
     LOGGER.info("ADF Version %s", ADF_VERSION)
     LOGGER.info("ADF Log Level is %s", ADF_LOG_LEVEL)
@@ -409,7 +474,8 @@ def main():  # pylint: disable=R0915
 
     policies = OrganizationPolicy()
     config = Config()
-
+    # fix the china org service endpoint
+    _china_region_extra_deploy(REGION_DEFAULT)
     try:
         parameter_store = ParameterStore(REGION_DEFAULT, boto3)
         deployment_account_id = parameter_store.fetch_parameter(

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -416,6 +416,11 @@ def _sfn_execution_exists_with(
 
 
 def _china_region_extra_deploy(region: str):
+    '''
+    This method is used to deploy extra resources
+    params: region: aws region
+    return: None
+    '''
     if region != "cn-north-1":
         return
     else:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/organization_policy.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/organization_policy.py
@@ -58,6 +58,16 @@ class OrganizationPolicy:
         return region.startswith("us-gov")
 
     @staticmethod
+    def _is_china(region: str) -> bool:
+        """
+        Evaluates the region to determine if it is part of China Partition.
+
+        :param region: a region (cn-north-1)
+        :return: Returns True if the region is China Partition, False otherwise.
+        """
+        return region.startswith("cn-")
+
+    @staticmethod
     def set_scp_attachment(access_identifier, organization_mapping, path, organizations):
         if access_identifier:
             if access_identifier.get("keep-default-scp") != "enabled":

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -40,6 +40,9 @@ def get_partition(region_name: str) -> str:
     if region_name.startswith('us-gov'):
         return 'aws-us-gov'
 
+    elif region_name.startswith("cn-"):
+        return "aws-cn"
+
     return 'aws'
 
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/retrieve_organization_accounts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/retrieve_organization_accounts.py
@@ -154,12 +154,15 @@ def main():
 def _get_partition(region_name: str) -> str:
     """Given the region, this function will return the appropriate partition.
 
-    :param region_name: The name of the region (us-east-1, us-gov-west-1)
+    :param region_name: The name of the region (us-east-1, us-gov-west-1 or cn-north-1)
     :return: Returns the partition name as a string.
     """
 
     if region_name.startswith("us-gov"):
         return "aws-us-gov"
+
+    elif region_name.startswith("cn-"):
+        return "aws-cn"
 
     return "aws"
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
@@ -18,9 +18,9 @@ from paginator import paginator
 LOGGER = configure_logger(__name__)
 STACK_TERMINATION_PROTECTION = os.environ.get('TERMINATION_PROTECTION', False)
 CFN_CONFIG = Config(
-    retries={
-        "max_attempts": 10,
-    },
+    retries=dict(
+        max_attempts=10
+    )
 )
 # A stack name can contain only alphanumeric characters (case sensitive)
 # and hyphens.
@@ -116,7 +116,6 @@ class WaitException(Exception):
 
 
 class CloudFormation(StackProperties):
-    # pylint: disable=too-many-arguments
     def __init__(
             self,
             region,
@@ -130,6 +129,8 @@ class CloudFormation(StackProperties):
             parameters=None,
             account_id=None,  # Used for logging visibility
             role_arn=None,
+            template_file_prefix=None, # define a custom template file
+            local_template_path=None, # support local tempplate path
     ):
         self.client = role.client(
             'cloudformation',
@@ -149,7 +150,12 @@ class CloudFormation(StackProperties):
             s3=s3,
             s3_key_path=s3_key_path
         )
-
+        self.template_url_from_template_file_prefix = self.s3.fetch_s3_url(
+            self._create_template_path(self.s3_key_path, template_file_prefix)
+        ) \
+            if template_file_prefix else None
+        self.template_url = template_url or self.template_url_from_template_file_prefix
+        self.local_template_path = local_template_path
     def validate_template(self):
         try:
             return self.client.validate_template(TemplateURL=self.template_url)
@@ -164,6 +170,20 @@ class CloudFormation(StackProperties):
             raise InvalidTemplateError(
                 f"{self.template_url}: {error}",
             ) from None
+
+    def _handle_template_path(
+        self,
+        template_path
+    ):
+        try:
+            # Read the CloudFormation template from a file
+            with open(template_path, 'r') as template_file:
+                template_body = template_file.read()
+
+            return template_body
+        except Exception as error:
+            LOGGER.error(f"Process _handle_template_path function error:\n {error}.")
+            return None
 
     def _wait_if_in_progress(self):
         status = self.get_stack_status()
@@ -314,16 +334,26 @@ class CloudFormation(StackProperties):
             self.stack_name,
         )
         try:
-            self.template_url = (
-                self.template_url
-                if self.template_url is not None
-                else self.get_template_url()
-            )
-            if self.template_url:
-                self.validate_template()
+            cfn_template_map = None
+            if self.local_template_path:
+                cfn_template_map = {
+                    "TemplateBody": self._handle_template_path(self.local_template_path)
+                }
+            else:    
+                self.template_url = (
+                    self.template_url
+                    if self.template_url is not None
+                    else self.get_template_url()
+                )
+                if self.template_url:
+                    self.validate_template()
+                    cfn_template_map = {
+                        "TemplateURL": self.template_url
+                    }                    
+
+            if cfn_template_map:
                 change_set_params = {
                     "StackName": self.stack_name,
-                    "TemplateURL": self.template_url,
                     "Parameters": (
                         self.parameters
                         if self.parameters is not None
@@ -340,6 +370,7 @@ class CloudFormation(StackProperties):
                     "ChangeSetName": self.stack_name,
                     "ChangeSetType": self._get_change_set_type()
                 }
+                change_set_params.update(cfn_template_map)
                 if self.role_arn:
                     change_set_params["RoleARN"] = self.role_arn
                 self._clean_up_when_required()
@@ -514,7 +545,7 @@ class CloudFormation(StackProperties):
             )
             return [item.get('OutputValue') for item in response.get('Stacks')
                     [0].get('Outputs') if item.get('OutputKey') == value][0]
-        except BaseException:  # pylint: disable=broad-exception-caught
+        except BaseException:
             LOGGER.warning(
                 "%s in %s - Attempted to get stack output from %s "
                 "but it failed.",

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
@@ -10,7 +10,7 @@ https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genre
 
 from boto3.session import Session
 
-COMPATIBLE_PARTITIONS = ['aws-us-gov', 'aws']
+COMPATIBLE_PARTITIONS = ['aws-us-gov', 'aws', 'aws-cn']
 
 
 class IncompatiblePartitionError(Exception):

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
@@ -44,4 +44,18 @@ def get_organization_api_region(region_name: str) -> str:
     if get_partition(region_name) == 'aws-us-gov':
         return 'us-gov-west-1'
 
+    elif region_name.startswith("cn-"):
+        return "aws-cn"
+
     return 'us-east-1'
+
+def get_aws_domain(region_name: str) -> str:
+    """
+    Get AWS domain suffix
+    """
+    import re
+    _partition = get_partition(region_name)
+    if re.match("^aws-.*", _partition):
+        return "amazonaws.com.{0}".format(_partition.split("-")[-1])
+    else:
+        return "amazonaws.com"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_partition.py
@@ -19,8 +19,11 @@ _govcloud_regions = [
     'us-gov-east-1'
 ]
 
-_incompatible_regions = [
-    'cn-north-1',
+_china_region = [
+    'cn-north-1'
+ ]
+
+_incompatible_region = [
     'cn-northwest-1'
 ]
 
@@ -34,8 +37,11 @@ def test_partition_govcloud_regions(region):
 def test_partition_us_commercial_regions(region):
     assert get_partition(region) == 'aws'
 
+@pytest.mark.parametrize('region', _china_region)
+def test_partition_china_regions(region):
+    assert get_partition(region) == 'aws-cn'
 
-@pytest.mark.parametrize('region', _incompatible_regions)
+@pytest.mark.parametrize('region', _incompatible_region)
 def test_partition_incompatible_regions(region):
     with pytest.raises(IncompatiblePartitionError) as excinfo:
         get_partition(region)

--- a/src/lambda_codebase/organization/main.py
+++ b/src/lambda_codebase/organization/main.py
@@ -70,14 +70,16 @@ class PhysicalResource:
 def create_(_event: Mapping[str, Any], _context: Any) -> CloudFormationResponse:
     approved_regions = [
         'us-east-1',
-        'us-gov-west-1'
+        'us-gov-west-1',
+        'cn-north-1'
     ]
     region = os.getenv('AWS_REGION')
 
     if region not in approved_regions:
         raise ValueError(
             "Deployment of ADF is only available via the us-east-1 "
-            "and us-gov-west-1 regions."
+            "us-gov-west-1 "
+            "and cn-north-1 regions."
         )
     organization_id, created = ensure_organization()
     organization_root_id = get_organization_root_id()

--- a/src/template.yml
+++ b/src/template.yml
@@ -3,7 +3,7 @@
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"
-Description: ADF CloudFormation Initial Base Stack for the Management Account in the base region of the partition (us-east-1, us-gov-west-1 or cn-north-1).
+Description: ADF CloudFormation Initial Base Stack for the Management Account in the cn-north-1 region.
 
 Metadata:
   AWS::ServerlessRepo::Application:
@@ -114,9 +114,17 @@ Parameters:
 Globals:
   Function:
     CodeUri: lambda_codebase
-    Runtime: python3.10
+    Runtime: python3.9
     Timeout: 300
 
+Conditions:
+  IsChinaMainRegion:
+    "Fn::Equals":
+      - !Sub "${AWS::Region}"
+      - "cn-north-1"
+  NotChinaMainRegion:
+      "Fn::Not":
+        - Condition: IsChinaMainRegion
 Resources:
   BootstrapTemplatesBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -151,9 +159,7 @@ Resources:
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      AccessControl: BucketOwnerFullControl
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -171,9 +177,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      AccessControl: BucketOwnerFullControl
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -267,7 +271,6 @@ Resources:
         - !Ref GetAccountRegionsFunctionRole
         - !Ref DeleteDefaultVPCFunctionRole
         - !Ref AccountAliasConfigFunctionRole
-        - !Ref AccountRegionConfigFunctionRole
         - !Ref AccountTagConfigFunctionRole
         - !Ref AccountOUConfigFunctionRole
         - !Ref CreateAccountFunctionRole
@@ -306,7 +309,6 @@ Resources:
                   - !GetAtt AccountOUConfigFunction.Arn
                   - !GetAtt GetAccountRegionsFunction.Arn
                   - !GetAtt DeleteDefaultVPCFunction.Arn
-                  - !GetAtt AccountRegionConfigFunction.Arn
 
   AccountFileProcessingFunction:
     Type: 'AWS::Serverless::Function'
@@ -365,6 +367,15 @@ Resources:
                 - lambda.amazonaws.com
             Action: "sts:AssumeRole"
       Path: "/aws-deployment-framework/account-management/"
+      Policies:
+        - PolicyName: "adf-lambda-create-account-alias-policy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "iam:CreateAccountAlias"
+                Resource: "*"
 
   AccountAliasConfigFunction:
     Type: 'AWS::Serverless::Function'
@@ -408,7 +419,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - "organizations:TagResource"
-                  - "organizations:UntagResource"
                 Resource: "*"
 
   AccountTagConfigFunction:
@@ -430,54 +440,6 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: AccountTagConfigurationFunction
       Role: !GetAtt AccountTagConfigFunctionRole.Arn
-
-  AccountRegionConfigFunctionRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action: "sts:AssumeRole"
-      Path: "/aws-deployment-framework/account-management/"
-      Policies:
-        - PolicyName: "adf-lambda-account-region-resource-policy"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "account:ListRegions"
-                  - "account:EnableRegion"
-                  - "sts:GetCallerIdentity"
-                Resource: "*"
-              - Effect: Allow
-                Action: ssm:GetParameter
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/target_regions"
-
-  AccountRegionConfigFunction:
-    Type: 'AWS::Serverless::Function'
-    Properties:
-      Handler: configure_account_regions.lambda_handler
-      Description: "ADF Lambda Function - Account region Configuration"
-      CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
-      Tracing: Active
-      Layers:
-        - !Ref LambdaLayerVersion
-      Environment:
-        Variables:
-          MASTER_ACCOUNT_ID: !Ref AWS::AccountId
-          ORGANIZATION_ID: !GetAtt Organization.OrganizationId
-          ADF_VERSION: !FindInMap ['Metadata', 'ADF', 'Version']
-          ADF_LOG_LEVEL: !Ref LogLevel
-      FunctionName: AccountRegionConfigurationFunction
-      Role: !GetAtt AccountRegionConfigFunctionRole.Arn
 
   AccountOUConfigFunction:
     Type: 'AWS::Serverless::Function'
@@ -688,9 +650,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
+      AccessControl: BucketOwnerFullControl
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -724,7 +684,7 @@ Resources:
                   "Next": "CreateAccount"
                 }
               ],
-              "Default": "ConfigureAccountRegions"
+              "Default": "ConfigureAccountAlias"
             },
             "ConfigureAccountAlias": {
               "Type": "Task",
@@ -801,41 +761,7 @@ Resources:
                   "MaxAttempts": 6
                 }
               ],
-              "Next": "ConfigureAccountRegions"
-            },
-            "ConfigureAccountRegions": {
-              "Type": "Task",
-              "Resource": "${AccountRegionConfigFunction.Arn}",
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "IntervalSeconds": 2,
-                  "MaxAttempts": 6,
-                  "BackoffRate": 2
-                }
-              ],
-              "Next": "AreRegionsConfigured"
-            },
-            "AreRegionsConfigured": {
-              "Type": "Choice",
-              "Choices": [
-                {
-                  "Variable": "$.all_regions_enabled",
-                  "BooleanEquals": true,
-                  "Next": "ConfigureAccountAlias"
-                }
-              ],
-              "Default": "Wait 15 seconds"
-            },
-            "Wait 15 seconds": {
-              "Type": "Wait",
-              "Seconds": 15,
-              "Next": "ConfigureAccountRegions"
+              "Next": "ConfigureAccountAlias"
             },
             "ConfigureAccountTags": {
               "Type": "Task",
@@ -971,7 +897,7 @@ Resources:
     Properties:
       ContentUri: "./lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/"
       CompatibleRuntimes:
-        - python3.10
+        - python3.9
       Description: "Shared Lambda Layer between master and deployment account"
       LayerName: shared_layer
 
@@ -1144,6 +1070,7 @@ Resources:
 
   CloudWatchEventsRule:
     Type: "AWS::Events::Rule"
+    Condition: NotChinaMainRegion
     Properties:
       Description: Triggers StateMachine on Move OU
       EventPattern:
@@ -1158,6 +1085,39 @@ Resources:
         - Arn: !Ref AccountBootstrappingStateMachine
           RoleArn: !GetAtt AccountBootstrapStartExecutionRole.Arn
           Id: CreateStackLinkedAccountV1
+
+  CodeCommitRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "adf-codecommit-role-base"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codecommit.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+
+  CodeCommitPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "adf-organizations-codecommit-role-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "codecommit:BatchGetRepositories"
+              - "codecommit:Get*"
+              - "codecommit:GitPull"
+              - "codecommit:List*"
+              - "codecommit:CancelUploadArchive"
+              - "codecommit:UploadArchive"
+            Resource: "*"
+      Roles:
+        - !Ref CodeCommitRole
 
   CodeBuildRole:
     Type: AWS::IAM::Role
@@ -1269,6 +1229,7 @@ Resources:
               - !Sub "arn:${AWS::Partition}:cloudformation:*:*:stack/adf-global-base-*/*"
               - !Sub "arn:${AWS::Partition}:cloudformation:*:*:stack/adf-regional-base-*/*"
               - !Sub "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/adf-global-base-adf-build/*"
+              - !Sub "arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31"
           - Effect: "Allow"
             Action:
               - "s3:DeleteObject"
@@ -1306,6 +1267,42 @@ Resources:
               - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${CrossAccountAccessRoleName}"
               - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${CrossAccountAccessRoleName}-readonly"
 
+  CodeBuildPolicyChina:
+    Type: "AWS::IAM::ManagedPolicy"
+    Condition: IsChinaMainRegion
+    Properties:
+      Description: "Policy to allow codebuild to perform actions for china region"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action:
+              - "lambda:*"
+              - "iam:PassRole"
+              - "iam:CreatePolicy"
+              - "iam:CreateRole"
+              - "iam:DeleteRole"
+              - "iam:DeleteRolePolicy"
+              - "iam:GetRole"
+              - "iam:PutRolePolicy"
+              - "iam:UpdateAssumeRolePolicy"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:ForwardStateMachineFunction"
+              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/adf-china-extra/adf-regional-base-*"
+          - Effect: "Allow"
+            Action:
+              - "s3:*"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::adf-china-bootstrap-cn-northwest-1-${AWS::AccountId}"
+              - !Sub "arn:${AWS::Partition}:s3:::adf-china-bootstrap-cn-northwest-1-${AWS::AccountId}/*"
+          - Effect: "Allow"
+            Action:
+              - "events:*"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:events:cn-northwest-1:${AWS::AccountId}:rule/adf-regional-base-china*"
+      Roles:
+        - !Ref BootstrapCodeBuildRole
+
   CodeCommitRepository:
     Type: AWS::CodeCommit::Repository
     Properties:
@@ -1322,7 +1319,7 @@ Resources:
       Environment:
         ComputeType: "BUILD_GENERAL1_LARGE"
         PrivilegedMode: true
-        Image: "aws/codebuild/standard:7.0"
+        Image: "aws/codebuild/standard:5.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
             Value: !FindInMap ["Metadata", "ADF", "Version"]
@@ -1355,13 +1352,12 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.11
+                python: 3.9
             pre_build:
               commands:
                 - |
-                  if [ "${AWS_REGION}" = "cn-north-1" ]; then
+                  if [ "${AWS_REGION}" = "cn-north-1" ] || [ "${AWS_REGION}" = "cn-northwest-1" ]; then
                     pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
-                    npm config set registry https://registry.npmmirror.com
                   fi
                 - >-
                   pip install
@@ -1375,11 +1371,18 @@ Resources:
                 - pytest -vvv
             build:
               commands:
+                - sam build -t adf-bootstrap/deployment/pipeline_management.yml
                 - sam build -t adf-bootstrap/deployment/global.yml
                 - >-
                     sam package --output-template-file adf-bootstrap/deployment/global.yml
                     --s3-prefix adf-bootstrap/deployment --s3-bucket $DEPLOYMENT_ACCOUNT_BUCKET
                 - python adf-build/store_config.py
+                - |
+                  if [ "${AWS_REGION}" = "cn-north-1" ] || [ "${AWS_REGION}" = "cn-northwest-1" ]; then
+                    python adf-build/create_s3_cn.py
+                    sam build -t adf-build/cn_northwest_deploy.yml --region cn-northwest-1
+                    sam package --output-template-file adf-build/cn_northwest_deploy.yml --s3-prefix adf-bootstrap --s3-bucket adf-china-bootstrap-cn-northwest-1-${MASTER_ACCOUNT_ID} --region cn-northwest-1
+                  fi
                 # Shared Modules to be used with AWS CodeBuild:
                 - aws s3 sync ./adf-build/shared s3://$DEPLOYMENT_ACCOUNT_BUCKET/adf-build --quiet
                 # Base templates:

--- a/src/template.yml
+++ b/src/template.yml
@@ -3,7 +3,7 @@
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"
-Description: ADF CloudFormation Initial Base Stack for the Management Account in the base region of the partition (us-east-1, us-gov-west-1 or cn-north-1).
+Description: ADF CloudFormation Initial Base Stack for the Management Account in the base region of the partition (us-east-1, us-gov-west-1 or cn-north-1), In China regions, as Organization service endpoint is located in cn-northwest-1 region, the org related service rule should be delpoyed in cn-northwest-1
 
 Metadata:
   AWS::ServerlessRepo::Application:

--- a/src/template.yml
+++ b/src/template.yml
@@ -3,7 +3,7 @@
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"
-Description: ADF CloudFormation Initial Base Stack for the Management Account in the us-east-1 region.
+Description: ADF CloudFormation Initial Base Stack for the Management Account in the base region of the partition (us-east-1, us-gov-west-1 or cn-north-1).
 
 Metadata:
   AWS::ServerlessRepo::Application:
@@ -77,9 +77,9 @@ Parameters:
 
   DeploymentAccountMainRegion:
     Type: String
-    AllowedPattern: "(us(-gov)?|ap|ca|eu|sa)-(central|(north|south)?(east|west)?)-\\d"
+    AllowedPattern: "(us(-gov)?|ap|ca|eu|sa|cn)-(central|(north|south)?(east|west)?)-\\d"
     MinLength: 6
-    Description: "Example -> us-east-1, us-gov-west-1, eu-west-1"
+    Description: "Example -> us-east-1, us-gov-west-1, eu-west-1 or cn-north-1"
 
   DeploymentAccountTargetRegions:
     Type: CommaDelimitedList
@@ -1321,7 +1321,7 @@ Resources:
         Type: CODEPIPELINE
       Environment:
         ComputeType: "BUILD_GENERAL1_LARGE"
-        PrivilegedMode: false
+        PrivilegedMode: true
         Image: "aws/codebuild/standard:7.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
@@ -1358,6 +1358,11 @@ Resources:
                 python: 3.11
             pre_build:
               commands:
+                - |
+                  if [ "${AWS_REGION}" = "cn-north-1" ]; then
+                    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+                    npm config set registry https://registry.npmmirror.com
+                  fi
                 - >-
                   pip install
                   -r adf-build/requirements.txt

--- a/src/template.yml
+++ b/src/template.yml
@@ -3,7 +3,7 @@
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"
-Description: ADF CloudFormation Initial Base Stack for the Management Account in the cn-north-1 region.
+Description: ADF CloudFormation Initial Base Stack for the Management Account in the base region of the partition (us-east-1, us-gov-west-1 or cn-north-1).
 
 Metadata:
   AWS::ServerlessRepo::Application:
@@ -114,7 +114,7 @@ Parameters:
 Globals:
   Function:
     CodeUri: lambda_codebase
-    Runtime: python3.9
+    Runtime: python3.10
     Timeout: 300
 
 Conditions:
@@ -897,7 +897,7 @@ Resources:
     Properties:
       ContentUri: "./lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/"
       CompatibleRuntimes:
-        - python3.9
+        - python3.10
       Description: "Shared Lambda Layer between master and deployment account"
       LayerName: shared_layer
 
@@ -1319,7 +1319,7 @@ Resources:
       Environment:
         ComputeType: "BUILD_GENERAL1_LARGE"
         PrivilegedMode: true
-        Image: "aws/codebuild/standard:5.0"
+        Image: "aws/codebuild/standard:7.0"
         EnvironmentVariables:
           - Name: ADF_VERSION
             Value: !FindInMap ["Metadata", "ADF", "Version"]
@@ -1352,12 +1352,13 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.9
+                python: 3.11
             pre_build:
               commands:
                 - |
-                  if [ "${AWS_REGION}" = "cn-north-1" ] || [ "${AWS_REGION}" = "cn-northwest-1" ]; then
+                  if [ "${AWS_REGION}" = "cn-north-1" ]; then
                     pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+                    npm config set registry https://registry.npmmirror.com
                   fi
                 - >-
                   pip install
@@ -1378,7 +1379,7 @@ Resources:
                     --s3-prefix adf-bootstrap/deployment --s3-bucket $DEPLOYMENT_ACCOUNT_BUCKET
                 - python adf-build/store_config.py
                 - |
-                  if [ "${AWS_REGION}" = "cn-north-1" ] || [ "${AWS_REGION}" = "cn-northwest-1" ]; then
+                  if [ "${AWS_REGION}" = "cn-north-1" ]; then
                     python adf-build/create_s3_cn.py
                     sam build -t adf-build/cn_northwest_deploy.yml --region cn-northwest-1
                     sam package --output-template-file adf-build/cn_northwest_deploy.yml --s3-prefix adf-bootstrap --s3-bucket adf-china-bootstrap-cn-northwest-1-${MASTER_ACCOUNT_ID} --region cn-northwest-1


### PR DESCRIPTION
# Why?
ADF Support for China Partition

Description:
This pull request introduces support for the China partition in the AWS Deployment Framework (ADF) project. It adds necessary support for the unique requirements and configurations specific to the China region. 

This addition enables users in the China region to leverage the full capabilities of ADF tailored to their environment. The changes have been tested to guarantee compatibility with Global, Govcloud and China partition.

Any feedback, suggestions, or required adjustments are highly appreciated.

## What?

Description of changes:

- Selectors for right partition based on region
- Mirrors for npm and Python dependencies behind the Firewall

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
