### PR TITLE
Update copyright statements and license info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
 # Makefile versions

--- a/Makefile.tox
+++ b/Makefile.tox
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
 # Files to work with

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,4 +2,4 @@
 
 AWS Deployment Framework
 
-Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com Inc. or its affiliates.

--- a/resources/OrganizationAccountAccessRole.yaml
+++ b/resources/OrganizationAccountAccessRole.yaml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
   Organizational Account Access Role for Cross-Account automation

--- a/samples/sample-cdk-app/buildspec.yml
+++ b/samples/sample-cdk-app/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-cdk-app/handler.py
+++ b/samples/sample-cdk-app/handler.py
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 def main(event, context):
     print("I'm running!")

--- a/samples/sample-cdk-app/index.ts
+++ b/samples/sample-cdk-app/index.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates.
+// SPDX-License-Identifier: Apache-2.0
+
 import events = require('@aws-cdk/aws-events');
 import targets = require('@aws-cdk/aws-events-targets');
 import lambda = require('@aws-cdk/aws-lambda');

--- a/samples/sample-codebuild-vpc/buildspec.yml
+++ b/samples/sample-codebuild-vpc/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-codebuild-vpc/params/global.yml
+++ b/samples/sample-codebuild-vpc/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Tags:
   Repository: sample-codebuild-vpc-repo
   App: Sample CodeBuild VPC application

--- a/samples/sample-codebuild-vpc/template.yml
+++ b/samples/sample-codebuild-vpc/template.yml
@@ -1,5 +1,5 @@
-# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Sample Template

--- a/samples/sample-codebuild-vpc/testspec.yml
+++ b/samples/sample-codebuild-vpc/testspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-ec2-java-app-codedeploy/appspec.yml
+++ b/samples/sample-ec2-java-app-codedeploy/appspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.0
 os: linux
 

--- a/samples/sample-ec2-java-app-codedeploy/buildspec.yml
+++ b/samples/sample-ec2-java-app-codedeploy/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-ec2-java-app-codedeploy/pom.xml
+++ b/samples/sample-ec2-java-app-codedeploy/pom.xml
@@ -1,3 +1,6 @@
+<!-- Copyright Amazon.com Inc. or its affiliates. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/samples/sample-ec2-java-app-codedeploy/scripts/start.sh
+++ b/samples/sample-ec2-java-app-codedeploy/scripts/start.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 cd /home/ec2-user/server
 sudo /usr/bin/java -jar -Dserver.port=80 \
   *.jar > /dev/null 2> /dev/null < /dev/null &

--- a/samples/sample-ec2-java-app-codedeploy/scripts/stop.sh
+++ b/samples/sample-ec2-java-app-codedeploy/scripts/stop.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 sudo killall java
 exit 0

--- a/samples/sample-ec2-java-app-codedeploy/scripts/validate.sh
+++ b/samples/sample-ec2-java-app-codedeploy/scripts/validate.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 echo "Waiting for 15 seconds before checking health.."
 sleep 15
 

--- a/samples/sample-ec2-java-app-codedeploy/src/main/java/hello/Application.java
+++ b/samples/sample-ec2-java-app-codedeploy/src/main/java/hello/Application.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates.
+// SPDX-License-Identifier: Apache-2.0
+
 package hello;
 
 import org.springframework.boot.SpringApplication;

--- a/samples/sample-ec2-java-app-codedeploy/src/resources/application.yml
+++ b/samples/sample-ec2-java-app-codedeploy/src/resources/application.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 server:
   port: 8080
 

--- a/samples/sample-ec2-with-codedeploy/buildspec.yml
+++ b/samples/sample-ec2-with-codedeploy/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-ec2-with-codedeploy/params/global.yml
+++ b/samples/sample-ec2-with-codedeploy/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   Environment: testing
   ApplicationName: sample

--- a/samples/sample-ec2-with-codedeploy/scripts/install-codedeploy.sh
+++ b/samples/sample-ec2-with-codedeploy/scripts/install-codedeploy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 set -xe
 
 ## Code Deploy Agent Bootstrap Script ##

--- a/samples/sample-ec2-with-codedeploy/scripts/install-deps.sh
+++ b/samples/sample-ec2-with-codedeploy/scripts/install-deps.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 # install apache httpd
 sudo yum install httpd -y
 

