### PR TITLE
Fix pipeline management state machine error handling

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -607,7 +607,7 @@ Resources:
                     },
                     "Catch": [
                       {
-                        "ErrorEquals": "ParameterNotFound",
+                        "ErrorEquals": ["ParameterNotFound"],
                         "Next": "ParameterNotFoundFallback"
                       }
                     ],


### PR DESCRIPTION
### Why?

The pipeline management Step Function state machine is not a valid definition.

### What?

The error(s) it catches should be an array.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
