### PR TITLE
Fix Shared ADF Lambda Layer builds and add move to ARM-64 Lambdas

### DIFF
--- a/linters/custom-adf-dict.txt
+++ b/linters/custom-adf-dict.txt
@@ -4,6 +4,7 @@ adf
 adfconfig
 awscli
 backoff
+binfmt
 bitnami
 boto
 boto3

--- a/src/lambda_codebase/account_bootstrap.py
+++ b/src/lambda_codebase/account_bootstrap.py
@@ -9,20 +9,22 @@ Stack on the target account.
 """
 
 import os
-import boto3
 
+import boto3
 from botocore.exceptions import ClientError
-from logger import configure_logger
+
+# ADF imports
 from errors import (
     AccountCreationNotFinishedError,
     GenericAccountConfigureError,
     ParameterNotFoundError,
 )
-from parameter_store import ParameterStore
 from cloudformation import CloudFormation
+from logger import configure_logger
+from parameter_store import ParameterStore
+from partition import get_partition
 from s3 import S3
 from sts import STS
-from partition import get_partition
 
 # Globals taken from the lambda environment variables
 S3_BUCKET = os.environ["S3_BUCKET_NAME"]

--- a/src/lambda_codebase/account_processing/configure_account_alias.py
+++ b/src/lambda_codebase/account_processing/configure_account_alias.py
@@ -6,9 +6,12 @@ Creates or updates an ALIAS for an account
 """
 
 import os
-from sts import STS
+
 from aws_xray_sdk.core import patch_all
+
+# ADF imports
 from logger import configure_logger
+from sts import STS
 
 patch_all()
 

--- a/src/lambda_codebase/account_processing/configure_account_ou.py
+++ b/src/lambda_codebase/account_processing/configure_account_ou.py
@@ -4,10 +4,12 @@
 """
 Moves an account to the specified OU.
 """
-from organizations import Organizations
 import boto3
 from aws_xray_sdk.core import patch_all
+
+# ADF imports
 from logger import configure_logger
+from organizations import Organizations
 
 
 patch_all()

--- a/src/lambda_codebase/account_processing/configure_account_regions.py
+++ b/src/lambda_codebase/account_processing/configure_account_regions.py
@@ -6,9 +6,10 @@ Takes regions that the account is not-opted into and opts into them.
 """
 from ast import literal_eval
 
-
 import boto3
 from aws_xray_sdk.core import patch_all
+
+# ADF imports
 from logger import configure_logger
 
 patch_all()

--- a/src/lambda_codebase/account_processing/configure_account_tags.py
+++ b/src/lambda_codebase/account_processing/configure_account_tags.py
@@ -9,6 +9,8 @@ in the config file.
 """
 import boto3
 from aws_xray_sdk.core import patch_all
+
+# ADF imports
 from logger import configure_logger
 
 patch_all()

--- a/src/lambda_codebase/account_processing/create_account.py
+++ b/src/lambda_codebase/account_processing/create_account.py
@@ -8,6 +8,8 @@ Creates an account within your organization.
 import os
 from aws_xray_sdk.core import patch_all
 import boto3
+
+# ADF imports
 from logger import configure_logger
 
 patch_all()

--- a/src/lambda_codebase/account_processing/delete_default_vpc.py
+++ b/src/lambda_codebase/account_processing/delete_default_vpc.py
@@ -5,9 +5,11 @@
 Deletes the default VPC in a particular region
 """
 import os
-from sts import STS
 from aws_xray_sdk.core import patch_all
+
+# ADF imports
 from logger import configure_logger
+from sts import STS
 
 patch_all()
 

--- a/src/lambda_codebase/account_processing/get_account_regions.py
+++ b/src/lambda_codebase/account_processing/get_account_regions.py
@@ -6,9 +6,11 @@ Gets all the default regions for an account.
 """
 
 import os
-from sts import STS
 from aws_xray_sdk.core import patch_all
+
+# ADF imports
 from logger import configure_logger
+from sts import STS
 
 patch_all()
 

--- a/src/lambda_codebase/account_processing/process_account_files.py
+++ b/src/lambda_codebase/account_processing/process_account_files.py
@@ -13,15 +13,17 @@ import tempfile
 import logging
 from typing import Any, TypedDict
 import re
-import yaml
 
+import yaml
 from yaml.error import YAMLError
 
 import boto3
 from botocore.exceptions import ClientError
 from aws_xray_sdk.core import patch_all
-from organizations import Organizations
+
+# ADF imports
 from logger import configure_logger
+from organizations import Organizations
 
 
 patch_all()

--- a/src/lambda_codebase/account_processing/register_account_for_support.py
+++ b/src/lambda_codebase/account_processing/register_account_for_support.py
@@ -11,8 +11,10 @@ from enum import Enum
 import boto3
 from botocore.exceptions import ClientError, BotoCoreError
 from botocore.config import Config
-from logger import configure_logger
 from aws_xray_sdk.core import patch_all
+
+# ADF imports
+from logger import configure_logger
 
 
 LOGGER = configure_logger(__name__)

