### PR TITLE
Auto generate unique branch names on new version deployments

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
@@ -9,6 +9,7 @@ from typing import Mapping, Optional, Union, List, Dict, Any, Tuple
 from dataclasses import dataclass, fields
 from enum import Enum
 from pathlib import Path
+from datetime import datetime, timezone
 import re
 import boto3
 import jinja2
@@ -234,6 +235,31 @@ def generate_commit_input(
     return output
 
 
+def branch_exists(repo_name, branch_name):
+    try:
+        CC_CLIENT.get_branch(
+            repositoryName=repo_name,
+            branchName=branch_name,
+        )
+        return True
+    except CC_CLIENT.exceptions.BranchDoesNotExistException:
+        return False
+
+
+def determine_unique_branch_name(repo_name, branch_name):
+    for index in range(0, 10):
+        new_branch_name = (
+            branch_name
+            if index == 0 else
+            f"{branch_name}-no-{index}"
+        )
+        if not branch_exists(repo_name, new_branch_name):
+            return new_branch_name
+    # Fallback, use the unix timestamp in the branch name
+    timestamp = round(datetime.now(timezone.utc).timestamp())
+    return f"{branch_name}-at-{timestamp}"
+
+
 def generate_commits(event, repo_name, directory, parent_commit_id=None):
     """
     Generate the commits for the specified repository.
@@ -256,6 +282,10 @@ def generate_commits(event, repo_name, directory, parent_commit_id=None):
     default_branch_name = event.ResourceProperties.DefaultBranchName
     branch_name = version
     if parent_commit_id:
+        branch_name = determine_unique_branch_name(
+            repo_name=repo_name,
+            branch_name=branch_name,
+        )
         CC_CLIENT.create_branch(
             repositoryName=repo_name,
             branchName=branch_name,


### PR DESCRIPTION
### Why?

In case a previous deployment of ADF failed for whatever reason, running it again would require you to delete the branch it created the first time.

### What?

Since we don't want to end up deleting a branch that we did not create, the proposed solution is to generate a unique name for the branch and use that.

1. It will start with the version number as the branch name, like `v3.2.0`.
2. If that exists, it will iterate from `v3.2.0-no-1` to `v3.2.0-no-9`.
3. Highly unlikely, but if all of these exist, it will fallback to `v3.2.0-at-{unix_timestamp}`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
