### PR TITLE
Fix PipelineDeletionStateMachine failing on deleted stacks

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -373,9 +373,6 @@ Resources:
                   - cloudformation:DeleteStack
                 Resource:
                   - "*"
-                Condition:
-                  StringEquals:
-                    'aws:ResourceTag/createdBy': "ADF"
               - Effect: Allow
                 Action:
                   - "ssm:DeleteParameter"


### PR DESCRIPTION
PipelineDeletionStateMachine's IAM role only allowed deleting stacks with a createdBy tag, however non-existing/deleted stacks don't have tags from IAM point of view.

When PipelineDeletionStateMachine is run for a stack that is already deleted but parameter is not deleted, it will try to delete the stack but fails with AccessDenied.

The stack can be deleted for example due to manual deletion or something going wrong when deleting the parameter.

Removing the condition fixes this and DeleteStack will be a noop when stack doesn't exist.

Something to keep in mind is that the protection for this to fail on stacks that are not created by ADF goes away and to keep we will have to complicated the logic to check for stack existance another way.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
