### PR TITLE
Add delete default VPC in management account support

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
@@ -99,6 +99,17 @@ Resources:
           - Effect: Allow
             Action:
               - cloudformation:ValidateTemplate
+              - ec2:DeleteInternetGateway
+              - ec2:DeleteNetworkInterface
+              - ec2:DeleteRouteTable
+              - ec2:DeleteSubnet
+              - ec2:DeleteVpc
+              - ec2:DescribeInternetGateways
+              - ec2:DescribeNetworkInterfaces
+              - ec2:DescribeRegions
+              - ec2:DescribeRouteTables
+              - ec2:DescribeSubnets
+              - ec2:DescribeVpcs
               - iam:CreateAccountAlias
               - iam:DeleteAccountAlias
               - iam:ListAccountAliases


### PR DESCRIPTION
## Why?

To allow the deletion of the Default VPC if one were to manage the management account via ADF's Account Management (adf-accounts).

## What?

Added the missing permissions to delete and describe the default VPCs in the management account.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
