### PR TITLE
Fix installer on ARM 64-bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Makefile versions
-MAKEFILE_VERSION := 2.3.1
+MAKEFILE_VERSION := 2.3.2
 UPDATE_VERSION := make/latest
 
 # This Makefile requires Python version 3.9 or later
@@ -153,8 +153,13 @@ tox: deps
 	)
 
 docker:
-	@echo "Prepare docker to support all architectures..."
-	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	( \
+		RUNNING_ON_ARCH=$$(arch); \
+		if [ "$$RUNNING_ON_ARCH" = "x86_64" ] || [ "$$RUNNING_ON_ARCH" = "i386" ]; then \
+			echo "Prepare docker to support the required architectures..." && \
+			docker run --rm --privileged multiarch/qemu-user-static --reset -p yes; \
+		fi \
+	)
 
 version_number: .venv
 	@echo "Generate a new version number..."


### PR DESCRIPTION
## Why?

The QEMU multi-arch docker container should only be executed on x86 based architectures.

## What?

Updated the installer to skip the QEMU docker container command if we are not running on a x86 based architecture.
The `multiarch/qemu-user-static` container is only executed on x86, instead of when not ARM 64, as x86 is the only supported architecture that it can run from at this moment.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
