### PR TITLE
Fix validation of notification endpoint to raise when empty

### DIFF
--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -391,7 +391,7 @@ Guide](./admin-guide.md#adfconfig).
 
 #### Parameter MainNotificationEndpoint
 
-Optional, default value: (empty)
+Required on installation, optional on update, default value: (empty)
 
 Example: `jane@example.com`
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_config.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/tests/test_config.py
@@ -60,10 +60,54 @@ def test_raise_validation_remove_deployment_target_region(cls):
         assert cls._parse_config()
 
 
+def test_raise_validation_no_notification_endpoint(cls):
+    cls.config.pop("main-notification-endpoint", None)
+    with raises(InvalidConfigError):
+        assert cls._parse_config()
+
+
 def test_raise_validation_length_deployment_target_region(cls):
     cls.config_contents["regions"]["deployment-account"] = [
         "region1",
         "region2",
+    ]
+    with raises(InvalidConfigError):
+        assert cls._parse_config()
+
+
+def test_raise_validation_empty_roles(cls):
+    cls.config_contents["roles"]["cross-account-access"] = ""
+    with raises(InvalidConfigError):
+        assert cls._parse_config()
+
+
+def test_raise_validation_empty_deployment_region(cls):
+    cls.config_contents["regions"]["deployment-account"] = ""
+    with raises(InvalidConfigError):
+        assert cls._parse_config()
+
+
+def test_raise_validation_zero_notification_endpoint(cls):
+    cls.config["main-notification-endpoint"] = []
+    with raises(InvalidConfigError):
+        assert cls._parse_config()
+
+
+def test_raise_validation_empty_obj_notification_endpoint(cls):
+    cls.config["main-notification-endpoint"] = [{}]
+    with raises(InvalidConfigError):
+        assert cls._parse_config()
+
+
+def test_raise_validation_empty_email_notification_endpoint(cls):
+    cls.config["main-notification-endpoint"] = [{"target": ""}]
+    with raises(InvalidConfigError):
+        assert cls._parse_config()
+
+
+def test_raise_validation_no_at_in_email_notification_endpoint(cls):
+    cls.config["main-notification-endpoint"] = [
+        {"target": "some-str", "type": "email"},
     ]
     with raises(InvalidConfigError):
         assert cls._parse_config()


### PR DESCRIPTION
Issue: #747

## Why?

When no notification endpoint is configured, it did not warm about this. Instead, the execution of the main bootstrap pipeline failed.

## What?

* Add validation logic to confirm that a notification endpoint is configured.
* When an email address is configured, it should contain the '@' character too.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