--- a/src/lambda_codebase/cross_region_bucket/main.py
+++ b/src/lambda_codebase/cross_region_bucket/main.py
@@ -23,6 +23,7 @@ from cfn_custom_resource import ( # pylint: disable=unused-import
     delete,
 )
 
+# ADF imports
 from partition import get_partition
 
 # Type aliases:

--- a/src/lambda_codebase/deployment_account_config.py
+++ b/src/lambda_codebase/deployment_account_config.py
@@ -14,6 +14,7 @@ Organizations when it needs to create pipelines.
 """
 
 import os
+
 import boto3
 
 from cloudformation import CloudFormation

--- a/src/lambda_codebase/determine_event.py
+++ b/src/lambda_codebase/determine_event.py
@@ -6,12 +6,14 @@ The Initial event object determination function
 """
 
 import os
+
 import boto3
 
-from parameter_store import ParameterStore
+# ADF imports
 from cache import Cache
 from event import Event
 from organizations import Organizations
+from parameter_store import ParameterStore
 
 REGION_DEFAULT = os.environ["AWS_REGION"]
 

--- a/src/lambda_codebase/event.py
+++ b/src/lambda_codebase/event.py
@@ -8,12 +8,15 @@ when accounts are moved into Organizational Units.
 
 import ast
 import os
+
+# ADF imports
 from errors import ParameterNotFoundError, RootOUIDError
 
 DEPLOYMENT_ACCOUNT_OU_NAME = 'deployment'
 DEPLOYMENT_ACCOUNT_S3_BUCKET = os.environ["DEPLOYMENT_ACCOUNT_BUCKET"]
 ADF_VERSION = os.environ["ADF_VERSION"]
 ADF_LOG_LEVEL = os.environ["ADF_LOG_LEVEL"]
+
 
 class Event:
     """
@@ -71,7 +74,6 @@ class Event:
         )
         self.set_destination_ou_name()
 
-
     def _determine_if_deployment_account(self):
         """
         Sets property based on if the account that has been moved
@@ -126,7 +128,7 @@ class Event:
             'full_path': "ROOT" if self.moved_to_root else account_path,
             'destination_ou_id': self.destination_ou_id,
             'source_ou_id': self.source_ou_id,
-            'deployment_account_parameters' : {
+            'deployment_account_parameters': {
                 'organization_id': organization_information.get(
                     "organization_id"
                 ),
@@ -139,5 +141,5 @@ class Event:
                 'deployment_account_bucket': DEPLOYMENT_ACCOUNT_S3_BUCKET,
                 'adf_version': ADF_VERSION,
                 'adf_log_level': ADF_LOG_LEVEL
-            }
+            },
         }

--- a/src/lambda_codebase/generic_account_config.py
+++ b/src/lambda_codebase/generic_account_config.py
@@ -14,10 +14,11 @@ created account.
 
 import os
 
+# ADF imports
 from logger import configure_logger
-from sts import STS
-from stepfunctions import StepFunctions
 from partition import get_partition
+from stepfunctions import StepFunctions
+from sts import STS
 
 LOGGER = configure_logger(__name__)
 REGION_DEFAULT = os.getenv('AWS_REGION')

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -72,26 +72,22 @@ Conditions:
 
 Globals:
   Function:
+    Architectures:
+      - arm64
     CodeUri: lambda_codebase
     Runtime: python3.12
 
 Resources:
-  LambdaLayerVersion:
+  ADFSharedPythonLambdaLayerVersion:
     Type: "AWS::Serverless::LayerVersion"
     Properties:
-      ContentUri: "../../adf-build/shared/"
+      ContentUri: "../../adf-build/shared/python"
       CompatibleRuntimes:
         - python3.12
       Description: "Shared Lambda Layer between master and deployment account"
-      LayerName: shared_layer
-
-  LambdaLayerVersionPermission:
-    Type: "AWS::Lambda::LayerVersionPermission"
-    Properties:
-      Action: lambda:GetLayerVersion
-      LayerVersionArn: !Ref LambdaLayerVersion
-      OrganizationId: !Ref OrganizationId
-      Principal: "*"
+      LayerName: adf_shared_layer
+    Metadata:
+      BuildMethod: python3.12
 
   KMSKey:
     Type: AWS::KMS::Key
@@ -185,7 +181,7 @@ Resources:
     Properties:
       Location: pipeline_management.yml
       Parameters:
-        LambdaLayer: !Ref LambdaLayerVersion
+        LambdaLayer: !Ref ADFSharedPythonLambdaLayerVersion
         ADFVersion: !Ref ADFVersion
         OrganizationId: !Ref OrganizationId
         CrossAccountAccessRole: !Ref CrossAccountAccessRole
@@ -1014,7 +1010,7 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - Send Slack Notification"
       FunctionName: SendSlackNotification
       Handler: slack.lambda_handler
@@ -1024,12 +1020,14 @@ Resources:
           ADF_PIPELINE_PREFIX: !Ref PipelinePrefix
           ADF_LOG_LEVEL: !Ref ADFLogLevel
       Timeout: 10
