### PR TITLE
Install: Add uncommitted changes check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Makefile versions
-MAKEFILE_VERSION := 2.2
+MAKEFILE_VERSION := 2.3
 UPDATE_VERSION := make/latest
 
 # This Makefile requires Python version 3.9 or later
@@ -268,6 +268,26 @@ verify_version: .venv
 			echo '' && \
 			exit 1 \
 		) \
+	)
+	@# If there are uncommitted changes or new files, this implies that ADF
+	@# might be modified, hence we should track that in the version number
+	@( \
+		git diff-index --quiet HEAD -- src || ( \
+			echo '' && \
+			echo '$(CLR_RED)Error: There are uncommitted changes!$(CLR_END)' && \
+			echo '$(CLR_RED)Please commit these changes first to continue.$(CLR_END)' && \
+			echo '' && \
+			exit 1 \
+		); \
+	)
+	@( \
+		test -z "$$(git ls-files --others --exclude-standard -- src)" || ( \
+			echo '' && \
+			echo '$(CLR_RED)Error: New files were added to ADF its source code!$(CLR_END)' && \
+			echo '$(CLR_RED)Please commit these changes first to continue.$(CLR_END)' && \
+			echo '' && \
+			exit 1 \
+		); \
 	)
 	@# If the version number is not a release-tagged version and we are not in a CI build
 	@( \


### PR DESCRIPTION
## Why?

In case one were to checkout a tagged release, then make changes, ADF will receive the tagged release number. Instead of tracking the change that was made in the release number as well.

By preventing these uncommitted changes, it makes it easier to detect what code is running in a specific version of ADF. So in case someone were to report an issue we can assume the number indicates which version of the code failed.

## What?

* Added check for uncommitted changes, these include files that are tracked by the git repository.
* Added check for newly created files, these would not be tracked by git yet.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