--- a/samples/sample-ec2-with-codedeploy/template.yml
+++ b/samples/sample-ec2-with-codedeploy/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Sample Template (EC2 Application with CodeDeploy Components)

--- a/samples/sample-ecr-repository/buildspec.yml
+++ b/samples/sample-ecr-repository/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-ecr-repository/params/global.yml
+++ b/samples/sample-ecr-repository/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   TestingAccountId: '11111111111'
   ProductionAccountId: '999999999999'

--- a/samples/sample-ecr-repository/template.yml
+++ b/samples/sample-ecr-repository/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: ADF CloudFormation Sample Template (Shared ECR Repository)

--- a/samples/sample-ecs-cluster/buildspec.yml
+++ b/samples/sample-ecs-cluster/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-ecs-cluster/params/banking-production.yml
+++ b/samples/sample-ecs-cluster/params/banking-production.yml
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   Environment: production

--- a/samples/sample-ecs-cluster/params/global.yml
+++ b/samples/sample-ecs-cluster/params/global.yml
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   Environment: testing

--- a/samples/sample-ecs-cluster/template.yml
+++ b/samples/sample-ecs-cluster/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 # This Template builds on top of the great work of Nathan Pec
 # => https://github.com/nathanpeck/aws-cloudformation-fargate

--- a/samples/sample-etl-pipeline/scripts/some_etl_script.sh
+++ b/samples/sample-etl-pipeline/scripts/some_etl_script.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 echo "Doing some ETL tasks... This could also be done with a custom CodeBuild Image..."

--- a/samples/sample-expunge-vpc/build-lambda.sh
+++ b/samples/sample-expunge-vpc/build-lambda.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 cd src/lambda_vpc

--- a/samples/sample-expunge-vpc/buildspec.yml
+++ b/samples/sample-expunge-vpc/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-expunge-vpc/src/lambda_vpc/lambda_function.py
+++ b/samples/sample-expunge-vpc/src/lambda_vpc/lambda_function.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 from crhelper import CfnResource
 import logging
 import boto3

--- a/samples/sample-expunge-vpc/template.yml
+++ b/samples/sample-expunge-vpc/template.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: Deploys the Custom Resource for deleting the default VPC in all regions

--- a/samples/sample-fargate-node-app/Dockerfile
+++ b/samples/sample-fargate-node-app/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM node:current-alpine
 WORKDIR /app
 COPY . .

--- a/samples/sample-fargate-node-app/build/docker.sh
+++ b/samples/sample-fargate-node-app/build/docker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 $(aws ecr get-login --region $AWS_REGION --no-include-email)

--- a/samples/sample-fargate-node-app/build/generate_parameters.sh
+++ b/samples/sample-fargate-node-app/build/generate_parameters.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet

--- a/samples/sample-fargate-node-app/buildspec.yml
+++ b/samples/sample-fargate-node-app/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-fargate-node-app/index.js
+++ b/samples/sample-fargate-node-app/index.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates.
+// SPDX-License-Identifier: Apache-2.0
+
 const express = require('express')
 
 const app = express()

--- a/samples/sample-fargate-node-app/package.json
+++ b/samples/sample-fargate-node-app/package.json
@@ -8,7 +8,7 @@
     "start": "node index.js"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "ejs": "^3.1.7",
     "express": "^4.16.3"

--- a/samples/sample-fargate-node-app/params/banking-production.yml
+++ b/samples/sample-fargate-node-app/params/banking-production.yml
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   Environment: production

--- a/samples/sample-fargate-node-app/params/global.yml
+++ b/samples/sample-fargate-node-app/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   Environment: testing
   ServiceName: sample-node-app