+    Metadata:
+      BuildMethod: python3.12
 
   EnableCrossAccountAccess:
     Type: "AWS::Serverless::Function"
     Properties:
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - EnableCrossAccountAccess"
       MemorySize: 1024
       Environment:
@@ -1042,12 +1040,14 @@ Resources:
       Handler: enable_cross_account_access.lambda_handler
       Role: !GetAtt EnableCrossAccountAccessLambdaRole.Arn
       Timeout: 900
+    Metadata:
+      BuildMethod: python3.12
 
   CheckPipelineStatus:
     Type: "AWS::Serverless::Function"
     Properties:
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - CheckPipelineStatus"
       Environment:
         Variables:
@@ -1058,6 +1058,8 @@ Resources:
       Handler: update_pipelines.lambda_handler
       Role: !GetAtt CheckPipelineStatusLambdaRole.Arn
       Timeout: 120
+    Metadata:
+      BuildMethod: python3.12
 
   SendSlackNotificationLambdaRole:
     Type: "AWS::IAM::Role"
@@ -1174,7 +1176,7 @@ Resources:
             Action:
               - "lambda:GetLayerVersion"
             Resource:
-              - !Ref LambdaLayerVersion
+              - !Ref ADFSharedPythonLambdaLayerVersion
           - Effect: Allow
             Action:
               - "logs:CreateLogGroup"
@@ -1383,6 +1385,8 @@ Resources:
                 - codecommit:GetRepository
               Resource: !GetAtt CodeCommitRepository.Arn
       FunctionName: ADFPipelinesDetermineDefaultBranchName
+    Metadata:
+      BuildMethod: python3.12
 
   InitialCommit:
     Type: Custom::InitialCommit
@@ -1415,6 +1419,8 @@ Resources:
               Resource: !GetAtt CodeCommitRepository.Arn
       FunctionName: PipelinesCreateInitialCommitFunction
       Timeout: 300
+    Metadata:
+      BuildMethod: python3.12
 
   KmsKeyArnParameter:
     Type: "AWS::SSM::Parameter"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
@@ -9,14 +9,16 @@ This runs as part of Step Functions on the Deployment Account
 """
 
 import os
-import boto3
 
+import boto3
 from botocore.exceptions import ClientError
+
+# ADF imports
+from iam_cfn_deploy_role_policy import IAMCfnDeployRolePolicy
 from logger import configure_logger
 from parameter_store import ParameterStore
-from sts import STS
 from partition import get_partition
-from iam_cfn_deploy_role_policy import IAMCfnDeployRolePolicy
+from sts import STS
 
 
 KEY_ID = os.environ["KMS_KEY_ID"]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
@@ -37,7 +37,7 @@ LOGGER.setLevel(ADF_LOG_LEVEL)
 PR_DESCRIPTION = """ADF Version {0}
 
 You can find the changelog at:
-https://github.com/awslabs/aws-deployment-framework/releases/tag/v{0}
+https://github.com/awslabs/aws-deployment-framework/releases/tag/{0}
 
 This PR was automatically created when you deployed version {0} of the
 AWS Deployment Framework.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/slack.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/slack.py
@@ -11,6 +11,7 @@ import json
 import urllib
 import boto3
 
