### PR TITLE
Feat/default codebuild image

### DIFF
--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -228,7 +228,7 @@ Provider type: `codebuild`.
 
 #### Properties
 
-- *image* *(String|Object)*.
+- *image* *(String|Object)*. - default: `STANDARD_5_0`
   - It is required to specify the container image your pipeline requires.
   - Specify the Image that the AWS CodeBuild will use. Images can be found
     [here](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-codebuild.LinuxBuildImage.html).

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py
@@ -22,6 +22,7 @@ from cdk_constructs.adf_codepipeline import Action
 
 ADF_DEPLOYMENT_REGION = os.environ["AWS_REGION"]
 ADF_DEPLOYMENT_ACCOUNT_ID = os.environ["ACCOUNT_ID"]
+DEFAULT_CODEBUILD_IMAGE = "STANDARD_5_0"
 DEFAULT_BUILD_SPEC_FILENAME = 'buildspec.yml'
 DEFAULT_DEPLOY_SPEC_FILENAME = 'deployspec.yml'
 ADF_DEFAULT_BUILD_ROLE_NAME = 'adf-codebuild-role'
@@ -338,7 +339,7 @@ class CodeBuild(Construct):
 
     @staticmethod
     def get_image_by_name(specific_image: str):
-        cdk_image_name = specific_image.upper()
+        cdk_image_name = (specific_image or DEFAULT_CODEBUILD_IMAGE).upper()
         if hasattr(_codebuild.LinuxBuildImage, cdk_image_name):
             return getattr(_codebuild.LinuxBuildImage, cdk_image_name)
         if specific_image.startswith('docker-hub://'):
@@ -392,9 +393,6 @@ class CodeBuild(Construct):
                 ecr_repo,
                 specific_image.get('tag', 'latest'),
             )
-
-        if not specific_image:
-            raise ValueError("Required CodeBuild image property is not configured")
 
         return CodeBuild.get_image_by_name(specific_image)
 

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
@@ -57,7 +57,7 @@ SOURCE_OUTPUT_ARTIFACT_FORMAT = Or(
 
 # CodeCommit Source
 CODECOMMIT_SOURCE_PROPS = {
-    "account_id": AWS_ACCOUNT_ID_SCHEMA,
+    Optional("account_id"): AWS_ACCOUNT_ID_SCHEMA,
     Optional("repository"): str,
     Optional("branch"): str,
     Optional("poll_for_changes"): bool,
@@ -308,7 +308,7 @@ PROVIDER_SCHEMA = {
             lambda x: PROVIDER_SOURCE_SCHEMAS[x['provider']].validate(x),
         ),
     ),
-    'build': Or(
+    Optional('build'): Or(
         And(
             {
                 Optional("provider"): 'codebuild',


### PR DESCRIPTION
# Why?

Now in the deployment map, if the codebuild image does not explicitly defined in the deployment map, the deployment will fail. I would like to add define a default build image for the ADF. 

## What?
An easy fix is to define the default build image in the `src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/adf_codebuild.py` and set the build stage to optional in the `src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py`.

Additionally, `account_id` should also be optional in the schema validation, as ADF 4.0 supports default source account id.