### PR TITLE
Feat: Improve samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ samconfig.toml
 samconfig.yml
 samconfig.yaml
 pipeline.json
-template-sam.yml
 deploy.sh
 Makefile.new
 
@@ -52,6 +51,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+node_modules
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,33 +69,33 @@ The parameters that are managed by ADF that got their path changed are:
 For the __management account__, in the __AWS Organizations region__
 (`us-east-1`, or `us-gov-west-1`):
 
-| Old Parameter Path           | New Parameter Path                  |
-|------------------------------|-------------------------------------|
-| `/adf_log_level`             | `/adf/adf_log_level`                |
-| `/adf_version`               | `/adf/adf_version`                  |
-| `/bucket_name`               | `/adf/bucket_name`                  |
-| `/confit`                    | `/adf/config`                       |
-| `/cross_account_access_role` | `/adf/cross_account_access_role`    |
-| `/deployment_account_id`     | `/adf/deployment_account_id`        |
-| `/deployment_account_region` | `/adf/deployment_account_region`    |
-| `/kms_arn`                   | `/adf/kms_arn`                      |
-| `/notification_channel`      | `/adf/notification_channel`         |
-| `/organization_id`           | `/adf/organization_id`              |
-| `/protected`                 | `/adf/protected`                    |
-| `/scp`                       | `/adf/scp`                          |
-| `/shared_modules_bucket`     | `/adf/shared_modules_bucket`        |
-| `/tagging-policy`            | `/adf/tagging_policy`               |
-| `/target_regions`            | `/adf/target_regions`               |
+| Old Parameter Path           | New Parameter Path               |
+|------------------------------|----------------------------------|
+| `/adf_log_level`             | `/adf/adf_log_level`             |
+| `/adf_version`               | `/adf/adf_version`               |
+| `/bucket_name`               | `/adf/bucket_name`               |
+| `/confit`                    | `/adf/config`                    |
+| `/cross_account_access_role` | `/adf/cross_account_access_role` |
+| `/deployment_account_id`     | `/adf/deployment_account_id`     |
+| `/deployment_account_region` | `/adf/deployment_account_region` |
+| `/kms_arn`                   | `/adf/kms_arn`                   |
+| `/notification_channel`      | `/adf/notification_channel`      |
+| `/organization_id`           | `/adf/organization_id`           |
+| `/protected`                 | `/adf/protected`                 |
+| `/scp`                       | `/adf/scp`                       |
+| `/shared_modules_bucket`     | `/adf/shared_modules_bucket`     |
+| `/tagging-policy`            | `/adf/tagging_policy`            |
+| `/target_regions`            | `/adf/target_regions`            |
 
 For the __management account__, in __other ADF regions__:
 
-| Old Parameter Path           | New Parameter Path                  |
-|------------------------------|-------------------------------------|
-| `/adf_version`               | `/adf/adf_version`                  |
-| `/bucket_name`               | `/adf/bucket_name`                  |
-| `/cross_account_access_role` | `/adf/cross_account_access_role`    |
-| `/deployment_account_id`     | `/adf/deployment_account_id`        |
-| `/kms_arn`                   | `/adf/kms_arn`                      |
+| Old Parameter Path           | New Parameter Path               |
+|------------------------------|----------------------------------|
+| `/adf_version`               | `/adf/adf_version`               |
+| `/bucket_name`               | `/adf/bucket_name`               |
+| `/cross_account_access_role` | `/adf/cross_account_access_role` |
+| `/deployment_account_id`     | `/adf/deployment_account_id`     |
+| `/kms_arn`                   | `/adf/kms_arn`                   |
 
 For the __deployment account__, in __the deployment region__:
 
@@ -114,24 +114,24 @@ For the __deployment account__, in __the deployment region__:
 
 For the __deployment account__, in __other ADF regions__:
 
-| Old Parameter Path           | New Parameter Path                  |
-|------------------------------|-------------------------------------|
-| `/adf_log_level`             | `/adf/adf_log_level`                |
-| `/adf_version`               | `/adf/adf_version`                  |
-| `/cross_account_access_role` | `/adf/cross_account_access_role`    |
-| `/deployment_account_bucket` | `/adf/deployment_account_bucket`    |
-| `/master_account_id`         | `/adf/management_account_id`        |
-| `/notification_endpoint`     | `/adf/notification_endpoint`        |
-| `/notification_type`         | `/adf/notification_type`            |
-| `/organization_id`           | `/adf/organization_id`              |
+| Old Parameter Path           | New Parameter Path               |
+|------------------------------|----------------------------------|
+| `/adf_log_level`             | `/adf/adf_log_level`             |
+| `/adf_version`               | `/adf/adf_version`               |
+| `/cross_account_access_role` | `/adf/cross_account_access_role` |
+| `/deployment_account_bucket` | `/adf/deployment_account_bucket` |
+| `/master_account_id`         | `/adf/management_account_id`     |
+| `/notification_endpoint`     | `/adf/notification_endpoint`     |
+| `/notification_type`         | `/adf/notification_type`         |
+| `/organization_id`           | `/adf/organization_id`           |
 
 For a __target account__, in __each ADF region__:
 
-| Old Parameter Path           | New Parameter Path                  |
-|------------------------------|-------------------------------------|
-| `/bucket_name`               | `/adf/bucket_name`                  |
-| `/deployment_account_id`     | `/adf/deployment_account_id`        |
-| `/kms_arn`                   | `/adf/kms_arn`                      |
+| Old Parameter Path       | New Parameter Path           |
+|--------------------------|------------------------------|
+| `/bucket_name`           | `/adf/bucket_name`           |
+| `/deployment_account_id` | `/adf/deployment_account_id` |
+| `/kms_arn`               | `/adf/kms_arn`               |
 
 #### AWS CodeStar Connections OAuth Token support dropped
 

--- a/docs/samples-guide.md
+++ b/docs/samples-guide.md
@@ -307,8 +307,8 @@ URL on the *ECS Cluster* AWS CloudFormation stack within the target accounts.
 
 ![cfn-output](./images/cfn-output.png)
 