+# ADF imports
 from parameter_store import ParameterStore
 
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/update_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/update_pipelines.py
@@ -8,7 +8,10 @@ it is not already executing or failed
 """
 
 import os
+
 import boto3
+
+# ADF imports
 from logger import configure_logger
 from codepipeline import CodePipeline
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -79,6 +79,9 @@ Resources:
               - "xray:PutTraceSegments"
               - "cloudwatch:PutMetricData"
             Resource: "*"
+          - Effect: "Allow"
+            Action: "lambda:GetLayerVersion"
+            Resource: !Ref LambdaLayer
       Roles:
         - !Ref DeploymentMapProcessingLambdaRole
         - !Ref CreateOrUpdateRuleLambdaRole
@@ -98,9 +101,6 @@ Resources:
           - Effect: "Allow"
             Action: "s3:ListBucket"
             Resource: !GetAtt ADFPipelineBucket.Arn
-          - Effect: "Allow"
-            Action: "lambda:GetLayerVersion"
-            Resource: !Ref LambdaLayer
           - Effect: "Allow"
             Action: "states:StartExecution"
             Resource: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:ADFPipelineManagementStateMachine"
@@ -943,6 +943,8 @@ Resources:
             Bucket:
               Ref: ADFPipelineBucket
             Events: s3:ObjectCreated:*
+    Metadata:
+      BuildMethod: python3.12
 
   ADFAutomationRoleCrossAccountAccessRolePolicy:
     Type: "AWS::IAM::ManagedPolicy"
@@ -974,6 +976,8 @@ Resources:
           S3_BUCKET_NAME: !Ref PipelineBucket
       FunctionName: ADFPipelineCreateOrUpdateRuleFunction
       Role: !GetAtt CreateOrUpdateRuleLambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   CreateRepositoryFunction:
     Type: 'AWS::Serverless::Function'
@@ -990,6 +994,8 @@ Resources:
           S3_BUCKET_NAME: !Ref PipelineBucket
       FunctionName: ADFPipelineCreateRepositoryFunction
       Role: !GetAtt CreateRepositoryLambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   GeneratePipelineInputsFunction:
     Type: 'AWS::Serverless::Function'
@@ -1007,6 +1013,8 @@ Resources:
           ROOT_ACCOUNT_ID: !Ref RootAccountId
       FunctionName: ADFPipelineGenerateInputsFunction
       Role: !GetAtt GeneratePipelineInputsLambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   StoreDefinitionFunction:
     Type: 'AWS::Serverless::Function'
@@ -1024,6 +1032,8 @@ Resources:
           ROOT_ACCOUNT_ID: !Ref RootAccountId
       FunctionName: ADFPipelineStoreDefinitionFunction
       Role: !GetAtt StoreDefinitionLambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   IdentifyOutOfDatePipelinesFunction:
     Type: 'AWS::Serverless::Function'
@@ -1042,6 +1052,8 @@ Resources:
           ADF_PIPELINE_PREFIX: !Ref PipelinePrefix
       FunctionName: ADFPipelineIdentifyOutOfDatePipelinesFunction
       Role: !GetAtt IdentifyOutOfDatePipelinesLambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   ADFDefinitionBucket:
     Type: "AWS::S3::Bucket"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
@@ -11,6 +11,8 @@ import os
 from botocore.exceptions import WaiterError, ClientError
 from botocore.config import Config
 import tenacity
+
+# ADF imports
 from errors import InvalidTemplateError, GenericAccountConfigureError
 from logger import configure_logger
 from paginator import paginator

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/deployment_map.py
@@ -12,6 +12,8 @@ import yaml
 
 from schema import SchemaError
 from schema_validation import SchemaValidation
+
+# ADF imports
 from errors import InvalidDeploymentMapError
 from logger import configure_logger
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/logger.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/logger.py
@@ -19,7 +19,9 @@ def configure_logger(logger_name):
 
     # Define our logging formatter
     formatter = logging.Formatter(
-        '%(asctime)s | %(levelname)s | %(name)s | %(message)s | (%(filename)s:%(lineno)d)')
+        '%(asctime)s | %(levelname)s | %(name)s | %(message)s '
+        '| (%(filename)s:%(lineno)d)',
+    )
 
     # Create our stream handler and apply the formatting
     stream_handler = logging.StreamHandler()

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -12,6 +12,7 @@ from time import sleep
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+# ADF imports
 from errors import RootOUIDError
 from logger import configure_logger
 from paginator import paginator

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/parameter_store.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/parameter_store.py
@@ -5,6 +5,8 @@
 """
 
 from botocore.config import Config
+
+# ADF imports
 from errors import ParameterNotFoundError
 from paginator import paginator
 from logger import configure_logger

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
@@ -14,7 +14,7 @@ COMPATIBLE_PARTITIONS = ['aws-us-gov', 'aws']
 
 
 class IncompatiblePartitionError(Exception):
-    pass
+    """Raised in case the partition is not supported."""
 
 
 def get_partition(region_name: str) -> str:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pipeline.py
@@ -8,6 +8,8 @@ properties associated with a pipeline.
 
 import os
 from copy import deepcopy
+
+# ADF imports
 from list_utils import flatten_to_unique_sorted
 
 DEPLOYMENT_ACCOUNT_REGION = os.environ["AWS_REGION"]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/repo.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/repo.py
@@ -7,11 +7,13 @@ properties associated with a pipeline.
 """
 
 import os
+
+# ADF imports
 from cloudformation import CloudFormation
-from s3 import S3
-from sts import STS
 from logger import configure_logger
 from partition import get_partition
+from s3 import S3
+from sts import STS
 
 LOGGER = configure_logger(__name__)
 DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/requirements.txt
@@ -1,0 +1,8 @@
+# Install libs here that you might want in the ADF Shared Python Lambda Layer
+boto3==1.34.17
+botocore==1.34.17
+pyyaml~=6.0.1
+schema~=0.7.5
+tenacity==8.2.3
+typing-extensions~=4.9.0
+urllib3~=2.0.7

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/rule.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/rule.py
@@ -7,11 +7,13 @@ properties associated with a pipeline.
 """
 
 import os
+
+# ADF imports
 from cloudformation import CloudFormation
+from logger import configure_logger
+from partition import get_partition
 from s3 import S3
 from sts import STS
-from partition import get_partition
-from logger import configure_logger
 
 LOGGER = configure_logger(__name__)
 TARGET_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
