### PR TITLE
Fix Terraform pipeline issue after upgrade to 4.0.0

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/global.yml
@@ -320,6 +320,7 @@ Resources:
               - "sts:AssumeRole"
             Resource:
               - !Sub arn:${AWS::Partition}:iam::*:role/adf-readonly-automation-role
+              - !Sub arn:${AWS::Partition}:iam::*:role/adf/organizations/adf-organizations-readonly
             Condition:
               StringEquals:
                 aws:PrincipalOrgID: !Ref OrganizationId

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/adf_terraform.sh
@@ -28,15 +28,17 @@ tfinit() {
   fi
   terraform init \
     -backend-config "bucket=$S3_BUCKET_REGION_NAME" \
+    -backend-config "encrypt=true" \
     -backend-config "kms_key_id=$KMS_KEY_ARN" \
     -backend-config "region=$AWS_REGION" \
     -backend-config "key=$ADF_PROJECT_NAME/$ACCOUNT_ID.tfstate" \
     -backend-config "dynamodb_table=adf-tflocktable"
 
-  echo "Bucket: $S3_BUCKET_REGION_NAME"
-  echo "KMS Key ARN: $KMS_KEY_ARN"
-  echo "Region: $AWS_REGION"
-  echo "Key:    $ADF_PROJECT_NAME/$ACCOUNT_ID.tfstate"
+  echo "Bucket:         $S3_BUCKET_REGION_NAME"
+  echo "Encrypt:        true"
+  echo "KMS Key ARN:    $KMS_KEY_ARN"
+  echo "Region:         $AWS_REGION"
+  echo "Key:            $ADF_PROJECT_NAME/$ACCOUNT_ID.tfstate"
   echo "DynamoDB table: adf-tflocktable"
 }
 tfplan() {
@@ -50,7 +52,7 @@ tfplan() {
   aws s3 cp \
     "${ADF_PROJECT_NAME}-${TF_VAR_TARGET_ACCOUNT_ID}-${TS}.log" \
     "s3://${S3_BUCKET_REGION_NAME}/${ADF_PROJECT_NAME}/tf-plan/${DATE}/${TF_VAR_TARGET_ACCOUNT_ID}/${ADF_PROJECT_NAME}-${TF_VAR_TARGET_ACCOUNT_ID}-${TS}.log" \
-    --sse-kms-key-id $KMS_KEY_ARN
+    --sse-kms-key-id $KMS_KEY_ARN --sse "aws:kms"
   echo "Path to terraform plan s3://$S3_BUCKET_REGION_NAME/$ADF_PROJECT_NAME/tf-plan/$DATE/$TF_VAR_TARGET_ACCOUNT_ID/$ADF_PROJECT_NAME-$TF_VAR_TARGET_ACCOUNT_ID-$TS.log"
 }
 tfapply() {


### PR DESCRIPTION
# Why?

Fix terraform pipeline issues after upgrade to 4.0.0. Terraform is not able to upload tf statefile to S3 bucket due to wrong definition of S3 terraform backend

Issue #744, #745 

## What?

Added encryption properties to terraform S3 backend.
Added permission to codebuild role in the deployment account to read AWS Organizations api

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
