### PR TITLE
Fix pipeline completion trigger description

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_events.py
@@ -119,7 +119,7 @@ class Events(Construct):
                 _event = _events.Rule(
                     self,
                     f'completion_{pipeline}',
-                    description="Triggers {pipeline} on completion of {params['pipeline']}",
+                    description=f"Triggers {pipeline} on completion of {params['pipeline']}",
                     enabled=True,
                     event_pattern=_events.EventPattern(
                         detail={


### PR DESCRIPTION
## Why?

Resolves: #654.

The description of the pipeline completion triggers did not parse the dynamic parameters that were defined.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
