### PR TITLE
Fix pipeline support for CodeBuild containers with Python < v3.10

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/requirements.txt
@@ -5,4 +5,5 @@ pyyaml~=6.0.1
 schema~=0.7.5
 tenacity==8.2.3
 typing-extensions~=4.9.0
-urllib3~=2.0.7
+urllib3~=1.26.18 ; python_version < "3.10"
+urllib3~=2.0.7 ; python_version >= "3.10"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
@@ -8,4 +8,5 @@ pyyaml~=6.0.1
 schema~=0.7.5
 tenacity==8.2.3
 typing-extensions~=4.9.0
-urllib3~=2.0.7
+urllib3~=1.26.18 ; python_version < "3.10"
+urllib3~=2.0.7 ; python_version >= "3.10"


### PR DESCRIPTION
## Why?

With the current dependency requirements, a build pipeline will fail to install liburl3 if a Python version prior to v3.10 is used.

As botocore defined a Python version specific requirement for urllib3, as can be seen at https://github.com/boto/botocore/blob/1.34.17/setup.py#L28-L29.

## What?

If urllib3 is installed in a CodeBuild container which has Python version < v3.10, we should use the latest 1.26 release that is available instead.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