@@ -6,6 +6,8 @@ Schema Validation for Deployment map files
 """
 
 from schema import Schema, And, Use, Or, Optional, Regex
+
+# ADF imports
 from logger import configure_logger
 
 LOGGER = configure_logger(__name__)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/stepfunctions.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/stepfunctions.py
@@ -7,6 +7,8 @@ Step Functions module used throughout the ADF
 
 import json
 from time import sleep
+
+# ADF imports
 from logger import configure_logger
 from partition import get_partition
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
@@ -9,16 +9,19 @@ require mutation depending on their structure.
 
 import re
 import os
+
+import boto3
+
+# ADF imports
 from errors import (
     InvalidDeploymentMapError,
     NoAccountsFoundError,
     InsufficientWaveSizeError,
 )
-from logger import configure_logger
-from schema_validation import AWS_ACCOUNT_ID_REGEX_STR
 from botocore.exceptions import ClientError
+from logger import configure_logger
 from parameter_store import ParameterStore
-import boto3
+from schema_validation import AWS_ACCOUNT_ID_REGEX_STR
 
 LOGGER = configure_logger(__name__)
 ADF_DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]

--- a/src/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/initial_commit.py
@@ -52,7 +52,7 @@ LOGGER.setLevel(ADF_LOG_LEVEL)
 PR_DESCRIPTION = """ADF Version {0}
 
 You can find the changelog at:
-https://github.com/awslabs/aws-deployment-framework/releases/tag/v{0}
+https://github.com/awslabs/aws-deployment-framework/releases/tag/{0}
 
 This PR was automatically created when you deployed version {0} of the
 AWS Deployment Framework.

--- a/src/lambda_codebase/moved_to_root.py
+++ b/src/lambda_codebase/moved_to_root.py
@@ -9,13 +9,15 @@ is moved to the root of the Organization.
 import ast
 import os
 from thread import PropagatingThread
+
 import boto3
 
-from sts import STS
+# ADF imports
+from cloudformation import CloudFormation
+from logger import configure_logger
 from parameter_store import ParameterStore
 from partition import get_partition
-from logger import configure_logger
-from cloudformation import CloudFormation
+from sts import STS
 
 LOGGER = configure_logger(__name__)
 REGION_DEFAULT = os.environ.get('AWS_REGION')

--- a/src/lambda_codebase/wait_until_complete.py
+++ b/src/lambda_codebase/wait_until_complete.py
@@ -11,13 +11,14 @@ are met.
 
 import os
 
-from sts import STS
-from s3 import S3
-from parameter_store import ParameterStore
+# ADF imports
+from cloudformation import CloudFormation
 from errors import RetryError
 from logger import configure_logger
-from cloudformation import CloudFormation
+from parameter_store import ParameterStore
 from partition import get_partition
+from s3 import S3
+from sts import STS
 
 S3_BUCKET = os.environ["S3_BUCKET_NAME"]
 REGION_DEFAULT = os.environ["AWS_REGION"]

--- a/src/template.yml
+++ b/src/template.yml
@@ -113,6 +113,8 @@ Parameters:
 
 Globals:
   Function:
+    Architectures:
+      - arm64
     CodeUri: lambda_codebase
     Runtime: python3.12
     Timeout: 300
@@ -219,9 +221,6 @@ Resources:
             Action: "s3:ListBucket"
             Resource: !GetAtt ADFAccountBucket.Arn
           - Effect: "Allow"
-            Action: "lambda:GetLayerVersion"
-            Resource: !Ref LambdaLayerVersion
-          - Effect: "Allow"
             Action: "states:StartExecution"
             Resource: !Ref AccountManagementStateMachine
           - Effect: "Allow"
@@ -314,11 +313,9 @@ Resources:
       Handler: process_account_files.lambda_handler
       Description: "ADF Lambda Function - Account File Processing"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
@@ -352,6 +349,8 @@ Resources:
                 Rules:
                   - Name: suffix
                     Value: yaml
+    Metadata:
+      BuildMethod: python3.12
 
   AccountAliasConfigFunctionRole:
     Type: "AWS::IAM::Role"
@@ -372,11 +371,9 @@ Resources:
       Handler: configure_account_alias.lambda_handler
       Description: "ADF Lambda Function - Account Alias Configuration"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           AWS_PARTITION: !Ref AWS::Partition
@@ -387,6 +384,8 @@ Resources:
           ADF_ROLE_NAME: !Ref CrossAccountAccessRoleName
       FunctionName: AccountAliasConfigurationFunction
       Role: !GetAtt AccountAliasConfigFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   AccountTagConfigFunctionRole:
     Type: "AWS::IAM::Role"
@@ -417,11 +416,9 @@ Resources:
       Handler: configure_account_tags.lambda_handler
       Description: "ADF Lambda Function - Account Tag Configuration"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
@@ -430,6 +427,8 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: AccountTagConfigurationFunction
       Role: !GetAtt AccountTagConfigFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   AccountRegionConfigFunctionRole:
     Type: "AWS::IAM::Role"
@@ -465,11 +464,9 @@ Resources:
       Handler: configure_account_regions.lambda_handler
       Description: "ADF Lambda Function - Account region Configuration"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
@@ -478,6 +475,8 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: AccountRegionConfigurationFunction
       Role: !GetAtt AccountRegionConfigFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   AccountOUConfigFunction:
     Type: 'AWS::Serverless::Function'
