### PR TITLE
Fix jump role manager AWS Organizations API retries

### DIFF
--- a/src/lambda_codebase/jump_role_manager/main.py
+++ b/src/lambda_codebase/jump_role_manager/main.py
@@ -32,6 +32,7 @@ import os
 
 from aws_xray_sdk.core import patch_all
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 # ADF imports
@@ -79,8 +80,13 @@ MAX_NUMBER_OF_ACCOUNTS = math.floor(
     / CHARS_PER_ACCOUNT_ID,
 )
 
+BOTO_ORG_CONFIG = Config(
+    retries={
+        "max_attempts": 15,
+    },
+)
 IAM_CLIENT = boto3.client("iam")
-ORGANIZATIONS_CLIENT = boto3.client("organizations")
+ORGANIZATIONS_CLIENT = boto3.client("organizations", config=BOTO_ORG_CONFIG)
 TAGGING_CLIENT = boto3.client("resourcegroupstaggingapi")
 CODEPIPELINE_CLIENT = boto3.client("codepipeline")
 

--- a/src/template.yml
+++ b/src/template.yml
@@ -920,6 +920,11 @@ Resources:
               "TimeoutSeconds": 300,
               "Retry": [
                 {
+                  "ErrorEquals": ["States.TaskFailed"],
+                  "IntervalSeconds": 3,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 10
+                }, {
                   "ErrorEquals": [
                     "Lambda.Unknown",
                     "Lambda.ServiceException",


### PR DESCRIPTION
## Why?

When multiple accounts are bootstrapped by ADF via changes in the AWS Oranizations hierarchy, the jump-role-manager could run into rate limits of the AWS Organizations API.

## What?

This change will ensure that the lambda function will retry more often. While using exponential back-off and jitter as built-in by boto3 and as configured in the Step Function retry logic.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
