### PR TITLE
Install: Add checks to ensure installer dependencies are available

### DIFF
--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -73,7 +73,10 @@ Please note that building on *Windows* is not supported, please use the
     This should return 4.3 or later.
 - [python 3](https://www.python.org/downloads/)
   - To test if it is available, run `python --version`.
-    This should return 3.11 or later.
+    This should return 3.9 or later.
+- [jq](https://github.com/jqlang/jq)
+  - To test if it is available, run `jq --version`.
+    This version should be 1.6 or later.
 - [sed](https://www.gnu.org/software/sed/)
   - To test if it is available, run `sed --version`.
     This should return 4.3 or later.


### PR DESCRIPTION
## Why?

When running the make / install process of ADF, we need to ensure it will not continue if some of the tools are not installed yet.

For example, in the past, if you did not install jq, it would still continue with the build process. Resulting in a broken template at deployment time.

As reported in #696, the Python version in the environment was set to v3.8, which resulted in a broken installation process too.

## What?

* Updated the documentation to indicate that `jq` needs to be available too.
* Added checks in the build process to exit and warn the user about missing dependencies.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