--- a/samples/sample-fargate-node-app/public/main.css
+++ b/samples/sample-fargate-node-app/public/main.css
@@ -1,3 +1,6 @@
+/* Copyright Amazon.com Inc. or its affiliates. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 @import url(https://fonts.googleapis.com/css?family=Signika:700,300,600);
 
 html, body {

--- a/samples/sample-fargate-node-app/template.yml
+++ b/samples/sample-fargate-node-app/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Sample Template (NodeJS Application)

--- a/samples/sample-fargate-node-app/views/index.ejs
+++ b/samples/sample-fargate-node-app/views/index.ejs
@@ -1,6 +1,9 @@
 <!doctype html>
 <html lang="en">
 
+    <!-- Copyright Amazon.com Inc. or its affiliates. -->
+    <!-- SPDX-License-Identifier: Apache-2.0 -->
+
     <head>
         <meta charset="utf-8">
         <title>Sample App</title>

--- a/samples/sample-iam/buildspec.yml
+++ b/samples/sample-iam/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-iam/params/global.yml
+++ b/samples/sample-iam/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Tags:
   TagKey: my_tag
   MyKey: new_value

--- a/samples/sample-iam/template.yml
+++ b/samples/sample-iam/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: ADF CloudFormation Sample Template (IAM)

--- a/samples/sample-mono-repo/apps/alpha/buildspec.yml
+++ b/samples/sample-mono-repo/apps/alpha/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/samples/sample-mono-repo/apps/alpha/params/global.yml
+++ b/samples/sample-mono-repo/apps/alpha/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Tags:
   Repository: sample-mono-repo
   App: Sample Mono Repo Alpha

--- a/samples/sample-mono-repo/apps/alpha/template.yml
+++ b/samples/sample-mono-repo/apps/alpha/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Sample Template (Mono Repo/App A)

--- a/samples/sample-mono-repo/apps/beta/buildspec.yml
+++ b/samples/sample-mono-repo/apps/beta/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/samples/sample-mono-repo/apps/beta/params/global.yml
+++ b/samples/sample-mono-repo/apps/beta/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Tags:
   Repository: sample-mono-repo
   App: Sample Mono Repo Beta

--- a/samples/sample-mono-repo/apps/beta/template.yml
+++ b/samples/sample-mono-repo/apps/beta/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Sample Template (Mono Repo/App B)

--- a/samples/sample-rdk-rules/buildspec.yml
+++ b/samples/sample-rdk-rules/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 phases:
   install:

--- a/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINATION_PROTECTION_ADF/EC2_CHECKS_TERMINATION_PROTECTION_ADF.py
+++ b/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINATION_PROTECTION_ADF/EC2_CHECKS_TERMINATION_PROTECTION_ADF.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import sys
 import datetime

--- a/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINATION_PROTECTION_ADF/EC2_CHECKS_TERMINATION_PROTECTION_ADF_test.py
+++ b/samples/sample-rdk-rules/config-rules/EC2_CHECKS_TERMINATION_PROTECTION_ADF/EC2_CHECKS_TERMINATION_PROTECTION_ADF_test.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 import unittest
 from unittest.mock import MagicMock

--- a/samples/sample-rdk-rules/lambda_helper.py
+++ b/samples/sample-rdk-rules/lambda_helper.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 import argparse
 import json
 import os

--- a/samples/sample-serverless-app/build/generate_parameters.sh
+++ b/samples/sample-serverless-app/build/generate_parameters.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 aws s3 cp s3://$S3_BUCKET_NAME/adf-build/ adf-build/ --recursive --quiet

--- a/samples/sample-serverless-app/buildspec.yml
+++ b/samples/sample-serverless-app/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-serverless-app/handler.py
+++ b/samples/sample-serverless-app/handler.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 
 def lambda_handler(event, context):

--- a/samples/sample-serverless-app/template.yml
+++ b/samples/sample-serverless-app/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31

--- a/samples/sample-service-catalog-product/buildspec.yml
+++ b/samples/sample-service-catalog-product/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-service-catalog-product/params/global.yml
+++ b/samples/sample-service-catalog-product/params/global.yml
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   ProductXTemplateURL: 'upload:eu-central-1:productX/template.yml'

--- a/samples/sample-service-catalog-product/productX/template.yml
+++ b/samples/sample-service-catalog-product/productX/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Sample Service Catalog Product

--- a/samples/sample-service-catalog-product/template.yml
+++ b/samples/sample-service-catalog-product/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: ADF CloudFormation Sample Template (Service Catalog Product)

--- a/samples/sample-terraform/buildspec.yml
+++ b/samples/sample-terraform/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/samples/sample-terraform/params/global.yml
+++ b/samples/sample-terraform/params/global.yml
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   ProjectName: "sample-terraform"

--- a/samples/sample-terraform/tf/backend.tf
+++ b/samples/sample-terraform/tf/backend.tf
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   backend "s3" {}
 }

--- a/samples/sample-terraform/tf/main.tf
+++ b/samples/sample-terraform/tf/main.tf
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 data "aws_partition" "current" {}
 
 terraform {

--- a/samples/sample-terraform/tf/s3.tf
+++ b/samples/sample-terraform/tf/s3.tf
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 resource "aws_s3_bucket" "s3" {
   bucket = "my-tf-test-bucket-${var.TARGET_REGION}-${var.TARGET_ACCOUNT_ID}"
   acl    = "private"

--- a/samples/sample-terraform/tf/variables.tf
+++ b/samples/sample-terraform/tf/variables.tf
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 variable "TARGET_ACCOUNT_ID" {
   type = string
 }

--- a/samples/sample-terraform/tf_apply.yml
+++ b/samples/sample-terraform/tf_apply.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/samples/sample-terraform/tf_destroy.yml
+++ b/samples/sample-terraform/tf_destroy.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/samples/sample-terraform/tf_plan.yml
+++ b/samples/sample-terraform/tf_plan.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/samples/sample-terraform/tf_scan.yml
+++ b/samples/sample-terraform/tf_scan.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-vpc/buildspec.yml
+++ b/samples/sample-vpc/buildspec.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 phases:

--- a/samples/sample-vpc/params/banking-production.yml
+++ b/samples/sample-vpc/params/banking-production.yml
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   Environment: production

--- a/samples/sample-vpc/params/global.yml
+++ b/samples/sample-vpc/params/global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 Parameters:
   CostCenter: '123'
   Environment: testing

--- a/samples/sample-vpc/template.yml
+++ b/samples/sample-vpc/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ADF CloudFormation Sample Template (VPC) - Designed to be launched into a region with 3 availability zones

--- a/src/lambda_codebase/__init__.py
+++ b/src/lambda_codebase/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/account/handler.py
+++ b/src/lambda_codebase/account/handler.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account/main.py
+++ b/src/lambda_codebase/account/main.py
@@ -1,5 +1,6 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
+
 """
 The Account main that is called when ADF is installed to initially create the
 deployment account if required.

--- a/src/lambda_codebase/account/pytest.ini
+++ b/src/lambda_codebase/account/pytest.ini
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests

--- a/src/lambda_codebase/account/tests/__init__.py
+++ b/src/lambda_codebase/account/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/account/tests/test_main.py
+++ b/src/lambda_codebase/account/tests/test_main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/account_bootstrap.py
+++ b/src/lambda_codebase/account_bootstrap.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/__init__.py
+++ b/src/lambda_codebase/account_processing/__init__.py
@@ -1,0 +1,4 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file

--- a/src/lambda_codebase/account_processing/configure_account_alias.py
+++ b/src/lambda_codebase/account_processing/configure_account_alias.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/configure_account_ou.py
+++ b/src/lambda_codebase/account_processing/configure_account_ou.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/configure_account_regions.py
+++ b/src/lambda_codebase/account_processing/configure_account_regions.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/configure_account_tags.py
+++ b/src/lambda_codebase/account_processing/configure_account_tags.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/create_account.py
+++ b/src/lambda_codebase/account_processing/create_account.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/delete_default_vpc.py
+++ b/src/lambda_codebase/account_processing/delete_default_vpc.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/get_account_regions.py
+++ b/src/lambda_codebase/account_processing/get_account_regions.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/process_account_files.py
+++ b/src/lambda_codebase/account_processing/process_account_files.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/pytest.ini
+++ b/src/lambda_codebase/account_processing/pytest.ini
@@ -1,7 +1,9 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests
 addopts = --cov=./src/lambda_codebase/account_processing/  --cov-fail-under=50 --cov-report term
 
 [coverage:run]
 omit = tests/
-

--- a/src/lambda_codebase/account_processing/register_account_for_support.py
+++ b/src/lambda_codebase/account_processing/register_account_for_support.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/account_processing/tests/__init__.py
+++ b/src/lambda_codebase/account_processing/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file

--- a/src/lambda_codebase/account_processing/tests/test_account_alias.py
+++ b/src/lambda_codebase/account_processing/tests/test_account_alias.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Tests the account alias configuration lambda
 """

--- a/src/lambda_codebase/account_processing/tests/test_account_creation.py
+++ b/src/lambda_codebase/account_processing/tests/test_account_creation.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Tests the account creation lambda
 """

--- a/src/lambda_codebase/account_processing/tests/test_account_file_processing.py
+++ b/src/lambda_codebase/account_processing/tests/test_account_file_processing.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Tests the account file processing lambda
 """

--- a/src/lambda_codebase/account_processing/tests/test_account_tags.py
+++ b/src/lambda_codebase/account_processing/tests/test_account_tags.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Tests the account tag configuration lambda
 """

--- a/src/lambda_codebase/account_processing/tests/test_configure_account_regions.py
+++ b/src/lambda_codebase/account_processing/tests/test_configure_account_regions.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Tests the account alias configuration lambda
 """

--- a/src/lambda_codebase/account_processing/tests/test_get_default_regions.py
+++ b/src/lambda_codebase/account_processing/tests/test_get_default_regions.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Tests the account tag configuration lambda
 """

--- a/src/lambda_codebase/cross_region_bucket/handler.py
+++ b/src/lambda_codebase/cross_region_bucket/handler.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/cross_region_bucket/main.py
+++ b/src/lambda_codebase/cross_region_bucket/main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/deployment_account_config.py
+++ b/src/lambda_codebase/deployment_account_config.py
@@ -1,7 +1,7 @@
-# pylint: skip-file
-
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file
 
 """
 Executes as part of the bootstrap process when the Deployment Account

--- a/src/lambda_codebase/determine_event.py
+++ b/src/lambda_codebase/determine_event.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/event.py
+++ b/src/lambda_codebase/event.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/generic_account_config.py
+++ b/src/lambda_codebase/generic_account_config.py
@@ -1,6 +1,5 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
-
 
 """
 Executes for any account that has been Bootstrapped other

--- a/src/lambda_codebase/initial_commit/adf.yml.j2
+++ b/src/lambda_codebase/initial_commit/adf.yml.j2
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 accounts:
   - account_full_name: {{ DeploymentAccountFullName }}
     organizational_unit_path: /deployment

--- a/src/lambda_codebase/initial_commit/adfconfig.yml.j2
+++ b/src/lambda_codebase/initial_commit/adfconfig.yml.j2
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 roles:
   cross-account-access: {{ CrossAccountAccessRole }}
   # ^ The role by ADF to assume cross account access
@@ -35,4 +38,3 @@ config:
   #org:
     # Optional: Use this variable to define the AWS Organization in case of staged multi-organization ADF deployments
     #stage: dev
-

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/example-global-iam.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/example-global-iam.yml
@@ -1,5 +1,6 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: ADF CloudFormation Template (Global) for IAM in the Deployment Account

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/__init__.py
@@ -1,2 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
+
+# pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/determine_default_branch.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/determine_default_branch.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 The Determine Default Branch Logic that is called when ADF is installed
 or updated to determine the default branch for the given repository.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/handler.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/handler.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 The Determine Default Branch Handler that is called when ADF is installed
 or updated to determine the default branch for the repository.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/pytest.ini
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/tests/test_determine_default_branch.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/determine_default_branch/tests/test_determine_default_branch.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/enable_cross_account_access.py
@@ -1,6 +1,5 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
-
 
 """
 Enables the connection between the deployment account

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/iam_cfn_deploy_role_policy.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/iam_cfn_deploy_role_policy.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/handler.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/handler.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 The Initial Commit Handler that is called when ADF is installed to commit the
 initial pipelines repository content.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/initial_commit.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 The Initial Commit main that is called when ADF is installed to commit the
 initial pipelines repository content.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pipelines_repository/example-deployment_map.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pipelines_repository/example-deployment_map.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 pipelines:
   - name: sample-iam  # The name of your pipeline (by default, this will match the name of your repository)
     default_providers:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/pytest.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests
 norecursedirs = pipelines_repository

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/tests/test_initial_commit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/initial_commit/tests/test_initial_commit.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/create_or_update_rule.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/create_or_update_rule.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Pipeline Management Lambda Function
 Creates or Updates an Event Rule for forwarding events

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/create_repository.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/create_repository.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Pipeline Management Lambda Function
 Creates or Updates a CodeCommit Repository

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/generate_pipeline_inputs.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/generate_pipeline_inputs.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Pipeline Management Lambda Function
 Generates Pipeline Inputs

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Pipeline Management Lambda Function
 Compares pipeline definitions in S3 to the definitions stored in SSM Param Store.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/process_deployment_map.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Pipeline Management Lambda Function
 Triggered by new Deployment Maps in S3 Bucket.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/store_pipeline_definition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/store_pipeline_definition.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Pipeline Management Lambda Function
 Stores pipeline input from prior function to S3.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/templates/codecommit.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/templates/codecommit.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 Parameters:
   RepoName:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/templates/events.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/templates/events.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 Parameters:
   DeploymentAccountId:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pytest.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests
 norecursedirs = initial_commit determine_default_branch

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/slack.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/slack.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/slack.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/slack.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/stub_iam.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/stubs/stub_iam.py
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/test_iam_cfn_deploy_role_policy.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/test_iam_cfn_deploy_role_policy.py
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/test_slack.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/tests/test_slack.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/update_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/update_pipelines.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 Description: ADF CloudFormation Stack for processing deployment maps.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: ADF CloudFormation Template (Regional) for Deployment Account

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-global-iam.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-global-iam.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: ADF CloudFormation Template (Global) for IAM in the Target Accounts

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/global.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/config.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/config.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Config module used as part of bootstrap_repository

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/global.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/organization_policy.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/organization_policy.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """__init__

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/account.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/account.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/configparser.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/configparser.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/support.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/support.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """Support module used throughout the ADF
 """
 from enum import Enum

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/vpc.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/provisioner/src/vpc.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/base_resolver.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/base_resolver.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_chatbot.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_chatbot.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to Notifications Codepipeline Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_cloudformation.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to CloudFormation Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to CodeBuild Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codecommit.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codecommit.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to CodeCommit Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codepipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to CodePipeline Action Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codestar.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codestar.py
@@ -1,7 +1,7 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
-"""Construct related to CodeStarConnection Codepipeline Input
+"""Construct related to CodeStarConnection CodePipeline Input
 """
 
 import os

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to Events Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_github.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_github.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to Github Codepipeline Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_jenkins.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_jenkins.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to Jenkins Codepipeline Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_notifications.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to Notifications Codepipeline Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_s3.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Construct related to S3 Codepipeline Input

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/adf_codepipeline_test_constants.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/adf_codepipeline_test_constants.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file
@@ -15,4 +15,3 @@ BASE_MAP_PARAMS = {
     },
     'name': 'name',
 }
-

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_buildspec.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_buildspec.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_determine_build_image.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codebuild_determine_build_image.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_generate.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_generate.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_input_artifacts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_input_artifacts.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_output_artifacts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_output_artifacts.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/clean_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/clean_pipelines.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/execute_pipeline_stacks.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/execute_pipeline_stacks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_stacks.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/generate_pipeline_stacks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/pytest.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths =
     cdk_constructs/tests

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/describe_codepipeline_trigger.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/describe_codepipeline_trigger.py
@@ -1,5 +1,6 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
+
 """
 Describe CodePipeline trigger.
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/package_transform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/package_transform.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-#
+
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 # This script will package all source code and send it to an S3 bucket in each region
 # where the lambda needs to be deployed to.
 #

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/pytest.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests
 norecursedirs = terraform

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/retrieve_organization_accounts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/retrieve_organization_accounts.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 retrieve_organization_accounts.py
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sts.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sts.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 if [ -z "$AWS_PARTITION" ]; then
   AWS_PARTITION="aws"
 fi

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/sync_to_s3.py
@@ -1,5 +1,6 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
+
 """
 Sync files to an S3 Bucket.
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 PATH=$PATH:$(pwd)
 export PATH
 CURRENT=$(pwd)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/get_accounts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/get_accounts.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/install_terraform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/install_terraform.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 set -e
 
 apt-get install --assume-yes jq

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/tests/test_sync_to_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/tests/test_sync_to_s3.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 import os
 from typing import Mapping
 from pathlib import Path

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/pytest.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests
 norecursedirs = python cdk helpers

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cache.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cache.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """CloudFormation module used throughout the ADF

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudwatch.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudwatch.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Standardized class for pushing CloudWatch metric data to a service within the ADF Namespace
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/codepipeline.py
@@ -1,5 +1,4 @@
-
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """CodePipeline module used throughout the ADF

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/deployment_map.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/errors.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/list_utils.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/list_utils.py
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/logger.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/logger.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Primary Logging Configuration Function

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/paginator.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/paginator.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/parameter_store.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/parameter_store.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """Parameter Store module used throughout the ADF

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
@@ -1,5 +1,6 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
+
 """Partition.
 
 A partition is a group of AWS Regions. This module provides a helper function

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/pytest.ini
@@ -1,2 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/repo.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/repo.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/rule.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/rule.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/s3.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/stepfunctions.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/stepfunctions.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/sts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/sts.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """STS module used throughout the ADF

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_cloudformation.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_codepipeline.py
@@ -1,6 +1,5 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
-
 
 """
 Stubs for testing codepipeline.py

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_deployment_map.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_deployment_map.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 pipelines:
   - name: sample-iam  # The name of your pipeline (by default, this will match the name of your repository)
     default_providers:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_event.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_event.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_kms.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_kms.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_organizations.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_parameter_store.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_parameter_store.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_s3.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_step_functions.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_step_functions.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_target.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cache.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cloudformation.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_codepipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_codepipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_deployment_map.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_list_utils.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_list_utils.py
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_organizations.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_parameter_store.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_parameter_store.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_partition.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """Tests for partition.py
 
 Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_pipeline.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_s3.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_s3.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_schema_validation.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 Tests for schema validation
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_step_functions.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_step_functions.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_target.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/thread.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/thread.py
@@ -1,6 +1,5 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
-
 
 # pylint: skip-file
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_param_store.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_param_store.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_stack_output.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_stack_output.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_upload.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_upload.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/templates/codecommit.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/templates/codecommit.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 Parameters:
   RepoName:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/templates/events.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/templates/events.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 Parameters:
   DeploymentAccountId:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/parameter_environment_acceptance_tag_project_a.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/parameter_environment_acceptance_tag_project_a.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 Parameters:
   Environment: acceptance
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/stub_cfn_global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/stubs/stub_cfn_global.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 Parameters:
   Environment: "testing"
   MySpecialValue: "resolve:/values/some_value"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/tests/test_generate_params.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/store_config.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/store_config.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/stubs/stub_adfconfig.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/stubs/stub_adfconfig.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 roles:
   cross-account-access: some_role
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_config.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_config.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_main.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/example-adfconfig.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/example-adfconfig.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 roles:
   cross-account-access: OrganizationAccountAccessRole
   # ^ The role by ADF to assume cross account access

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/pytest.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 env =
     ACCOUNT_ID="123456789012"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/tox.ini
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/tox.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 # tox (https://tox.readthedocs.io/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"

--- a/src/lambda_codebase/initial_commit/handler.py
+++ b/src/lambda_codebase/initial_commit/handler.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 The Initial Commit Handler that is called when ADF is installed to commit the
 initial bootstrap repository content.

--- a/src/lambda_codebase/initial_commit/initial_commit.py
+++ b/src/lambda_codebase/initial_commit/initial_commit.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 """
 The Initial Commit main that is called when ADF is installed to commit the
 initial bootstrap repository content.

--- a/src/lambda_codebase/initial_commit/pytest.ini
+++ b/src/lambda_codebase/initial_commit/pytest.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 testpaths = tests
 norecursedirs = bootstrap_repository

--- a/src/lambda_codebase/initial_commit/tests/__init__.py
+++ b/src/lambda_codebase/initial_commit/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/initial_commit/tests/test_initial_commit.py
+++ b/src/lambda_codebase/initial_commit/tests/test_initial_commit.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 # pylint: skip-file

--- a/src/lambda_codebase/moved_to_root.py
+++ b/src/lambda_codebase/moved_to_root.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/organization/handler.py
+++ b/src/lambda_codebase/organization/handler.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/organization/main.py
+++ b/src/lambda_codebase/organization/main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/organization_unit/handler.py
+++ b/src/lambda_codebase/organization_unit/handler.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/organization_unit/main.py
+++ b/src/lambda_codebase/organization_unit/main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/lambda_codebase/wait_until_complete.py
+++ b/src/lambda_codebase/wait_until_complete.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: MIT-0
 
 """

--- a/src/template.yml
+++ b/src/template.yml
@@ -1,5 +1,5 @@
-# // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# // SPDX-License-Identifier: Apache-2.0
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
 # tox (https://tox.readthedocs.io/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"


### PR DESCRIPTION
## Why?

The year is no longer required in our Copyright statements. Additionally, some files were missing a Copyright / license statement, while it is a best practice to add one.

## What?

* Add/update copyright statement,
* Add Apache-2.0 license, except for Lambda Functions, these should have MIT-0 instead. Since most of our code is in the initial-commit Lambda Function, these files are under the MIT-0 license. With the exception of CloudFormation templates.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
