### PR TITLE
Require CodeBuild image from v4 onward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,21 @@ these customizations to CDK v2 as well.
 
 #### CodeBuild default image
 
-As written in the [CodeBuild provider
+As was written in the [CodeBuild provider
 docs](./docs/providers-guide.md#properties-3), it is a best-practice to define
 the exact CodeBuild container image you would like to use for each pipeline.
 
 However, in case you rely on the default, in prior ADF releases it would
 default to `UBUNTU_14_04_PYTHON_3_7_1`. This container image is no longer
-supported. With ADF v4.0, the new default is `STANDARD_7_0`.
-Also referred to as: `aws/codebuild/standard:7.0`.
+supported. With ADF v4.0, using the CodeBuild provider requires defining the
+specific CodeBuild container image to use. This way, it will not fallback to
+a default that might be secure today but deprecated in the future.
+
+For each pipeline definition in the deployment maps, the CodeBuild image will
+need to be defined. Alternatively, upgrade ADF and check which pipelines failed
+to deploy after. Most likely all pipelines already define the CodeBuild image
+to use, as the previous default image is [not supported by
+AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html#deprecated-images).
 
 #### ADF Parameters in AWS Systems Manager Parameter Store
 

--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -220,11 +220,9 @@ Provider type: `codebuild`.
 
 #### Properties
 
-- *image* *(String|Object)* - default: `STANDARD_7_0`.
-  - It is recommended to specify the container image your pipeline requires.
-    Relying on the default value might impact the pipeline in future updates
-    of ADF if the default were to change.
-  - The Image that the AWS CodeBuild will use. Images can be found
+- *image* *(String|Object)*.
+  - It is required to specify the container image your pipeline requires.
+  - Specify the Image that the AWS CodeBuild will use. Images can be found
     [here](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-codebuild.LinuxBuildImage.html).
   - Image can also take an object that contains a reference to a public docker
     hub image with a prefix of `docker-hub://`, such as

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -22,7 +22,6 @@ from cdk_constructs.adf_codepipeline import Action
 
 ADF_DEPLOYMENT_REGION = os.environ["AWS_REGION"]
 ADF_DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]
-DEFAULT_CODEBUILD_IMAGE = "STANDARD_7_0"
 DEFAULT_BUILD_SPEC_FILENAME = 'buildspec.yml'
 DEFAULT_DEPLOY_SPEC_FILENAME = 'deployspec.yml'
 ADF_DEFAULT_BUILD_ROLE_NAME = 'adf-codebuild-role'
@@ -339,14 +338,9 @@ class CodeBuild(Construct):
 
     @staticmethod
     def get_image_by_name(specific_image: str):
-        image_name = (
-            (
-                specific_image
-                or DEFAULT_CODEBUILD_IMAGE
-            ).upper()
-        )
-        if hasattr(_codebuild.LinuxBuildImage, image_name):
-            return getattr(_codebuild.LinuxBuildImage, image_name)
+        cdk_image_name = specific_image.upper()
+        if hasattr(_codebuild.LinuxBuildImage, cdk_image_name):
+            return getattr(_codebuild.LinuxBuildImage, cdk_image_name)
         if specific_image.startswith('docker-hub://'):
             specific_image = specific_image.split('docker-hub://')[-1]
             return _codebuild.LinuxBuildImage.from_docker_registry(
@@ -398,6 +392,9 @@ class CodeBuild(Construct):
                 ecr_repo,
                 specific_image.get('tag', 'latest'),
             )
+
+        if not specific_image:
+            raise ValueError("Required CodeBuild image property is not configured")
 
         return CodeBuild.get_image_by_name(specific_image)
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_default_pipeline_type.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_default_pipeline_type.py
@@ -46,7 +46,7 @@ def test_pipeline_creation_outputs_as_expected_when_input_has_1_target_with_2_wa
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {
@@ -113,7 +113,7 @@ def test_pipeline_creation_outputs_as_expected_when_input_has_2_targets_with_2_w
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_pipeline_creation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_stacks/tests/test_pipeline_creation.py
@@ -60,7 +60,7 @@ def test_pipeline_creation_outputs_as_expected_when_source_is_s3_and_build_is_co
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {
@@ -117,7 +117,7 @@ def test_pipeline_creation_outputs_as_expected_when_source_is_codecommit_and_bui
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {
@@ -179,7 +179,7 @@ def test_pipeline_creation_outputs_as_expected_when_source_is_codecommit_with_co
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {
@@ -252,7 +252,7 @@ def test_pipeline_creation_outputs_with_codeartifact_trigger():
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {
@@ -313,7 +313,7 @@ def test_pipeline_creation_outputs_with_codeartifact_trigger_with_package_name()
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {
@@ -381,7 +381,7 @@ def test_pipeline_creation_outputs_with_invalid_trigger_type():
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {
@@ -434,7 +434,7 @@ def test_pipeline_creation_outputs_as_expected_when_notification_endpoint_is_cha
     }
     stack_input["pipeline_input"]["default_providers"]["build"] = {
         "provider": "codebuild",
-        "properties": {"account_id": "123456789012"},
+        "properties": {"image": "STANDARD_7_0"},
     }
 
     stack_input["ssm_params"][region_name] = {

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_deployment_map.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/stubs/stub_deployment_map.yml
@@ -10,6 +10,8 @@ pipelines:
           account_id: 111111111111
       build:
         provider: codebuild
+        properties:
+          image: STANDARD_7_0
       deploy:
         provider: cloudformation
     params:
@@ -38,6 +40,7 @@ pipelines:
       build:
         provider: codebuild
         properties:
+          image: STANDARD_7_0
           role: packer
           size: medium  # Resource allocation for the build stage -> small | medium | large
     params:
@@ -56,6 +59,10 @@ pipelines:
           repository: example-vpc-adf  # Optional, above name property will be used if this is not specified
           owner: awslabs
           codeconnections_param_path: /path/to/parameter  # The path in AWS Systems Manager Parameter Store that holds the AWS CodeConnections ARN
+      build:
+        provider: codebuild
+        properties:
+          image: STANDARD_7_0
       deploy:
         provider: cloudformation
         properties:
@@ -74,6 +81,10 @@ pipelines:
           repository: my-ecs-app  # Optional, the name of the pipeline will be used if this is not specified
           owner: github-enterprise-team-org
           codeconnections_param_path: /path/to/parameter  # The path in AWS Systems Manager Parameter Store that holds the AWS CodeConnections ARN
+      build:
+        properties:
+          image:
+            repository_arn: 'arn:aws:ecr:region:012345678910:repository-namespace/repository-name'
     params:
       notification_endpoint: team@example.com
     targets:
@@ -85,8 +96,14 @@ pipelines:
         provider: codecommit
         properties:
           account_id: 333333333333  # A different account id as this pipeline is owned by a different team
+      build:
+        properties:
+          image: STANDARD_7_0
       deploy:
         provider: codebuild
+        properties:
+          image:
+            repository_name: 'some-repo-name'
     targets:  # Targets looks for the deploy defaults above to determine parameters
       - properties:
           spec_filename: custom-spec-one.yml
@@ -103,6 +120,8 @@ pipelines:
         provider: codecommit
         properties:
           account_id: 333333333333  # A different account id as this pipeline is owned by a different team
+      build:
+        provider: jenkins
     targets:
       - 222222222222
 
@@ -134,6 +153,9 @@ pipelines:
         provider: codecommit
         properties:
           account_id: 111111111111
+      build:
+        properties:
+          image: docker-hub://some-image
     targets:
       - target: 222222222222
         properties:

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_deployment_map.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_deployment_map.py
@@ -38,7 +38,13 @@ def test_update_deployment_parameters(cls):
                     "properties": {
                         "account_id": 111111111111,
                     },
-                }
+                },
+                "build": {
+                    "name": "codebuild",
+                    "properties": {
+                        "image": "STANDARD_7_0",
+                    },
+                },
             },
         }
     )
@@ -83,7 +89,13 @@ def test_update_deployment_parameters_waves(cls):
                 "properties": {
                     "account_id": 111111111111,
                 }
-            }
+            },
+            "build": {
+                "name": "codebuild",
+                "properties": {
+                    "image": "STANDARD_7_0",
+                },
+            },
         }
     })
     pipeline.template_dictionary = {


### PR DESCRIPTION
## Why?

Closes: #626

In prior versions of ADF, the CodeBuild image default was set to `UBUNTU_14_04_PYTHON_3_7_1`. This container image was no longer supported by the AWS CodeBuild service. Hence, using this version introduces a security risk as it is no longer patched.

Moving to the latest CodeBuild image `STANDARD_7_0` was proposed when we switched to CDK v2. This change of the default image to use was one of the main reasons why just upgrading to CDK v2 required a major version release. As updating the default introduces a breaking change that might impact the pipelines of ADF.

## What?

In the future, if we would only update the default we would require a new major version upgrade when `STANDARD_7_0` is deprecated too. Instead, this change proposes to require the image for the CodeBuild provider in the default properties of the build and deploy (when using CodeBuild to deploy) stages.

For targets, it continues to be marked optional. In case the target does not have an image set and nor does the default deploy provider, it will raise a `ValueError`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
