### PR TITLE
Fix clean bootstrap of the deployment account

### DIFF
--- a/src/lambda_codebase/event.py
+++ b/src/lambda_codebase/event.py
@@ -86,12 +86,10 @@ class Event:
             1 if self.destination_ou_name == DEPLOYMENT_ACCOUNT_OU_NAME
             else 0
         )
-        try:
-            self.deployment_account_id = (
-                self.parameter_store.fetch_parameter('deployment_account_id')
-            )
-        except ParameterNotFoundError:
-            self.deployment_account_id = self.account_id
+        self.deployment_account_id = self._read_parameter(
+            'deployment_account_id',
+            self.account_id,
+        )
 
     def set_destination_ou_name(self):
         """
@@ -107,6 +105,12 @@ class Event:
             self.destination_ou_name = "ROOT"
         finally:
             self._determine_if_deployment_account()
+
+    def _read_parameter(self, name, default_value_when_missing):
+        try:
+            return self.parameter_store.fetch_parameter(name)
+        except ParameterNotFoundError:
+            return default_value_when_missing
 
     def create_output_object(self, account_path):
         """
@@ -140,6 +144,12 @@ class Event:
                 'cross_account_access_role': self.cross_account_access_role,
                 'deployment_account_bucket': DEPLOYMENT_ACCOUNT_S3_BUCKET,
                 'adf_version': ADF_VERSION,
-                'adf_log_level': ADF_LOG_LEVEL
+                'adf_log_level': ADF_LOG_LEVEL,
+                'extensions/terraform/enabled': (
+                    self._read_parameter(
+                        'extensions/terraform/enabled',
+                        'False',
+                    )
+                ),
             },
         }


### PR DESCRIPTION
## Why?

When you attempt to install ADF the first time, it will bootstrap the deployment account via the account bootstrap state machine. This, however, happens just before executing the bootstrap pipeline the first time. Resulting in missing parameters in the deployment account at the time the [regional stack](https://github.com/awslabs/aws-deployment-framework/blob/7a4359fcc441f3e62818b3c24569ddf069ec7a74/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml#L14) is deployed.

This stack requires the `extensions/terraform/enabled` parameter (see [here](https://github.com/awslabs/aws-deployment-framework/blob/7a4359fcc441f3e62818b3c24569ddf069ec7a74/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml#L14)). If that is not there yet, which is the case in the situation above, it will fail to bootstrap the account. Hereby the bootstrap state machine and pipeline both fail initially.

## What?

When the bootstrap state machine determines the event details, it should try to retrieve the parameter in the management account to see if Terraform is enabled or not. If this is not configured yet, it should default to False.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
