### PR TITLE
Fix missing deployment_account_id and initial deployment global IAM bootstrap

### DIFF
--- a/Makefile.tox
+++ b/Makefile.tox
@@ -11,10 +11,8 @@ all: test lint
 
 test:
 	# Run unit tests
-	( \
-		for config in $(TEST_CONFIGS); do \
-			pytest $$(dirname $$config) -vvv -s -c $$config; \
-		done \
+	@ $(foreach config,$(TEST_CONFIGS), \
+		pytest $$(dirname $(config)) -vvv -s -c $(config) || exit 1; \
 	)
 
 lint:

--- a/src/lambda_codebase/event.py
+++ b/src/lambda_codebase/event.py
@@ -135,6 +135,7 @@ class Event:
                 'master_account_id': organization_information.get(
                     "organization_master_account_id"
                 ),
+                'deployment_account_id': self.deployment_account_id,
                 'notification_endpoint': self.main_notification_endpoint,
                 'notification_type': self.notification_type,
                 'cross_account_access_role': self.cross_account_access_role,

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -147,6 +147,10 @@ def prepare_deployment_account(sts, deployment_account_id, config):
         'deployment_account_bucket', DEPLOYMENT_ACCOUNT_S3_BUCKET_NAME
     )
     deployment_account_parameter_store.put_parameter(
+        'deployment_account_id',
+        deployment_account_id,
+    )
+    deployment_account_parameter_store.put_parameter(
         'default_scm_branch',
         config.config.get('scm', {}).get(
             'default-scm-branch',

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_main.py
@@ -133,7 +133,7 @@ def test_prepare_deployment_account_defaults(param_store_cls, cls, sts):
     )
     for param_store in parameter_store_list:
         assert param_store.put_parameter.call_count == (
-            12 if param_store == deploy_param_store else 2
+            13 if param_store == deploy_param_store else 2
         )
         param_store.put_parameter.assert_has_calls(
             [
@@ -147,6 +147,7 @@ def test_prepare_deployment_account_defaults(param_store_cls, cls, sts):
             call('adf_version', '1.0.0'),
             call('adf_log_level', 'CRITICAL'),
             call('deployment_account_bucket', 'some_deployment_account_bucket'),
+            call('deployment_account_id', deployment_account_id),
             call('default_scm_branch', 'master'),
             call('/adf/org/stage', 'none'),
             call('cross_account_access_role', 'some_role'),
@@ -225,7 +226,7 @@ def test_prepare_deployment_account_specific_config(param_store_cls, cls, sts):
     )
     for param_store in parameter_store_list:
         assert param_store.put_parameter.call_count == (
-            14 if param_store == deploy_param_store else 2
+            15 if param_store == deploy_param_store else 2
         )
         param_store.put_parameter.assert_has_calls(
             [
@@ -239,6 +240,7 @@ def test_prepare_deployment_account_specific_config(param_store_cls, cls, sts):
             call('adf_version', '1.0.0'),
             call('adf_log_level', 'CRITICAL'),
             call('deployment_account_bucket', 'some_deployment_account_bucket'),
+            call('deployment_account_id', deployment_account_id),
             call('default_scm_branch', 'main'),
             call('/adf/org/stage', 'test-stage'),
             call('auto_create_repositories', 'disabled'),

--- a/src/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/initial_commit.py
@@ -33,6 +33,9 @@ REWRITE_PATHS: Dict[str, str] = {
     "bootstrap_repository/adf-bootstrap/example-global-iam.yml": (
         "adf-bootstrap/global-iam.yml"
     ),
+    "bootstrap_repository/adf-bootstrap/deployment/example-global-iam.yml": (
+        "adf-bootstrap/deployment/global-iam.yml"
+    ),
     "adf.yml.j2": "adf-accounts/adf.yml",
     "adfconfig.yml.j2": "adfconfig.yml",
 }


### PR DESCRIPTION
### Why?

Issues: #659 and #594.

When installing ADF the first time, the global IAM bootstrap stack that gets deployed is sourced from the `adf-bootstrap/global-iam.yml`.

The reason for this behaviour is the absence of the `global-iam.yml` file in the deployment OU bootstrap folder
(`adf-bootstrap/deployment/global-iam.yml`).

It iterates to the parent directory until it finds a `global-iam.yml` to deploy. Hence, when the `adf-bootstrap/global-iam.yml` gets deployed in the deployment account, it was looking for the `deployment_account_id` SSM parameter. That did not get deployed in the deployment account.

### What?

* Add the creation of the `deployment_account_id` in the deployment account, so if the global IAM bootstrap stack failed to deploy before, it will work in the next release. This would be the case if the previous deployment failed but the same `aws-deployment-framework-bootstrap` repository is used in the upgrade.
* When installing the first time, it creates the bootstrap repository. At the time of creation, it will copy the `adf-bootstrap/deployment/example-global-iam.yml` to `adf-bootstrap/deployment/global-iam.yml`. The same logic as how ADF creates the initial `adf-bootstrap/global-iam.yml`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