-Accessing the *ExternalUrl* output in your web browser, you should be greeted
-with the application running inside AWS Fargate.
+Accessing the *LoadBalancerExternalUrl* output in your web browser, you should
+be greeted with the application running inside AWS Fargate.
 
 For more samples, please see the other pipeline/resource definitions in the
 `samples` folder, or check out the numerous CloudFormation resource available

--- a/samples/sample-cdk-bootstrap/README.md
+++ b/samples/sample-cdk-bootstrap/README.md
@@ -1,13 +1,13 @@
-# Sample CDK Application to showcase ADF Pipelines
+# Sample CDK Bootstrap pipeline
 
 This pipeline is expecting *(in the example case)* an AWS CodeCommit repository
 on the account `111111111111` in your main deployment region named
-*sample-cdk-application*.
+*sample-cdk-bootstrap*.
 
 ## Deployment Map example
 
 ```yaml
-  - name: sample-cdk-application
+  - name: sample-cdk-bootstrap
     default_providers:
       source:
         provider: codecommit

--- a/samples/sample-cdk-bootstrap/buildspec.yml
+++ b/samples/sample-cdk-bootstrap/buildspec.yml
@@ -16,12 +16,7 @@ phases:
   build:
     commands:
       - npm install aws-cdk -g
-      - npm install
-      - npm run build
-      - cdk synth > template.yml
+      - cdk bootstrap --show-template > template.yml
 
 artifacts:
-  files:
-    - 'template.yml'
-    - 'params/*.json'
-    - 'params/*.yml'
+  files: '**/*'

--- a/samples/sample-cdk-bootstrap/params/global.yml
+++ b/samples/sample-cdk-bootstrap/params/global.yml
@@ -1,0 +1,62 @@
+# Copyright Amazon.com Inc. or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Parameters of the CDK Bootstrap stack:
+#  TrustedAccounts:
+#     Description: List of AWS accounts that are trusted to publish assets and deploy stacks to this environment
+#     Default: ""
+#     Type: CommaDelimitedList
+#   TrustedAccountsForLookup:
+#     Description: List of AWS accounts that are trusted to look up values in this environment
+#     Default: ""
+#     Type: CommaDelimitedList
+#   CloudFormationExecutionPolicies:
+#     Description: List of the ManagedPolicy ARN(s) to attach to the CloudFormation deployment role
+#     Default: ""
+#     Type: CommaDelimitedList
+#   FileAssetsBucketName:
+#     Description: The name of the S3 bucket used for file assets
+#     Default: ""
+#     Type: String
+#   FileAssetsBucketKmsKeyId:
+#     Description: Empty to create a new key (default), 'AWS_MANAGED_KEY' to use a managed S3 key, or the ID/ARN of an existing key.
+#     Default: ""
+#     Type: String
+#   ContainerAssetsRepositoryName:
+#     Description: A user-provided custom name to use for the container assets ECR repository
+#     Default: ""
+#     Type: String
+#   Qualifier:
+#     Description: An identifier to distinguish multiple bootstrap stacks in the same environment
+#     Default: hnb659fds
+#     Type: String
+#     AllowedPattern: "[A-Za-z0-9_-]{1,10}"
+#     ConstraintDescription: Qualifier must be an alphanumeric identifier of at most 10 characters
+#   PublicAccessBlockConfiguration:
+#     Description: Whether or not to enable S3 Staging Bucket Public Access Block Configuration
+#     Default: "true"
+#     Type: String
+#     AllowedValues:
+#       - "true"
+#       - "false"
+#   InputPermissionsBoundary:
+#     Description: Whether or not to use either the CDK supplied or custom permissions boundary
+#     Default: ""
+#     Type: String
+#   UseExamplePermissionsBoundary:
+#     Default: "false"
+#     AllowedValues:
+#       - "true"
+#       - "false"
+#     Type: String
+#   BootstrapVariant:
+#     Type: String
+#     Default: "AWS CDK: Default Resources"
+
+Parameters:
+  TrustedAccounts: 'resolve:/adf/deployment_account_id'
+  TrustedAccountsForLookup: 'resolve:/adf/deployment_account_id'
+
+Tags:
+  Repository: sample-codebuild-vpc-repo
+  App: Sample CodeBuild VPC application

--- a/samples/sample-ec2-java-app-codedeploy/pom.xml
+++ b/samples/sample-ec2-java-app-codedeploy/pom.xml
@@ -1,10 +1,10 @@
-<!-- Copyright Amazon.com Inc. or its affiliates. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <!-- Copyright Amazon.com Inc. or its affiliates. -->
+    <!-- SPDX-License-Identifier: Apache-2.0 -->
 
     <groupId>org.springframework</groupId>
     <artifactId>gs-spring-boot</artifactId>

--- a/samples/sample-ec2-with-codedeploy/README.md
+++ b/samples/sample-ec2-with-codedeploy/README.md
@@ -5,10 +5,6 @@ is aimed at showcasing how to deploy a basic Spring Boot application with
 [AWS CodeDeploy](https://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html)
 via ADF.
 
-This stack assumes an Amazon EC2
-[Key Pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
-has been created in the target accounts.
-
 This stack is a generic stack for applications that run on Amazon EC2.
 This stack could be extended and used as a base for all line of business type
 applications that run Amazon EC2.
@@ -16,9 +12,11 @@ applications that run Amazon EC2.
 This stack also requires `sample-vpc` and `sample-iam` to be in deployed as it
 imports resources directly from both of them.
 
-## Deployment Map example
+## Prerequisites
 
-### This sample stack depends on resources in sample-iam and sample-vpc
+This sample stack depends on resources in `sample-iam` and `sample-vpc`.
+
+## Deployment Map example
 
 ```yaml
   - name: sample-ec2-app-codedeploy

