### PR TITLE
Fix updating old global-iam stacks in the deployment account

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -558,7 +558,7 @@ Resources:
   CloudFormationDeploymentPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: "adf-cloudformation-deployment-role-policy"
+      PolicyName: "adf-cloudformation-deployment-role-policy-kms"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
@@ -47,7 +47,7 @@ DEPLOYMENT_ROLE_POLICIES = {
         "adf-codepipeline-role-policy-kms",
     ],
     "adf-cloudformation-deployment-role": [
-        "adf-cloudformation-deployment-role-policy",
+        "adf-cloudformation-deployment-role-policy-kms",
     ],
     "adf-cloudformation-role": [
         "adf-cloudformation-role-policy",


### PR DESCRIPTION
## Why?

With PR #568, the policy names in the
`adf-bootstrap/deployment/example-global-iam.yml` file were updated to ensure that they are unique. However, if the `example-global-iam.yml` was not updated recently, then copied/renamed to `global-iam.yml` it would overwrite, and or delete policies that were created by the `global.yml` stack instead.

This creates an issue that is hard to debug unfortunately.

## What?

This proposed change will introduce the ADF managed policy as defined in the `global.yml` stack of the deployment account. This way the policies are (re)created correctly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
