### PR TITLE
Fix CloudFormation cross-region changeset approval

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_cloudformation.py
@@ -43,7 +43,7 @@ class CloudFormation(Construct):
                         name=f"{target['name']}-{region}",
                         provider="Manual",
                         category="Approval",
-                        region=region,
+                        region=ADF_DEPLOYMENT_REGION,
                         target=target,
                         run_order=2,
                         map_params=map_params,


### PR DESCRIPTION
## Why?

With the CloudFormation deployment provider: It would fail to create the pipeline if one were to set the `change_set_approval` property to `True`, while the pipeline lives in another region than where it is asked to deploy to.

## What?

* The approval action should be performed in the region that hosts the pipeline. Not the target region.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