--- a/samples/sample-ec2-with-codedeploy/buildspec.yml
+++ b/samples/sample-ec2-with-codedeploy/buildspec.yml
@@ -13,4 +13,7 @@ phases:
       - python adf-build/generate_params.py
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-ec2-with-codedeploy/params/global.yml
+++ b/samples/sample-ec2-with-codedeploy/params/global.yml
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Parameters:
-  Environment: testing
-  ApplicationName: sample
-  InstanceMaxSize: '3'
-  InstanceMinSize: '1'
-  ImageId: 'resolve:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
-  InstanceType: t3.micro
-  CodeDeployAgentInstallScript: 'upload:path:scripts/install-codedeploy.sh'
-  JavaInstallScript: 'upload:path:scripts/install-deps.sh'
-  KeyPair: some_key_pair
+  Environment: "testing"
+  ApplicationName: "sample"
+  InstanceMaxSize: "3"
+  InstanceMinSize: "1"
+  ImageId: "resolve:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+  InstanceType: "t3.micro"
+  CodeDeployAgentInstallScript: "upload:path:scripts/install-codedeploy.sh"
+  JavaInstallScript: "upload:path:scripts/install-deps.sh"

--- a/samples/sample-ec2-with-codedeploy/scripts/install-deps.sh
+++ b/samples/sample-ec2-with-codedeploy/scripts/install-deps.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
+
+set -xe
 
 # install apache httpd
 sudo yum install httpd -y
@@ -10,15 +12,12 @@ sudo yum install httpd -y
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 
-# install java 8
-sudo yum install java-1.8.0 -y
-# remove java 1.7
-sudo yum remove java-1.7.0-openjdk -y
+# install Java
+sudo yum install -y java-17-amazon-corretto-headless
 
-# install maven
-sudo wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo
-sudo sed -i s/\$releasever/7/g /etc/yum.repos.d/epel-apache-maven.repo
-sudo yum install -y apache-maven
+# install Maven
+yum -y update
+sudo yum install -y maven
 
 # sdk version
 java -version
@@ -30,7 +29,7 @@ sdk install springboot
 # create a springboot user to run the app as a service
 sudo useradd springboot
 # springboot login shell disabled
-sudo chsh -s /sbin/nologin springboot
+sudo usermod --shell /sbin/nologin springboot
 
 # forward port 80 to 8080
 echo "
@@ -42,8 +41,8 @@ echo "
 " | sudo tee -a /etc/httpd/conf/httpd.conf > /dev/null
 
 # start the httpd service now and stop it until userdata
-sudo service httpd start
-sudo service httpd stop
+sudo systemctl start httpd
+sudo systemctl stop httpd
 
 # ensure httpd stays on
-sudo chkconfig httpd on
+sudo systemctl enable httpd

--- a/samples/sample-ec2-with-codedeploy/template.yml
+++ b/samples/sample-ec2-with-codedeploy/template.yml
@@ -52,10 +52,6 @@ Parameters:
     ConstraintDescription: "Must be one of the values from the list."
     Description: "Instance type for the EC2 instances."
 
-  KeyPair:
-    Description: "Amazon EC2 Key Pair"
-    Type: "AWS::EC2::KeyPair::KeyName"
-
 Resources:
   AutoScalingGroup:
     Type: "AWS::AutoScaling::AutoScalingGroup"
@@ -71,7 +67,9 @@ Resources:
       AvailabilityZones: !GetAZs ""
       MinSize: !Ref "InstanceMinSize"
       MaxSize: !Ref "InstanceMaxSize"
-      LaunchConfigurationName: !Ref "LaunchConfiguration"
+      LaunchTemplate:
+        LaunchTemplateId: !GetAtt LaunchTemplate.LaunchTemplateId
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
       MetricsCollection:
         - Granularity: "1Minute"
       TerminationPolicies:
@@ -99,7 +97,7 @@ Resources:
           - DEPLOYMENT_FAILURE
       DeploymentGroupName: !Sub "${Environment}-${ApplicationName}"
       DeploymentConfigName: "CodeDeployDefault.OneAtATime"
-      ServiceRoleArn: !ImportValue CodeDeployRoleArn
+      ServiceRoleArn: !ImportValue "CodeDeployServiceRoleArn"
       DeploymentStyle:
         DeploymentOption: WITH_TRAFFIC_CONTROL
       LoadBalancerInfo:
@@ -108,32 +106,40 @@ Resources:
       AutoScalingGroups:
         - !Ref "AutoScalingGroup"
 
-  LaunchConfiguration:
-    Type: "AWS::AutoScaling::LaunchConfiguration"
+  LaunchTemplate:
+    Type: "AWS::EC2::LaunchTemplate"
     Properties:
-      AssociatePublicIpAddress: false
-      IamInstanceProfile: !ImportValue GlobalInstanceProfileName
-      ImageId: !Ref "ImageId"
-      InstanceType: !Ref "InstanceType"
-      KeyName: !Ref "KeyPair"
-      SecurityGroups:
-        - !Ref "PrivateSecurityGroup"
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          BUCKET_NAME=$(echo ${CodeDeployAgentInstallScript} | sed 's/^.*adf-global-base/adf-global-base/' |sed 's/\/.*//')
-          KEY=$(echo ${CodeDeployAgentInstallScript} | sed 's/^.*adf-upload/adf-upload/')
-          aws s3api get-object --bucket $BUCKET_NAME --key $KEY /tmp/code_deploy_install.sh
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !ImportValue IamInstanceProfile
+        ImageId: !Ref "ImageId"
+        InstanceType: !Ref "InstanceType"
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpPutResponseHopLimit: 2
+          HttpTokens: required
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: false
+            DeviceIndex: 0
+            Groups:
+              - !Ref "PrivateSecurityGroup"
+        UserData:
+          "Fn::Base64": !Sub |
+            #!/bin/bash
+            BUCKET_NAME=$(echo "${CodeDeployAgentInstallScript}" | sed 's/^.*adf-global-base/adf-global-base/' | sed 's/\/.*//')
+            KEY=$(echo "${CodeDeployAgentInstallScript}" | sed 's/^.*adf-upload/adf-upload/')
+            aws s3api get-object --bucket "${!BUCKET_NAME}" --key "${!KEY}" /tmp/code_deploy_install.sh
 
