### PR TITLE
fix: remove dangerous default ADF_ORG_STAGE

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/generate_params.py
@@ -118,7 +118,7 @@ LOGGER = configure_logger(__name__)
 DEPLOYMENT_ACCOUNT_REGION = os.environ["AWS_REGION"]
 PROJECT_NAME = os.environ["ADF_PROJECT_NAME"]
 EMPTY_PARAMS_DICT: ParametersAndTags = {'Parameters': {}, 'Tags': {}}
-ADF_ORG_STAGE = os.getenv("ADF_ORG_STAGE", "dev")
+ADF_ORG_STAGE = os.getenv("ADF_ORG_STAGE")
 
 
 class Parameters:
@@ -302,13 +302,14 @@ class Parameters:
                     current_params
                 )
                 # Compare account_region final to global_stage
-                current_params = self._merge_params(
-                    Parameters._parse(
-                        params_root_path=self.cwd,
-                        params_filename=f"global_{ADF_ORG_STAGE}",
-                    ),
-                    current_params,
-                )
+                if ADF_ORG_STAGE:
+                    current_params = self._merge_params(
+                        Parameters._parse(
+                            params_root_path=self.cwd,
+                            params_filename=f"global_{ADF_ORG_STAGE}",
+                        ),
+                        current_params,
+                    )
                 # Compare account_region final to global
                 current_params = self._merge_params(
                     Parameters._parse(


### PR DESCRIPTION
# Why?

When using ADF in a multi-org setup the generate_params.py helper file will read local Org Stage specific config files. 
If however the environment variable ADF_ORG_STAGE is not set in the Codebuild environment, the generate_params.py should not default to 'Dev' org. 

This can result in loading the incorrect Local Params file when deploying into a non 'Dev' Stage.

*Issue #, if available:*

## What?
Remove Default value in helper file.

Description of changes:

- Just updated the generate_params.py
---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
