### PR TITLE
Fix initial value type of allow-empty-targets

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -157,7 +157,7 @@ def prepare_deployment_account(sts, deployment_account_id, config):
         '/adf/deployment-maps/allow-empty-target',
         config.config.get('deployment-maps', {}).get(
             'allow-empty-target',
-            ADF_DEFAULT_DEPLOYMENT_MAPS_ALLOW_EMPTY_TARGET,
+            str(ADF_DEFAULT_DEPLOYMENT_MAPS_ALLOW_EMPTY_TARGET),
         )
     )
     deployment_account_parameter_store.put_parameter(


### PR DESCRIPTION
### Why?

ADF fails to build in the bootstrap pipeline if no `allow-empty-targets` value is configured in the `adfconfig.yml` file.

Root cause, the default value is a boolean False. While the Parameter Store service expects values to be of type string.

### What?

This change set fixes it by converting the default to string when written to Parameter Store.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