-          BUCKET_NAME=$(echo ${JavaInstallScript} | sed 's/^.*adf-global-base/adf-global-base/' |sed 's/\/.*//')
-          KEY=$(echo ${JavaInstallScript} | sed 's/^.*adf-upload/adf-upload/')
-          aws s3api get-object --bucket $BUCKET_NAME --key $KEY /tmp/java_install.sh
+            BUCKET_NAME=$(echo "${JavaInstallScript}" | sed 's/^.*adf-global-base/adf-global-base/' |sed 's/\/.*//')
+            KEY=$(echo "${JavaInstallScript}" | sed 's/^.*adf-upload/adf-upload/')
+            aws s3api get-object --bucket "${!BUCKET_NAME}" --key "${!KEY}" /tmp/java_install.sh
 
-          chmod +x /tmp/java_install.sh
-          chmod +x /tmp/code_deploy_install.sh
-          /tmp/code_deploy_install.sh
-          /tmp/java_install.sh
-          /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource AutoScalingGroup --region ${AWS::Region}
+            chmod +x /tmp/java_install.sh
+            chmod +x /tmp/code_deploy_install.sh
+            /tmp/code_deploy_install.sh
+            /tmp/java_install.sh
+            /opt/aws/bin/cfn-signal -e 0 --stack "${AWS::StackName}" --resource AutoScalingGroup --region "${AWS::Region}"
 
   PrivateSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/samples/sample-ecr-repository/buildspec.yml
+++ b/samples/sample-ecr-repository/buildspec.yml
@@ -13,4 +13,7 @@ phases:
       - python adf-build/generate_params.py
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-ecr-repository/params/global.yml
+++ b/samples/sample-ecr-repository/params/global.yml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Parameters:
-  TestingAccountId: '11111111111'
-  ProductionAccountId: '999999999999'
+  TestingAccountId: "11111111111"
+  ProductionAccountId: "999999999999"
+
 Tags:
-  TagKey: TagValue
-  MyKey: MyValue
+  TagKey: "TagValue"
+  MyKey: "MyValue"

--- a/samples/sample-ecs-cluster/README.md
+++ b/samples/sample-ecs-cluster/README.md
@@ -1,5 +1,10 @@
 # Sample ECS Cluster to showcase ADF Pipelines
 
+## Prerequisites
+
+Please make sure you deploy the `sample-vpc` example before you deploy
+this sample. The VPC should be deployed to the same target accounts and region.
+
 ## Deployment Map example
 
 ```yaml

--- a/samples/sample-ecs-cluster/buildspec.yml
+++ b/samples/sample-ecs-cluster/buildspec.yml
@@ -13,4 +13,7 @@ phases:
       - python adf-build/generate_params.py
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-ecs-cluster/params/banking-production.yml
+++ b/samples/sample-ecs-cluster/params/banking-production.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Parameters:
-  Environment: production
+  Environment: "production"

--- a/samples/sample-ecs-cluster/template.yml
+++ b/samples/sample-ecs-cluster/template.yml
@@ -103,8 +103,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: [ecs.amazonaws.com]
-            Action: ['sts:AssumeRole']
+              Service:
+                - ecs.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
       Path: /
       Policies:
         - PolicyName: ecs-service
@@ -139,8 +141,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: [ecs-tasks.amazonaws.com]
-            Action: ['sts:AssumeRole']
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
       Path: /
       Policies:
         - PolicyName: AmazonECSTaskExecutionRolePolicy
@@ -166,11 +170,11 @@ Outputs:
     Export:
       Name: 'ClusterName'
 
-  ExternalUrl:
+  ECSLoadBalancerExternalUrl:
     Description: The url of the external load balancer
     Value: !Sub http://${PublicLoadBalancer.DNSName}
     Export:
-      Name: 'ExternalUrl'
+      Name: 'ECSLoadBalancerExternalUrl'
 
   ECSRole:
     Description: The ARN of the ECS role

--- a/samples/sample-expunge-vpc/README.md
+++ b/samples/sample-expunge-vpc/README.md
@@ -23,7 +23,7 @@ Upon stack deletion the default VPCs will be recreated.
           # ^ Required for templates that contain transforms (eg SAM Templates)
 
   params:
-    - restart_execution_on_update: true
+    restart_execution_on_update: true
   targets:
     - path: /test
       name: test-deployments

--- a/samples/sample-fargate-node-app/Dockerfile
+++ b/samples/sample-fargate-node-app/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:current-alpine
+FROM public.ecr.aws/docker/library/node:current-alpine
 WORKDIR /app
 COPY . .
 RUN npm install

--- a/samples/sample-fargate-node-app/README.md
+++ b/samples/sample-fargate-node-app/README.md
@@ -1,9 +1,20 @@
 # Sample NodeJS Web Application running on AWS Fargate
 
+## Prerequisites
+
+Please make sure you deploy the `sample-ecr-repository` and
+`sample-ecs-cluster` examples before you deploy this sample.
+The ECS cluster should be deployed to the same target accounts and region.
+
+If you want to change the region to another region, please make sure to rename
+the `params/global_eu-west-1.json` file to use the new region name.
+For example: `params/global_us-east-1.json`.
+Also update the regions list in the deployment map for this example.
+
 ## Deployment Map example
 
 ```yaml
-  - name: sample-node-app
+  - name: sample-fargate-node-app
     default_providers:
       source:
         provider: codecommit
@@ -17,6 +28,8 @@
           # ^ Required for Docker in Docker to work as expected (since
           #   CodeBuild will run our docker commands to create and push our
           #   image).
+    regions:
+      - eu-west-1
     targets:
       # Example Targets: These accounts/regions have had the sample-vpc deployed
       - 222222222222