@@ -485,11 +484,9 @@ Resources:
       Handler: configure_account_ou.lambda_handler
       Description: "ADF Lambda Function - Account OU Configuration"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
@@ -498,6 +495,8 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: AccountOUConfigurationFunction
       Role: !GetAtt AccountOUConfigFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   AccountOUConfigFunctionRole:
     Type: "AWS::IAM::Role"
@@ -532,11 +531,9 @@ Resources:
       Handler: get_account_regions.lambda_handler
       Description: "ADF Lambda Function - Get Default Regions for an account"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           AWS_PARTITION: !Ref AWS::Partition
@@ -547,6 +544,8 @@ Resources:
           ADF_ROLE_NAME: !Ref CrossAccountAccessRoleName
       FunctionName: GetAccountRegionsFunction
       Role: !GetAtt GetAccountRegionsFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   GetAccountRegionsFunctionRole:
     Type: "AWS::IAM::Role"
@@ -567,11 +566,9 @@ Resources:
       Handler: delete_default_vpc.lambda_handler
       Description: "ADF Lambda Function - Delete the default VPC for a region"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           AWS_PARTITION: !Ref AWS::Partition
@@ -582,6 +579,8 @@ Resources:
           ADF_ROLE_NAME: !Ref CrossAccountAccessRoleName
       FunctionName: DeleteDefaultVPCFunction
       Role: !GetAtt DeleteDefaultVPCFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   DeleteDefaultVPCFunctionRole:
     Type: "AWS::IAM::Role"
@@ -602,11 +601,9 @@ Resources:
       Handler: create_account.lambda_handler
       Description: "ADF Lambda Function - Create an account"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
@@ -616,6 +613,8 @@ Resources:
           ADF_ROLE_NAME: !Ref CrossAccountAccessRoleName
       FunctionName: CreateAccountFunction
       Role: !GetAtt CreateAccountFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   CreateAccountFunctionRole:
     Type: "AWS::IAM::Role"
@@ -646,11 +645,9 @@ Resources:
       Handler: register_account_for_support.lambda_handler
       Description: "ADF Lambda Function - Registers an account for enterprise support"
       CodeUri: lambda_codebase/account_processing
-      Architectures:
-        - arm64
       Tracing: Active
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Environment:
         Variables:
           MASTER_ACCOUNT_ID: !Ref AWS::AccountId
@@ -659,6 +656,8 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: RegisterAccountForSupportFunction
       Role: !GetAtt RegisterAccountForSupportFunctionRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   RegisterAccountForSupportFunctionRole:
     Type: "AWS::IAM::Role"
@@ -966,27 +965,40 @@ Resources:
           }
   ### Account processing end
 
-  LambdaLayerVersion:
+  ADFSharedPythonLambdaLayerVersion:
     Type: "AWS::Serverless::LayerVersion"
     Properties:
-      ContentUri: "./lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/"
+      ContentUri: "./lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python"
       CompatibleArchitectures:
-        - x86_64
+        - arm64
       CompatibleRuntimes:
         - python3.12
       Description: "Shared Lambda Layer between master and deployment account"
-      LayerName: shared_layer
+      LayerName: adf_shared_layer
     Metadata:
       BuildMethod: python3.12
-      BuildArchitecture: x86_64
 
-  LambdaLayerVersionPermission:
-    Type: "AWS::Lambda::LayerVersionPermission"
+  LambdaLayerPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      Action: lambda:GetLayerVersion
-      LayerVersionArn: !Ref LambdaLayerVersion
-      OrganizationId: !GetAtt Organization.OrganizationId
-      Principal: "*"
+      Description: "Policy to allow Lambda functions to use the ADF Shared Python layer"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "lambda:GetLayerVersion"
+            Resource: !Ref ADFSharedPythonLambdaLayerVersion
+      Roles:
+        - !Ref AccountAliasConfigFunctionRole
+        - !Ref AccountOUConfigFunctionRole
+        - !Ref AccountProcessingLambdaRole
+        - !Ref AccountRegionConfigFunctionRole
+        - !Ref AccountTagConfigFunctionRole
+        - !Ref CreateAccountFunctionRole
+        - !Ref DeleteDefaultVPCFunctionRole
+        - !Ref GetAccountRegionsFunctionRole
+        - !Ref LambdaRole
+        - !Ref RegisterAccountForSupportFunctionRole
 
   LambdaRole:
     Type: "AWS::IAM::Role"
@@ -1012,7 +1024,6 @@ Resources:
           - Effect: "Allow"
             Action:
               - "sts:AssumeRole"
-              - "lambda:GetLayerVersion"
               - "logs:CreateLogGroup"
               - "logs:CreateLogStream"
               - "logs:PutLogEvents"
@@ -1042,10 +1053,8 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: wait_until_complete.lambda_handler
-      Architectures:
-        - x86_64
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - StackWaiterFunction"
       Environment:
         Variables:
@@ -1057,15 +1066,15 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: StackWaiter
       Role: !GetAtt LambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   DetermineEventFunction:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: determine_event.lambda_handler
