### PR TITLE
Install: Add version checks and pre-deploy warnings

### DIFF
--- a/.github/workflows/adf.yml
+++ b/.github/workflows/adf.yml
@@ -2,6 +2,9 @@ name: ADF CI
 
 on: [push, pull_request]
 
+env:
+  CI_BUILD: 1
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,6 +15,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 150
+          fetch-tags: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Why?

When you clone the ADF Github repository, it will not fetch the git tags. The installation docs describe that you should run `git fetch --tags` to retrieve those. However, if someone forgets to run that command, you run into a weird error that does not describe what is going wrong in a resolvable manner:

> Error: Failed to create changeset for the stack: aws-deployment-framework,
> Parameter validation failed:
> Invalid length for parameter Tags[0].Value, value: 0, valid min length: 1

 Additionally, if you installed ADF with the updated installer before. Then forget to fetch the latest git tags when you are about to deploy a new version of ADF, it will return a version number that is based on the old version instead of the new one. Making it hard to determine what version of ADF was installed.
Long story short, the version in the `src/template.yml` should never be newer than the version determined via git tags.

## What?

Added check to verify that the version number can be determined correctly.

* If it did not return the version number, but an empty string instead:
  * it will test whether there is a .git folder. * If not, the user should clone a repository instead. * If the .git directory exists, it will instruct the user to fetch the git tags.
* If a version number is returned, it will check whether the version number matches with the tag.
  * If it does, this means that it is building a released version of ADF.
  * If it does not, the user might not have switched to the right version tag yet. Hence, we warn the user to proceed with caution.

Additionally, this change will add a warning when ADF gets deployed that the specific version and changes should be reviewed and tested in a non-production environment.

Lastly, a check is added to ensure that the ADF version of the `src/template.yml` file should not be newer than the version resolved via git tags. If this is the case, it should instruct the user to fetch the latest tags from the ADF repository.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