--- a/samples/sample-fargate-node-app/buildspec.yml
+++ b/samples/sample-fargate-node-app/buildspec.yml
@@ -17,4 +17,7 @@ phases:
       - bash build/generate_parameters.sh
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-fargate-node-app/index.js
+++ b/samples/sample-fargate-node-app/index.js
@@ -16,7 +16,9 @@ app.get('/', (req, res) => {
 })
 
 app.get('/version', (req, res) => {
-  res.json({ version: '0.0.1' })
+  res.json({
+    version: '0.0.1'
+  })
 })
 
 app.listen(3000, () => {

--- a/samples/sample-fargate-node-app/package-lock.json
+++ b/samples/sample-fargate-node-app/package-lock.json
@@ -1,46 +1,64 @@
 {
   "name": "sample-node-app",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "accepts": {
+  "packages": {
+    "": {
+      "name": "sample-node-app",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.10",
+        "express": "^4.19.2"
+      }
+    },
+    "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "requires": {
+      "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
+      "dependencies": {
         "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "array-flatten": {
+    "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
-    "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "body-parser": {
+    "node_modules/body-parser": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
       "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-      "requires": {
+      "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
@@ -53,157 +71,220 @@
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "requires": {
-        "balanced-match": "^1.0.0"
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
-    "bytes": {
+    "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
-    "call-bind": {
+    "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "requires": {
+      "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "chalk": {
+    "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
+      "dependencies": {
         "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "content-disposition": {
+    "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "requires": {
+      "dependencies": {
         "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "content-type": {
+    "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "cookie": {
+    "node_modules/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "cookie-signature": {
+    "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
-    "debug": {
+    "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
+      "dependencies": {
         "ms": "2.0.0"
       }
     },
-    "define-data-property": {
+    "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "requires": {
+      "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "depd": {
+    "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
-    "destroy": {
+    "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
-    "ee-first": {
+    "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
-    "ejs": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
-      "integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
-      "requires": {
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dependencies": {
         "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "encodeurl": {
+    "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
-    "es-define-property": {
+    "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "requires": {
+      "dependencies": {
         "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "es-errors": {
+    "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "escape-html": {
+    "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
-    "etag": {
+    "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "express": {
+    "node_modules/express": {
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
       "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
-      "requires": {
+      "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.2",
@@ -235,31 +316,43 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "filelist": {
+    "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
       "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "requires": {
-        "minimatch": "^5.0.1"
-      },
       "dependencies": {
-        "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
+        "minimatch": "^5.0.1"
       }
     },
-    "finalhandler": {
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
       "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
-      "requires": {
+      "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -267,248 +360,356 @@
         "parseurl": "~1.3.3",
         "statuses": "2.0.1",
         "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "forwarded": {
+    "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "fresh": {
+    "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "function-bind": {
+    "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "get-intrinsic": {
+    "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "requires": {
+      "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "gopd": {
+    "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "requires": {
+      "dependencies": {
         "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "has-flag": {
+    "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "has-property-descriptors": {
+    "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "requires": {
+      "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "has-proto": {
+    "node_modules/has-proto": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "has-symbols": {
+    "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "hasown": {
+    "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "requires": {
+      "dependencies": {
         "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "http-errors": {
+    "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "requires": {
+      "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "iconv-lite": {
+    "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
+      "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ipaddr.js": {
+    "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-    },
-    "jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
-      "requires": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "media-typer": {
+    "node_modules/jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "merge-descriptors": {
+    "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
-    "methods": {
+    "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime": {
+    "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "mime-db": {
+    "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
+      "dependencies": {
         "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
       },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        }
+      "engines": {
+        "node": "*"
       }
     },
-    "ms": {
+    "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "negotiator": {
+    "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "object-inspect": {
+    "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "on-finished": {
+    "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "requires": {
+      "dependencies": {
         "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "parseurl": {
+    "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
-    "path-to-regexp": {
+    "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "proxy-addr": {
+    "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "requires": {
+      "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "qs": {
+    "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "requires": {
+      "dependencies": {
         "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "range-parser": {
+    "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "raw-body": {
+    "node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "requires": {
+      "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "safer-buffer": {
+    "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "send": {
+    "node_modules/send": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
       "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "requires": {
+      "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -523,95 +724,129 @@
         "range-parser": "~1.2.1",
         "statuses": "2.0.1"
       },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "serve-static": {
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-      "requires": {
+      "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
         "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "set-function-length": {
+    "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "requires": {
+      "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "setprototypeof": {
+    "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "side-channel": {
+    "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "requires": {
+      "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.4",
         "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "statuses": {
+    "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "requires": {
+      "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "toidentifier": {
+    "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
-    "type-is": {
+    "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "requires": {
+      "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "unpipe": {
+    "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
-    "utils-merge": {
+    "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
-    "vary": {
+    "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     }
   }
 }

--- a/samples/sample-fargate-node-app/package.json
+++ b/samples/sample-fargate-node-app/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "ejs": "^3.1.7",
-    "express": "^4.16.3"
+    "ejs": "^3.1.10",
+    "express": "^4.19.2"
   }
 }

--- a/samples/sample-fargate-node-app/params/global.yml
+++ b/samples/sample-fargate-node-app/params/global.yml
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Parameters:
-  Environment: testing
-  ServiceName: sample-node-app
-  ContainerPort: '3000'
-  Priority: '1'
+  Environment: "testing"
+  ServiceName: "sample-node-app"
+  ContainerPort: "3000"
+  Priority: "1"
+
 Tags:
-  TagKey: TagValue
-  MyKey: MyValue
+  TagKey: "TagValue"
+  MyKey: "MyValue"

--- a/samples/sample-fargate-node-app/params/global_eu-west-1.json
+++ b/samples/sample-fargate-node-app/params/global_eu-west-1.json
@@ -1,0 +1,5 @@
+{
+    "Parameters": {
+        "Image": ""
+    }
+}

--- a/samples/sample-iam/README.md
+++ b/samples/sample-iam/README.md
@@ -3,6 +3,15 @@
 This pipeline is expecting *(in the example case)* a AWS CodeCommit repository
 on the account `111111111111` in your main deployment region named *sample-iam*.
 
+This sample is configured to deploy to the `eu-west-1` region.
+If you would like to deploy it to another region, please update the
+parameters in the `params/global.yml` file. Replacing the `eu-west-1` part
+with the region you like to deploy to.
+
+As all resources in this stack are globally accessible, this sample should only
+be deployed to a single region per account. It is recommended to leave it
+configured to the default deployment region of your ADF installation.
+
 ## Deployment Map example
 
 ```yaml

--- a/samples/sample-iam/buildspec.yml
+++ b/samples/sample-iam/buildspec.yml
@@ -13,4 +13,7 @@ phases:
       - python adf-build/generate_params.py
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-iam/params/global.yml
+++ b/samples/sample-iam/params/global.yml
@@ -1,6 +1,10 @@
 # Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
+Parameters:
+  DeploymentAssetS3BucketName: "resolve:/adf/cross_region/s3_regional_bucket/eu-west-1"
+  DeploymentAssetKMSKeyArn: "resolve:/adf/cross_region/kms_arn/eu-west-1"
+
 Tags:
-  TagKey: my_tag
-  MyKey: new_value
+  TagKey: "my_tag"
+  MyKey: "new_value"

--- a/samples/sample-iam/template.yml
+++ b/samples/sample-iam/template.yml
@@ -6,6 +6,15 @@ Description: ADF CloudFormation Sample Template (IAM)
 Metadata:
   License: Apache-2.0
 
+Parameters:
+  DeploymentAssetS3BucketName:
+    Type: "String"
+    Description: "The S3 Bucket name where deployment assets will be located"
+
+  DeploymentAssetKMSKeyArn:
+    Type: "String"
+    Description: "The KMS Key Arn with which deployment assets will encrypted"
+
 Resources:
   DevelopersIAMGroup:
     Type: AWS::IAM::Group
@@ -38,7 +47,7 @@ Resources:
             Action:
               - "sts:AssumeRole"
       ManagedPolicyArns:
-        - !Ref "DefaultInstanceManagedPolicy"
+        - !Ref DefaultInstanceManagedPolicy
       RoleName: "global-instance-role"
 
   DefaultInstanceManagedPolicy:
@@ -61,11 +70,20 @@ Resources:
               - "elasticloadbalancing:DescribeTargetGroups"
               - "elasticloadbalancing:DescribeTargetHealth"
               - "elasticloadbalancing:RegisterTargets"
+            Resource:
+              - "*"
+          - Effect: "Allow"
+            Action:
               - "kms:Decrypt"
+            Resource:
+              - !Ref DeploymentAssetKMSKeyArn
+          - Effect: "Allow"
+            Action:
               - "s3:GetObject"
               - "s3:GetObjectVersion"
             Resource:
-              - "*"
+              - !Sub "arn:${AWS::Partition}:s3:::${DeploymentAssetS3BucketName}/adf-upload/*"
+              - !Sub "arn:${AWS::Partition}:s3:::${DeploymentAssetS3BucketName}/adf-pipeline-*"
 
   CodeDeployServiceRole:
     Type: "AWS::IAM::Role"
@@ -83,6 +101,19 @@ Resources:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSCodeDeployRole"
       RoleName: "codedeploy-service-role"
 
+  ApiGatewayCloudWatchRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+          Action: sts:AssumeRole
+
 Outputs:
   DevelopersIAMGroup:
     Description: The ARN of the Developers IAM Group to be exported.
@@ -90,15 +121,28 @@ Outputs:
       Name: SampleDevelopersIAMGroupArn
     Value: !GetAtt DevelopersIAMGroup.Arn
 
-  CodeDeployRole:
-    Description: The ARN of the CodeDeploy Service Role Arn to be exported.
+  GlobalInstanceProfileArn:
+    Description: The Arn of the EC2 Instance Profile to be exported.
     Export:
-      Name: CodeDeployRoleArn
+      Name: GlobalInstanceProfileArn
+    Value: !GetAtt GlobalInstanceProfile.Arn
+
+  CodeDeployServiceRoleArn:
+    Description: The Arn of the CodeDeploy IAM Role to be exported.
+    Export:
+      Name: CodeDeployServiceRoleArn
     Value: !GetAtt CodeDeployServiceRole.Arn
 
-  GlobalInstanceProfile:
-    Description: >-
-      The ARN of the Default EC2 Instance Role to be imported into application stacks.
-    Value: !Ref GlobalInstanceProfile
+  ApiGatewayCloudWatchRoleArn:
+    Description: The ARN of the API Gateway IAM Role Arn to be exported.
     Export:
-      Name: GlobalInstanceProfileName
+      Name: ApiGatewayCloudWatchRoleArn
+    Value: !GetAtt ApiGatewayCloudWatchRole.Arn
+
+  DefaultInstanceManagedPolicyArn:
+    Description: >-
+      The Arn of the Default EC2 Instance Managed Policy to be
+      imported into application stacks
+    Export:
+      Name: DefaultInstanceManagedPolicyArn
+    Value: !Ref DefaultInstanceManagedPolicy

--- a/samples/sample-serverless-app/buildspec.yml
+++ b/samples/sample-serverless-app/buildspec.yml
@@ -14,4 +14,7 @@ phases:
       - bash adf-build/helpers/package_transform.sh
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template*.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-serverless-app/params/global.yml
+++ b/samples/sample-serverless-app/params/global.yml
@@ -1,5 +1,6 @@
 # Copyright Amazon.com Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
-Parameters:
-  Environment: "testing"
+Tags:
+  TagKey: "my_tag"
+  MyKey: "new_value"

--- a/samples/sample-service-catalog-product/buildspec.yml
+++ b/samples/sample-service-catalog-product/buildspec.yml
@@ -13,4 +13,7 @@ phases:
       - python adf-build/generate_params.py
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-service-catalog-product/params/global.yml
+++ b/samples/sample-service-catalog-product/params/global.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Parameters:
-  ProductXTemplateURL: 'upload:eu-central-1:productX/template.yml'
+  ProductXTemplateURL: "upload:path:productX/template.yml"

--- a/samples/sample-service-catalog-product/productX/template.yml
+++ b/samples/sample-service-catalog-product/productX/template.yml
@@ -9,8 +9,9 @@ Metadata:
 Parameters:
   Environment:
     Type: String
-    Default: testing
+    Default: development
     AllowedValues:
+      - development
       - testing
     Description: The environment to use, IDE are only supported in testing
 

--- a/samples/sample-service-catalog-product/template.yml
+++ b/samples/sample-service-catalog-product/template.yml
@@ -5,6 +5,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: ADF CloudFormation Sample Template (Service Catalog Product)
 Metadata:
   License: Apache-2.0
+
 Parameters:
   ProductXTemplateURL:
     Type: String
@@ -18,16 +19,19 @@ Resources:
       Description: Portfolio containing Cloud9 Development Environment
       DisplayName: IDE Portfolio
       ProviderName: Company
+
   IDETagOption:
     Type: "AWS::ServiceCatalog::TagOption"
     Properties:
       Key: "ProductType"
       Value: "IDE"
+
   IDEPortfolioTagOptionAssociation:
     Type: "AWS::ServiceCatalog::TagOptionAssociation"
     Properties:
       ResourceId: !Ref Portfolio
       TagOptionId: !Ref IDETagOption
+
   Cloud9Product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
     Properties:
@@ -42,12 +46,14 @@ Resources:
       SupportDescription: For help with Cloud9 Dev Environment contact us
       SupportEmail: john@example.com
       SupportUrl: http://example.com
+
   Association:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:
       AcceptLanguage: en
       PortfolioId: !Ref Portfolio
       ProductId: !Ref Cloud9Product
+
   IDEPortfolioPrincipalAssociation:
     Type: "AWS::ServiceCatalog::PortfolioPrincipalAssociation"
     Properties:

--- a/samples/sample-vpc/buildspec.yml
+++ b/samples/sample-vpc/buildspec.yml
@@ -13,4 +13,7 @@ phases:
       - python adf-build/generate_params.py
 
 artifacts:
-  files: '**/*'
+  files:
+    - 'template.yml'
+    - 'params/*.json'
+    - 'params/*.yml'

--- a/samples/sample-vpc/params/banking-production.yml
+++ b/samples/sample-vpc/params/banking-production.yml
@@ -2,4 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Parameters:
-  Environment: production
+  CostCenter: "123"
+  Environment: "production"
+
+Tags:
+  TagKey: "my_tag"
+  MyKey: "new_value"

--- a/samples/sample-vpc/params/global.yml
+++ b/samples/sample-vpc/params/global.yml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Parameters:
-  CostCenter: '123'
-  Environment: testing
+  CostCenter: "123"
+  Environment: "testing"
+
 Tags:
-  TagKey: my_tag
-  MyKey: new_value
+  TagKey: "my_tag"
+  MyKey: "new_value"

--- a/samples/sample-vpc/template.yml
+++ b/samples/sample-vpc/template.yml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: '2010-09-09'
-Description: ADF CloudFormation Sample Template (VPC) - Designed to be launched into a region with 3 availability zones
+Description: >-
+  ADF CloudFormation Sample Template (VPC) - Designed to be
+  launched into a region with three availability zones.
 Metadata:
   License: Apache-2.0
 
@@ -23,87 +25,6 @@ Mappings:
     PrivateThree:
       CIDR: '10.0.5.0/24'
 
-Outputs:
-  DefaultInternetConnectivitySecurityGroupId:
-    Description: The ID of the Internet connectivity security groups
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-private-connectivity-security-group
-    Value:
-      Ref: DefaultInternetConnectivitySecurityGroup
-
-  PrivateRouteTableId:
-    Description: The ID of the Private Route Table
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-private-route-table
-    Value:
-      Ref: PrivateRouteTable
-
-  PrivateSubnet1a:
-    Description: The ID of the Private Subnet 1a
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-private-subnet-1a
-    Value:
-      Ref: PrivateSubnet1a
-
-  PrivateSubnet1b:
-    Description: The ID of the Private Subnet 1b
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-private-subnet-1b
-    Value:
-      Ref: PrivateSubnet1b
-
-  PrivateSubnet1c:
-    Description: The ID of the Private Subnet 1c
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-private-subnet-1c
-    Value:
-      Ref: PrivateSubnet1c
-
-  PublicRouteTableId:
-    Description: The ID of the Public Route Table
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-public-route-table
-    Value:
-      Ref: PublicRouteTable
-
-  PublicSubnet1a:
-    Description: The ID of the Public Subnet 1a
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-public-subnet-1a
-    Value:
-      Ref: PublicSubnet1a
-
-  PublicSubnet1b:
-    Description: The ID of the Public Subnet 1b
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-public-subnet-1b
-    Value:
-      Ref: PublicSubnet1b
-
-  PublicSubnet1c:
-    Description: The ID of the Public Subnet 1c
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-public-subnet-1c
-    Value:
-      Ref: PublicSubnet1c
-
-  VPC:
-    Description: The ID of the main VPC
-    Export:
-      Name:
-        Fn::Sub: ${Environment}-vpc-id
-    Value:
-      Ref: VPC
-
 Parameters:
   Environment:
     AllowedValues:
@@ -116,6 +37,55 @@ Parameters:
   CostCenter:
     Description: The Tag used to define the cost center
     Type: String
+
+  VPCFlowLog:
+    Description: Whether and how to enable VPC Flow Logs or not.
+    Type: String
+    Default: 'Off'
+    ConstraintDescription: Must be 'Off', 'S3', or 'CloudWatch Logs'.
+    AllowedValues:
+      - 'Off'
+      - 'S3'
+      - 'CloudWatch Logs'
+
+  VPCFlowLogS3DestinationArn:
+    Description: >-
+      Arn of the location where the VPC Flow Logs should be delivered.
+    Type: String
+    Default: 'NOT_SET'
+
+  VPCFlogLogGroupName:
+    Description: >-
+      The Log Group name to use when specified to use 'cloud-watch-logs'.
+    Type: String
+    Default: 'NOT_SET'
+
+  VPCFlowLogTrafficType:
+    Description: >-
+      The Traffic Type to log in VPC Flow Logs.
+    Type: String
+    Default: 'ALL'
+    AllowedValues:
+      - 'ACCEPT'
+      - 'ALL'
+      - 'REJECT'
+
+Conditions:
+  ShouldDeployVPCFlowLog:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref VPCFlowLog
+          - 'Off'
+
+  ShouldDeployVPCFlowLogToCloudWatch:
+    Fn::Equals:
+      - !Ref VPCFlowLog
+      - 'CloudWatch Logs'
+
+  ShouldCreateVPCFlowLogCloudWatchRole:
+    Fn::And:
+      - !Condition ShouldDeployVPCFlowLog
+      - !Condition ShouldDeployVPCFlowLogToCloudWatch
 
 Resources:
   AttachInternetGateway:
@@ -203,6 +173,8 @@ Resources:
   PrivateRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
+      VpcId:
+        Ref: VPC
       Tags:
         - Key: Name
           Value:
@@ -213,8 +185,6 @@ Resources:
         - Key: CostCenter
           Value:
             Ref: CostCenter
-      VpcId:
-        Ref: VPC
 
   PrivateSubnet1a:
     Type: AWS::EC2::Subnet
@@ -421,3 +391,146 @@ Resources:
         - Key: CostCenter
           Value:
             Ref: CostCenter
+
+  EC2VPCFlowLog:
+    Type: AWS::EC2::FlowLog
+    Condition: ShouldDeployVPCFlowLog
+    Properties:
+      DeliverLogsPermissionArn:
+        Fn::If:
+          - ShouldDeployVPCFlowLogToCloudWatch
+          - !GetAtt "VPCFlowLogToCloudWatchRole.Arn"
+          - !Ref "AWS::NoValue"
+      LogDestination:
+        Fn::If:
+          - ShouldDeployVPCFlowLogToCloudWatch
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:${VPCFlogLogGroupName}"
+          - !Ref "VPCFlowLogS3DestinationArn"
+      LogDestinationType:
+        Fn::If:
+          - ShouldDeployVPCFlowLogToCloudWatch
+          - 'cloud-watch-logs'
+          - 's3'
+      LogGroupName:
+        Fn::If:
+          - ShouldDeployVPCFlowLogToCloudWatch
+          - !Ref "VPCFlogLogGroupName"
+          - !Ref "AWS::NoValue"
+      ResourceId: !Ref VPC
+      ResourceType: 'VPC'
+      TrafficType: !Ref VPCFlowLogTrafficType
+
+  VPCFlowLogToCloudWatchRole:
+    Type: AWS::IAM::Role
+    Condition: ShouldCreateVPCFlowLogCloudWatchRole
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: 'ec2.amazonaws.com'
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: 'root'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:DescribeLogGroups"
+                  - "logs:DescribeLogStreams"
+                  - "logs:PutLogEvents"
+                  - "logs:GetLogEvents"
+                  - "logs:FilterLogEvents"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:${VPCFlogLogGroupName}/*"
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:${VPCFlogLogGroupName}"
+
+Outputs:
+  VPCCidrRange:
+    Value:
+      !FindInMap ['SubnetConfig', 'VPC', 'CIDR']
+    Export:
+      Name: VPCCIDR
+
+  DefaultInternetConnectivitySecurityGroupId:
+    Description: The ID of the Internet connectivity security groups
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-private-connectivity-security-group
+    Value:
+      Ref: DefaultInternetConnectivitySecurityGroup
+
+  PrivateRouteTableId:
+    Description: The ID of the Private Route Table
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-private-route-table
+    Value:
+      Ref: PrivateRouteTable
+
+  PrivateSubnet1a:
+    Description: The ID of the Private Subnet 1a
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-private-subnet-1a
+    Value:
+      Ref: PrivateSubnet1a
+
+  PrivateSubnet1b:
+    Description: The ID of the Private Subnet 1b
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-private-subnet-1b
+    Value:
+      Ref: PrivateSubnet1b
+
+  PrivateSubnet1c:
+    Description: The ID of the Private Subnet 1c
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-private-subnet-1c
+    Value:
+      Ref: PrivateSubnet1c
+
+  PublicRouteTableId:
+    Description: The ID of the Public Route Table
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-public-route-table
+    Value:
+      Ref: PublicRouteTable
+
+  PublicSubnet1a:
+    Description: The ID of the Public Subnet 1a
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-public-subnet-1a
+    Value:
+      Ref: PublicSubnet1a
+
+  PublicSubnet1b:
+    Description: The ID of the Public Subnet 1b
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-public-subnet-1b
+    Value:
+      Ref: PublicSubnet1b
+
+  PublicSubnet1c:
+    Description: The ID of the Public Subnet 1c
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-public-subnet-1c
+    Value:
+      Ref: PublicSubnet1c
+
+  VPC:
+    Description: The ID of the main VPC
+    Export:
+      Name:
+        Fn::Sub: ${Environment}-vpc-id
+    Value:
+      Ref: VPC

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_upload.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/resolver_upload.py
@@ -58,7 +58,7 @@ class ResolverUpload(BaseResolver):
             for item in S3.supported_path_styles()
         ):
             raise ValueError(
-                'When uploading to S3 you need to specify a path style'
+                'When uploading to S3 you need to specify a path style '
                 'to use for the returned value to be used. '
                 f'Supported path styles include: {S3.supported_path_styles()}'
             ) from None


### PR DESCRIPTION
## Why?

These changes aim to improve the overall quality, maintainability, and
usability of the ADF sample templates, while also providing better
documentation and aligning with the latest AWS best practices.

- To adhere to best practices and improve maintainability of the code base.
- To enhance security and observability by enabling VPC Flow Logs.
- To address code style issues and enforce consistent formatting.

## What?

- Specified explicit files to include in the CodeBuild output artifacts.
- Improvements to the VPC example:
      - Added support for enabling VPC Flow Logs to S3 or CloudWatch Logs.
      - Refactored resource ordering and added conditions for better readability.
      - Exported additional VPC CIDR range output for convenience.
- Fixed minor documentation issues in sample guides.
- Update README files with additional details, prerequisites, and deployment
   instructions for various samples.
- Upgrade the `sample-fargate-node-app` to use the AWS public container registry
   (public.ecr.aws) instead.
- Refactor the `sample-ec2-with-codedeploy` sample to use AWS Launch Templates,
   a newer and recommended approach instead of Launch Configurations.
- Update `sample-ec2-with-codedeploy` scripts to install newer versions of
   Amazon Linux 2023, Java, and other dependencies. Also fixed the scripts to be
   compatible to the recommended IMDSv2 authenticated APIs.
- Miscellaneous improvements and bug fixes across various sample templates.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