-      Architectures:
-        - x86_64
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - DetermineEvent"
       Environment:
         Variables:
@@ -1078,15 +1087,15 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: DetermineEventFunction
       Role: !GetAtt LambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   CrossAccountExecuteFunction:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: account_bootstrap.lambda_handler
-      Architectures:
-        - x86_64
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - CrossAccountExecuteFunction"
       Environment:
         Variables:
@@ -1100,15 +1109,15 @@ Resources:
       FunctionName: CrossAccountExecuteFunction
       Role: !GetAtt LambdaRole.Arn
       Timeout: 900
+    Metadata:
+      BuildMethod: python3.12
 
   RoleStackDeploymentFunction:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: deployment_account_config.lambda_handler
-      Architectures:
-        - x86_64
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - RoleStackDeploymentFunction"
       Environment:
         Variables:
@@ -1119,15 +1128,15 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: RoleStackDeploymentFunction
       Role: !GetAtt LambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   MovedToRootActionFunction:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: moved_to_root.lambda_handler
-      Architectures:
-        - x86_64
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - MovedToRootActionFunction"
       Environment:
         Variables:
@@ -1139,15 +1148,15 @@ Resources:
       FunctionName: MovedToRootActionFunction
       Role: !GetAtt LambdaRole.Arn
       Timeout: 900
+    Metadata:
+      BuildMethod: python3.12
 
   UpdateResourcePoliciesFunction:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: generic_account_config.lambda_handler
-      Architectures:
-        - x86_64
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - UpdateResourcePoliciesFunction"
       Environment:
         Variables:
@@ -1158,6 +1167,8 @@ Resources:
           ADF_LOG_LEVEL: !Ref LogLevel
       FunctionName: UpdateResourcePoliciesFunction
       Role: !GetAtt LambdaRole.Arn
+    Metadata:
+      BuildMethod: python3.12
 
   CloudWatchEventsRule:
     Type: "AWS::Events::Rule"
@@ -1386,19 +1397,40 @@ Resources:
                   -r adf-build/shared/helpers/requirements-dev.txt
                   --quiet
                 - tox
+                - >-
+                  docker run --privileged --rm
+                  public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
+                  --install arm64
             build:
               commands:
-                - sam build -t adf-bootstrap/deployment/global.yml
                 - >-
-                    sam package --output-template-file adf-bootstrap/deployment/global.yml
-                    --s3-prefix adf-bootstrap/deployment --s3-bucket $DEPLOYMENT_ACCOUNT_BUCKET
+                  sam build
+                  --use-container
+                  --template adf-bootstrap/deployment/global.yml
+                - >-
+                  sam package
+                  --output-template-file adf-bootstrap/deployment/global.yml
+                  --s3-prefix adf-bootstrap/deployment
+                  --s3-bucket $DEPLOYMENT_ACCOUNT_BUCKET
                 - python adf-build/store_config.py
                 # Shared Modules to be used with AWS CodeBuild:
-                - aws s3 sync ./adf-build/shared s3://$DEPLOYMENT_ACCOUNT_BUCKET/adf-build --quiet
+                - >-
+                  aws s3 sync
+                  ./adf-build/shared
+                  s3://$DEPLOYMENT_ACCOUNT_BUCKET/adf-build
+                  --quiet
                 # Base templates:
-                - aws s3 sync . s3://$S3_BUCKET --quiet --delete
+                - >-
+                  aws s3 sync . s3://$S3_BUCKET --quiet --delete
                 # Upload account files to the ACCOUNT_BUCKET
-                - python adf-build/shared/helpers/sync_to_s3.py --extension .yml --extension .yaml --metadata adf_version=${ADF_VERSION} --upload-with-metadata execution_id=${CODEPIPELINE_EXECUTION_ID} --recursive adf-accounts s3://$ACCOUNT_BUCKET
+                - >-
+                  python adf-build/shared/helpers/sync_to_s3.py
+                  --extension .yml
+                  --extension .yaml
+                  --metadata adf_version=${ADF_VERSION}
+                  --upload-with-metadata execution_id=${CODEPIPELINE_EXECUTION_ID}
+                  --recursive adf-accounts
+                  s3://$ACCOUNT_BUCKET
                 # Sleep for 10 seconds so the state machine is able to kick start the processing
                 # of these newly uploaded files if any.
                 - sleep 10
@@ -1791,8 +1823,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: handler.lambda_handler
-      Architectures:
-        - x86_64
       CodeUri: lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch
       Description: "ADF Lambda Function - BootstrapDetermineDefaultBranchName"
       Policies:
@@ -1803,6 +1833,8 @@ Resources:
                 - codecommit:GetRepository
               Resource: !GetAtt CodeCommitRepository.Arn
       FunctionName: ADFBootstrapDetermineDefaultBranchName
+    Metadata:
+      BuildMethod: python3.12
 
   InitialCommit:
     Type: Custom::InitialCommit
