### PR TITLE
Update pipeline_management.yml for listTags allow

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/pipeline_management.yml
@@ -1005,6 +1005,7 @@ Resources:
                   - "lambda:CreateFunction"
                   - "lambda:DeleteFunction"
                   - "lambda:GetFunction"
+                  - "lambda:ListTags"
                   - "lambda:GetFunctionConfiguration"
                   - "lambda:UpdateFunctionCode"
                   - "lambda:UpdateFunctionConfiguration"


### PR DESCRIPTION
as per aws update GetFunction will no longer support to get data related to Tags if it not is explicitly allow by code for lambda

# Why?
Mail from aws team 

We are contacting you because we are making a change to the Lambda GetFunction API authorization which may require your action.

Previously, permissions on ListTags were required only when using the ListTags API explicitly. However, principals with GetFunction API permissions could still access tag information outputted by the GetFunction call. Beginning July 27, 2024, Lambda will return tags data only when the principal calling GetFunction API has a policy with explicit allow permission on ListTags API. When the role calling the GetFunction API has a policy with a deny or has no policy with explicit allow access to ListTags API, Lambda will not return tags data in the response to the GetFunction API call.

We identified your account has roles with allow access to the GetFunction API, however, the policy does not allow access to the ListTags API. If you intend to continue receiving tags data using the GetFunction API, you must add a policy to the AWS Identity and Access Management (IAM) role used to call the GetFunction API with an explicit “allow access to the ListTags API. Please refer to our "Permissions required for working with tags" user guide for information about the permissions required for using tags with Lambda resources [1].

To allow you time to review and make necessary changes, we have added your account to an allow list until September 1, 2024. After this date, calls to the GetFunction API will return tags data only if the caller has explicit allow access to the ListTags API. If the caller does not have allow access to the ListTags or has deny access to the ListTags API, the GetFunction API will return function configuration excluding tags data. Additionally, the message will include the new TagsError object which provides the reason for not returning the tags data.

![image](https://github.com/user-attachments/assets/4f4a17ee-1f14-428c-b391-7b1c0af3eba0)



*Issue #, if available:*

## What?

Description of changes:
added allow ListTags for getFunction in the pipeline_management.yml

- List
- What
- You
- Changed

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
