### PR TITLE
Fix Markdown Anchor Link Check

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -27,7 +27,11 @@ jobs:
 
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter@v7
+        # MegaLinter v7.11 upgrades Markdown-Link-Check to v3.12.1
+        # This version broke anchor link checks according to:
+        # https://github.com/tcort/markdown-link-check/issues/304
+        # Setting the version to v7.10.0 for now:
+        uses: oxsecurity/megalinter@v7.10.0
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/


### PR DESCRIPTION
## Why?

With the release of MegaLinter v7.11, the markdown-link-check dependency was upgraded to v3.12.1. This, however, fails checks where anchor links are used.

## What?

Fixed the MegaLinter workflow to v7.10 for now.
We can revert this change/loosen the requirement to v7 when the issue is resolved later on.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
