### PR TITLE
Fix tagging of Cross Account Access role in the management account

### DIFF
--- a/src/template.yml
+++ b/src/template.yml
@@ -1307,7 +1307,6 @@ Resources:
               - "s3:GetObject"
               - "s3:ListBucket"
               - "s3:PutObject"
-              - "s3:ListObjects"
             Resource:
               - !GetAtt "BootstrapTemplatesBucket.Arn"
               - !Sub "${BootstrapTemplatesBucket.Arn}/*"
@@ -1332,6 +1331,8 @@ Resources:
               - "iam:DeleteRolePolicy"
               - "iam:GetRole"
               - "iam:PutRolePolicy"
+              - "iam:TagRole"
+              - "iam:UntagRole"
               - "iam:UpdateAssumeRolePolicy"
             Resource:
               - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${CrossAccountAccessRoleName}"


### PR DESCRIPTION
## Why?

When ADF needs to tag or untag the cross-account access role, it fails to do so.

## What?

* Granting the required permissions to tag and untag the roles.
* Removal of the invalid `s3:ListObjects` permission, the permissions required to list objects in a bucket are managed via the `s3:ListBucket` permission. Which is already present.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