@@ -1826,8 +1858,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: handler.lambda_handler
-      Architectures:
-        - x86_64
       CodeUri: lambda_codebase/initial_commit
       Description: "ADF Lambda Function - BootstrapCreateInitialCommitFunction"
       Policies:
@@ -1843,6 +1873,8 @@ Resources:
                 - codecommit:GetDifferences
               Resource: !GetAtt CodeCommitRepository.Arn
       FunctionName: BootstrapCreateInitialCommitFunction
+    Metadata:
+      BuildMethod: python3.12
 
   SharedModulesBucket:
     Type: Custom::CrossRegionBucket
@@ -1886,10 +1918,8 @@ Resources:
     Properties:
       Handler: handler.lambda_handler
       CodeUri: lambda_codebase/cross_region_bucket
-      Architectures:
-        - x86_64
       Layers:
-        - !Ref LambdaLayerVersion
+        - !Ref ADFSharedPythonLambdaLayerVersion
       Description: "ADF Lambda Function - Create Deployment Bucket in Main Deployment Region"
       Policies:
         - Version: "2012-10-17"
@@ -1912,7 +1942,12 @@ Resources:
                 # dependency. Converting this to an inline policy can break the circle
                 - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/shared_modules_bucket"
                 - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/deployment_account_region"
+            - Effect: "Allow"
+              Action: "lambda:GetLayerVersion"
+              Resource: !Ref ADFSharedPythonLambdaLayerVersion
       FunctionName: CrossRegionBucketHandler
+    Metadata:
+      BuildMethod: python3.12
 
   Organization:
     Type: Custom::Organization
@@ -1924,8 +1959,6 @@ Resources:
     Properties:
       Handler: handler.lambda_handler
       CodeUri: lambda_codebase/organization
-      Architectures:
-        - x86_64
       Description: "ADF Lambda Function - Enable AWS Organizations"
       Policies:
         - Version: "2012-10-17"
@@ -1941,6 +1974,8 @@ Resources:
               Action: "iam:CreateServiceLinkedRole"
               Resource: !Sub "arn:${AWS::Partition}:iam::*:role/aws-service-role/*"
       FunctionName: AwsOrganizationsHandler
+    Metadata:
+      BuildMethod: python3.12
 
   DeploymentOrganizationUnit:
     Type: Custom::OrganizationUnit
@@ -1954,8 +1989,6 @@ Resources:
     Properties:
       Handler: handler.lambda_handler
       CodeUri: lambda_codebase/organization_unit
-      Architectures:
-        - x86_64
       Description: "ADF Lambda Function - Create Organization Unit"
       Policies:
         - Version: "2012-10-17"
@@ -1967,6 +2000,8 @@ Resources:
                 - "organizations:ListOrganizationalUnitsForParent"
               Resource: "*"
       FunctionName: OrganizationUnitHandler
+    Metadata:
+      BuildMethod: python3.12
 
   DeploymentAccount:
     Type: Custom::Account
@@ -1983,8 +2018,6 @@ Resources:
     Properties:
       Handler: handler.lambda_handler
       CodeUri: lambda_codebase/account
-      Architectures:
-        - x86_64
       Description: "ADF Lambda Function - Create Account"
       Policies:
         - Version: "2012-10-17"
@@ -1998,6 +2031,8 @@ Resources:
               Action: ssm:GetParameter
               Resource: !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/deployment_account_id"
       FunctionName: AccountHandler
+    Metadata:
+      BuildMethod: python3.12
 
   PipelineCloudWatchEventRole:
     Type: AWS::IAM::Role
@@ -2048,12 +2083,6 @@ Outputs:
     Value: !FindInMap ["Metadata", "ADF", "Version"]
     Export:
       Name: "ADFVersionNumber"
-
-  LayerArn:
-    Description: "The Shared modules Lambda Layer Arn"
-    Value: !Ref LambdaLayerVersion
-    Export:
-      Name: "SharedLayerArn"
 
   CodeCommitHttpURL:
     Description: "The CodeCommit HTTP Url"


### PR DESCRIPTION
### Why?

The Lambda Layer that ADF builds included the `bootstrap/adf-build/shared` folder as its source.

Unfortunately, this resulted in 388 MB of unzipped dependencies. While the maximum limit for AWS Lambda Layers is set at 250 MB.

### What?

After going through each of the lambda functions that use this Lambda Layer, I realized that they only require the files located in `bootstrap/adf-build/shared/python`.

Since this implied no longer requiring AWS CDK in the Lambda Layer, I also used this opportunity to move to the ARM-64 Lambdas in ADF.

The new Lambda Layer is 26 MB.

To build ARM-64 on CodeBuild, I've added the Amazon managed container that enables cross-architecture builds on Docker. That will launch and configure Qemu correctly, so ARM-64 Docker images can execute correctly. I've also fixed the build metadata and updated the `sam build` process to use a container instead. As without it, it could not resolve the dependencies required for PyYaml and others specifically for ARM-64.

Lastly, I've updated the shared lambda layer permissions, so we have control in the stack who can access and build on top of it.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
