### PR TITLE
fix(deployment): Cross-account deployment required KMS operations

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/deployment/regional.yml
@@ -153,6 +153,9 @@ Resources:
             Action:
               - kms:Decrypt
               - kms:DescribeKey
+              - kms:Encrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
             Resource: "*"
             Condition:
               StringEquals:


### PR DESCRIPTION
Add kms:Encrypt, kms:GenerateDataKey*, and kms:ReEncrypt* actions to allow use of key

# Why?

These permissions are needed for cross-account roles to access the artifact bucket.

*Issue #, if available:* https://github.com/awslabs/aws-deployment-framework/issues/756

## What?

Description of changes:

Added:
- kms:Encrypt
- kms:GenerateDataKey*
- kms:ReEncrypt* 
...actions to DeploymentFrameworkRegionalKMSKey's "Allow use of the key" statement

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
