### PR TITLE
Fix Jinja2 template rendering with autoescape enabled

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
@@ -510,7 +510,7 @@ def get_files_to_commit(directory_path: Path) -> List[FileToCommit]:
 def create_adf_config_file(props: CustomResourceProperties) -> FileToCommit:
     template = HERE / "adfconfig.yml.j2"
     adf_config = (
-        jinja2.Template(template.read_text(), undefined=jinja2.StrictUndefined)
+        jinja2.Template(template.read_text(), undefined=jinja2.StrictUndefined , autoescape=True)
         .render(vars(props))
         .encode()
     )

--- a/src/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/initial_commit.py
@@ -555,7 +555,7 @@ def create_adf_config_file(
 ) -> FileToCommit:
     template = HERE / input_file_name
     adf_config = (
-        jinja2.Template(template.read_text(), undefined=jinja2.StrictUndefined)
+        jinja2.Template(template.read_text(), undefined=jinja2.StrictUndefined,autoescape=True)
         .render(vars(props))
         .encode()
     )

--- a/src/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/initial_commit.py
@@ -555,7 +555,7 @@ def create_adf_config_file(
 ) -> FileToCommit:
     template = HERE / input_file_name
     adf_config = (
-        jinja2.Template(template.read_text(), undefined=jinja2.StrictUndefined,autoescape=True)
+        jinja2.Template(template.read_text(), undefined=jinja2.StrictUndefined, autoescape=True)
         .render(vars(props))
         .encode()
     )


### PR DESCRIPTION
## Why?

We are using aws-deployment-framework for deployments. In our AWS accounts we are solving an Security Hub findings.
One of the finding found is referenced as CWE-20,79,80 - Cross-site scripting(XSS) with  high security labelled.

The issue is in the Jinja2 library, as used by `initial_commit.py` files. There was no `autoescape=True`.
I added the `autoescape=True` attribute to resolve this.
With these changes, the finding related with XSS is resolved in our AWS account.
Please consider this in next release.

Security-hub finding issue -CWE-20,79,80 - Cross-site scripting

> User-controllable input must be sanitized before it's included in output used to dynamically generate a web page.
> Unsanitized user input can introduce cross-side scripting (XSS) vulnerabilities that can lead to inadvertedly running malicious code in a trusted context.

## What?

Description of changes:

1. Add `autoescape=True` to resolve the XSS issue while rendering Jinja2 templates.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
