### PR TITLE
Fix sample expunge VPC, if-len, and process deployment maps

### DIFF
--- a/samples/sample-expunge-vpc/src/lambda_vpc/requirements.txt
+++ b/samples/sample-expunge-vpc/src/lambda_vpc/requirements.txt
@@ -1,0 +1,1 @@
+crhelper

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/iam_cfn_deploy_role_policy.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/iam_cfn_deploy_role_policy.py
@@ -72,7 +72,7 @@ class IAMCfnDeployRolePolicy:
             'calling grant_s3_buckets_access for bucket_names %s',
             bucket_names,
         )
-        if len(bucket_names) == 0:
+        if not bucket_names:
             return
 
         statement = self._get_statement('S3')
@@ -112,7 +112,7 @@ class IAMCfnDeployRolePolicy:
             'calling grant_usage_on_kms_keys for key arns %s',
             kms_key_arns,
         )
-        if len(kms_key_arns) == 0:
+        if not kms_key_arns:
             return
 
         statement = self._get_statement('KMS')

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/lambda_codebase/pipeline_management/identify_out_of_date_pipelines.py
@@ -148,7 +148,7 @@ def lambda_handler(event, _):
     )
 
     output = {}
-    if len(out_of_date_pipelines) > 0:
+    if out_of_date_pipelines:
         output["pipelines_to_be_deleted"] = out_of_date_pipelines
 
     data_md5 = hashlib.md5(

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cloudformation.py
@@ -569,7 +569,7 @@ class CloudFormation(StackProperties):
             )
             if not matches_search:
                 continue
-            if len(stack.get('ParentId', '')) > 0:
+            if stack.get('ParentId', ''):
                 # Skip nested stacks
                 continue
 
@@ -635,7 +635,7 @@ class CloudFormation(StackProperties):
             response = self.client.describe_stacks(
                 StackName=name,
             )
-            if response and len(response.get('Stacks', [])) > 0:
+            if response and response.get('Stacks', []):
                 return response['Stacks'][0]['StackStatus']
             return None
         except (ClientError, ValidationError) as error:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/list_utils.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/list_utils.py
@@ -10,7 +10,7 @@ def _flatten_list(input_list):
     result = []
     for item in input_list:
         if isinstance(item, list):
-            if len(item) > 0:
+            if item:
                 result.extend(
                     _flatten_list(item),
                 )

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -200,7 +200,7 @@ class Organizations:  # pylint: disable=R0904
     def list_policies(self, name, policy_type="SERVICE_CONTROL_POLICY"):
         response = list(paginator(self.client.list_policies, Filter=policy_type))
         filtered_policies = [policy for policy in response if policy["Name"] == name]
-        if len(filtered_policies) > 0:
+        if filtered_policies:
             return filtered_policies[0]["Id"]
         return []
 
@@ -217,7 +217,7 @@ class Organizations:  # pylint: disable=R0904
             for policy in response["Policies"]
             if f"ADF Managed {policy_type}" in policy["Description"]
         ]
-        if len(adf_managed_policies) > 0:
+        if adf_managed_policies:
             return adf_managed_policies[0]["Id"]
         return []
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver.py
@@ -33,7 +33,7 @@ class Resolver:
             lambda resolver: resolver.supports(lookup_str),
             self.resolvers,
         ))
-        return None if len(matches) == 0 else matches[0]
+        return None if not matches else matches[0]
 
     def apply_intrinsic_function_if_any(
         self,


### PR DESCRIPTION
## Why?

Amazon CodeGuru suggested improvements to:

* Use paginators in the sample-expunge-vpc code, after reviewing, this sample required some more attention.
* Change `if len(...) > or ==` statements to match against the value. A list with elements is True, an empty list is False. Improving readability.
* Move boto3 client and resource creation to the initialization phase of the process deployment map Lambda function, to speed up its execution in consecutive runs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
