### PR TITLE
Apply caching when handling parameters

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cache.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/cache.py
@@ -23,3 +23,7 @@ class Cache:
 
     def add(self, key, value):
         self._stash[key] = value
+
+    def remove(self, key):
+        if key in self._stash:
+            del self._stash[key]

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/parameter_store.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/parameter_store.py
@@ -7,13 +7,14 @@
 from botocore.config import Config
 
 # ADF imports
+from cache import Cache
 from errors import ParameterNotFoundError
 from paginator import paginator
 from logger import configure_logger
 
 LOGGER = configure_logger(__name__)
-PARAMETER_DESCRIPTION = 'DO NOT EDIT - Used by The AWS Deployment Framework'
-PARAMETER_PREFIX = '/adf'
+PARAMETER_DESCRIPTION = "DO NOT EDIT - Used by The AWS Deployment Framework"
+PARAMETER_PREFIX = "/adf"
 SSM_CONFIG = Config(
     retries={
         "max_attempts": 10,
@@ -22,28 +23,27 @@ SSM_CONFIG = Config(
 
 
 class ParameterStore:
-    """Class used for modeling Parameters
-    """
+    """Class used for modeling Parameters"""
 
-    def __init__(self, region, role):
-        self.client = role.client('ssm', region_name=region, config=SSM_CONFIG)
+    def __init__(self, region, role, cache=None):
+        self.cache = cache or Cache()
+        self.client = role.client("ssm", region_name=region, config=SSM_CONFIG)
 
-    def put_parameter(self, name, value, tier='Standard'):
-        """Puts a Parameter into Parameter Store
-        """
+    def put_parameter(self, name, value, tier="Standard"):
+        """Puts a Parameter into Parameter Store"""
         try:
             current_value = self.fetch_parameter(name)
             assert current_value == value
             LOGGER.debug(
-                'No need to update parameter %s with value %s since they '
-                'are the same',
+                "No need to update parameter %s with value %s since they "
+                "are the same",
                 ParameterStore._build_param_name(name),
                 value,
             )
         except (ParameterNotFoundError, AssertionError):
             param_name = ParameterStore._build_param_name(name)
             LOGGER.debug(
-                'Putting SSM Parameter %s with value %s',
+                "Putting SSM Parameter %s with value %s",
                 param_name,
                 value,
             )
@@ -51,70 +51,76 @@ class ParameterStore:
                 Name=param_name,
                 Description=PARAMETER_DESCRIPTION,
                 Value=value,
-                Type='String',
+                Type="String",
                 Overwrite=True,
-                Tier=tier
+                Tier=tier,
             )
+            self.cache.add(param_name, value)
 
     def delete_parameter(self, name):
         param_name = ParameterStore._build_param_name(name)
         try:
-            LOGGER.debug('Deleting Parameter %s', param_name)
+            LOGGER.debug("Deleting Parameter %s", param_name)
+            self.cache.remove(param_name)
             self.client.delete_parameter(
                 Name=param_name,
             )
         except self.client.exceptions.ParameterNotFound:
             LOGGER.debug(
-                'Attempted to delete Parameter %s but it was not found',
+                "Attempted to delete Parameter %s but it was not found",
                 param_name,
             )
 
     def fetch_parameters_by_path(self, path):
-        """Gets a Parameter(s) by Path from Parameter Store (Recursively)
-        """
+        """Gets a Parameter(s) by Path from Parameter Store (Recursively)"""
         param_path = ParameterStore._build_param_name(path)
         try:
             LOGGER.debug(
-                'Fetching Parameters from path %s',
+                "Fetching Parameters from path %s",
                 param_path,
             )
             return paginator(
                 self.client.get_parameters_by_path,
                 Path=param_path,
                 Recursive=True,
-                WithDecryption=False
+                WithDecryption=False,
             )
         except self.client.exceptions.ParameterNotFound as error:
             raise ParameterNotFoundError(
-                f'Parameter Path {param_path} Not Found',
+                f"Parameter Path {param_path} Not Found",
             ) from error
 
     @staticmethod
     def _build_param_name(name, adf_only=True):
-        slash_name = name if name.startswith('/') else f"/{name}"
-        add_prefix = (
-            adf_only
-            and not slash_name.startswith(f"{PARAMETER_PREFIX}/")
-        )
-        param_prefix = PARAMETER_PREFIX if add_prefix else ''
+        slash_name = name if name.startswith("/") else f"/{name}"
+        add_prefix = adf_only and not slash_name.startswith(f"{PARAMETER_PREFIX}/")
+        param_prefix = PARAMETER_PREFIX if add_prefix else ""
         return f"{param_prefix}{slash_name}"
 
     def fetch_parameter(self, name, with_decryption=False, adf_only=True):
-        """Gets a Parameter from Parameter Store (Returns the Value)
-        """
+        """Gets a Parameter from Parameter Store (Returns the Value)"""
         param_name = ParameterStore._build_param_name(name, adf_only)
+        if self.cache.exists(param_name):
+            LOGGER.debug("Reading Parameter from Cache: %s", param_name)
+            cached_value = self.cache.get(param_name)
+            if isinstance(cached_value, ParameterNotFoundError):
+                raise cached_value
+            return cached_value
         try:
-            LOGGER.debug('Fetching Parameter %s', param_name)
+            LOGGER.debug("Fetching Parameter %s", param_name)
             response = self.client.get_parameter(
-                Name=param_name,
-                WithDecryption=with_decryption
+                Name=param_name, WithDecryption=with_decryption
             )
-            return response['Parameter']['Value']
+            fetched_value = response["Parameter"]["Value"]
+            self.cache.add(param_name, fetched_value)
+            return fetched_value
         except self.client.exceptions.ParameterNotFound as error:
-            LOGGER.debug('Parameter %s not found', param_name)
-            raise ParameterNotFoundError(
-                f'Parameter {param_name} Not Found',
-            ) from error
+            LOGGER.debug("Parameter %s not found", param_name)
+            not_found = ParameterNotFoundError(
+                f"Parameter {param_name} Not Found",
+            )
+            self.cache.add(param_name, not_found)
+            raise not_found from error
 
     def fetch_parameter_accept_not_found(
         self,
@@ -131,5 +137,5 @@ class ParameterStore:
         try:
             return self.fetch_parameter(name, with_decryption, adf_only)
         except ParameterNotFoundError:
-            LOGGER.debug('Using default instead: %s', default_value)
+            LOGGER.debug("Using default instead: %s", default_value)
             return default_value

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
@@ -156,7 +156,6 @@ class Target:
             ).lower() == "enabled"
         )
 
-
     @staticmethod
     def _account_is_active(account):
         return bool(account.get("Status") == "ACTIVE")

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cache.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_cache.py
@@ -32,3 +32,52 @@ def test_get(cls):
     assert cls.get('my_key') == 'my_value'
     assert cls.get('true_key') is True
     assert cls.get('false_key') is False
+
+
+def test_remove_existing_key(cls):
+    # Arrange
+    cls.add("test_key", "test_value")
+
+    # Act
+    cls.remove("test_key")
+
+    # Assert
+    assert cls.exists("test_key") is False
+    assert cls.get("test_key") is None
+
+
+def test_remove_non_existing_key(cls):
+    # Arrange
+    cls.remove("non_existing_key")
+
+    # Assert
+    assert cls.exists("non_existing_key") is False
+    assert cls.get("non_existing_key") is None
+
+
+def test_remove_and_read(cls):
+    # Arrange
+    cls.add("test_key", "test_value")
+
+    # Act
+    cls.remove("test_key")
+    cls.add("test_key", "new_value")
+
+    # Assert
+    assert cls.exists("test_key") is True
+    assert cls.get("test_key") == "new_value"
+
+
+def test_remove_multiple_keys(cls):
+    # Arrange
+    cls.add("key1", "value1")
+    cls.add("key2", "value2")
+
+    # Act
+    cls.remove("key1")
+
+    # Assert
+    assert cls.exists("key1") is False
+    assert cls.exists("key2") is True
+    assert cls.get("key1") is None
+    assert cls.get("key2") == "value2"

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_parameter_store.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_parameter_store.py
@@ -3,53 +3,72 @@
 
 # pylint: skip-file
 
-import os
-import boto3
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 from stubs import stub_parameter_store
 from mock import Mock
 
+from cache import Cache
+from errors import ParameterNotFoundError
 from parameter_store import ParameterStore
 
 
 @fixture
-def cls():
-    cls = ParameterStore(
-        'us-east-1',
-        boto3
-    )
+def mock_ssm_client():
+    ssm_client = Mock()
+    ssm_client.exceptions.ParameterNotFound = Exception
+    return ssm_client
+
+
+@fixture
+def mock_role(mock_ssm_client):
+    role = Mock()
+    role.client.return_value = mock_ssm_client
+    return role
+
+
+@fixture
+def cache():
+    return Cache()
+
+
+@fixture
+def cls(mock_role, cache):
+    cls = ParameterStore("us-east-1", mock_role, cache)
     return cls
 
 
 @mark.parametrize(
     "input_name, output_path",
     [
-        ('/adf/test', '/adf/test'),
-        ('adf/test', '/adf/test'),
-        ('/adf_version', '/adf_version'),
-        ('/test', '/test'),
-        ('test', '/test'),
-        ('/other/test', '/other/test'),
-        ('other/test', '/other/test'),
+        ("/adf/test", "/adf/test"),
+        ("adf/test", "/adf/test"),
+        ("/adf_version", "/adf_version"),
+        ("/test", "/test"),
+        ("test", "/test"),
+        ("/other/test", "/other/test"),
+        ("other/test", "/other/test"),
     ],
 )
 def test_build_param_name_not_adf_only(input_name, output_path):
-    assert ParameterStore._build_param_name(
-        input_name,
-        adf_only=False,
-    ) == output_path
+    assert (
+        ParameterStore._build_param_name(
+            input_name,
+            adf_only=False,
+        )
+        == output_path
+    )
 
 
 @mark.parametrize(
     "input_name, output_path",
     [
-        ('/adf/test', '/adf/test'),
-        ('adf/test', '/adf/test'),
-        ('/adf_version', '/adf/adf_version'),
-        ('/test', '/adf/test'),
-        ('test', '/adf/test'),
-        ('/other/test', '/adf/other/test'),
-        ('other/test', '/adf/other/test'),
+        ("/adf/test", "/adf/test"),
+        ("adf/test", "/adf/test"),
+        ("/adf_version", "/adf/adf_version"),
+        ("/test", "/adf/test"),
+        ("test", "/adf/test"),
+        ("/other/test", "/adf/other/test"),
+        ("other/test", "/adf/other/test"),
     ],
 )
 def test_build_param_name_adf_only(input_name, output_path):
@@ -59,4 +78,174 @@ def test_build_param_name_adf_only(input_name, output_path):
 def test_fetch_parameter(cls):
     cls.client = Mock()
     cls.client.get_parameter.return_value = stub_parameter_store.get_parameter
-    assert cls.fetch_parameter('some_path') == 'some_parameter_value'
+    assert cls.fetch_parameter("some_path") == "some_parameter_value"
+
+
+def test_has_cache(cls):
+    assert cls.cache is not None
+
+
+def test_put_parameter_updates_cache(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    expected_value = "test-value"
+    full_param_name = f"/adf/{parameter_name}"
+
+    # Simulate parameter not found to trigger put
+    mock_ssm_client.get_parameter.side_effect = (
+        mock_ssm_client.exceptions.ParameterNotFound
+    )
+
+    # Act
+    cls.put_parameter(parameter_name, expected_value)
+
+    # Assert
+    assert cls.cache.exists(full_param_name)
+    assert cls.cache.get(full_param_name) == expected_value
+
+
+def test_put_parameter_skips_if_value_unchanged(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    existing_value = "test-value"
+
+    # Setup mock to return existing value
+    mock_ssm_client.get_parameter.return_value = {
+        "Parameter": {
+            "Value": existing_value,
+        },
+    }
+
+    # Act
+    cls.put_parameter(parameter_name, existing_value)
+
+    # Assert
+    assert not mock_ssm_client.put_parameter.called
+
+
+def test_put_parameter_skips_if_value_cached_and_unchanged(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    existing_value = "test-value"
+    full_param_name = f"/adf/{parameter_name}"
+
+    # Setup mock to return existing value
+    cls.cache.add(full_param_name, existing_value)
+
+    # Act
+    cls.put_parameter(parameter_name, existing_value)
+
+    # Assert
+    assert not mock_ssm_client.put_parameter.called
+
+
+def test_delete_parameter_removes_from_cache(cls):
+    # Arrange
+    parameter_name = "test-param"
+    full_param_name = f"/adf/{parameter_name}"
+    cls.cache.add(full_param_name, "test-value")
+
+    # Act
+    cls.delete_parameter(parameter_name)
+
+    # Assert
+    assert not cls.cache.exists(full_param_name)
+
+
+def test_delete_parameter_removes_from_cache_even_when_failing(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    full_param_name = f"/adf/{parameter_name}"
+    cls.cache.add(full_param_name, "test-value")
+
+    # Simulate parameter not found when deleting
+    mock_ssm_client.delete_parameter.side_effect = (
+        mock_ssm_client.exceptions.ParameterNotFound
+    )
+
+    # Act
+    cls.delete_parameter(parameter_name)
+
+    # Assert
+    assert not cls.cache.exists(full_param_name)
+
+
+def test_fetch_parameter_returns_cached_value(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    full_param_name = f"/adf/{parameter_name}"
+    cached_value = "cached-value"
+    cls.cache.add(full_param_name, cached_value)
+
+    # Act
+    result = cls.fetch_parameter(parameter_name)
+
+    # Assert
+    assert result == cached_value
+    assert not mock_ssm_client.get_parameter.called
+
+
+def test_fetch_parameter_caches_new_value(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    full_param_name = f"/adf/{parameter_name}"
+    expected_value = "test-value"
+    mock_ssm_client.get_parameter.return_value = {
+        "Parameter": {
+            "Value": expected_value,
+        },
+    }
+
+    # Act
+    result = cls.fetch_parameter(parameter_name)
+
+    # Assert
+    assert result == expected_value
+    assert cls.cache.get(full_param_name) == expected_value
+
+
+def test_fetch_parameter_caches_not_found_error(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    full_param_name = f"/adf/{parameter_name}"
+    mock_ssm_client.get_parameter.side_effect = (
+        mock_ssm_client.exceptions.ParameterNotFound
+    )
+
+    # Act & Assert
+    with raises(ParameterNotFoundError):
+        cls.fetch_parameter(parameter_name)
+
+    # Verify the error is cached
+    cached_value = cls.cache.get(full_param_name)
+    assert isinstance(cached_value, ParameterNotFoundError)
+
+
+def test_fetch_parameter_returns_cached_not_found_error(cls, mock_ssm_client):
+    # Arrange
+    parameter_name = "test-param"
+    full_param_name = f"/adf/{parameter_name}"
+    cached_error = ParameterNotFoundError("Parameter not found")
+    cls.cache.add(full_param_name, cached_error)
+
+    # Act & Assert
+    with raises(ParameterNotFoundError):
+        cls.fetch_parameter(parameter_name)
+    assert not mock_ssm_client.get_parameter.called
+
+
+def test_fetch_parameter_accept_not_found_with_cached_error(cls):
+    # Arrange
+    parameter_name = "test-param"
+    full_param_name = f"/adf/{parameter_name}"
+    default_value = "default"
+    cached_error = ParameterNotFoundError("Parameter not found")
+    cls.cache.add(full_param_name, cached_error)
+
+    # Act
+    result = cls.fetch_parameter_accept_not_found(
+        parameter_name, default_value=default_value
+    )
+
+    # Assert
+    assert result == default_value


### PR DESCRIPTION
Fixes: #781

## Why?

When generating the pipeline definition, it needs to know whether or not empty targets are allowed, a config that is managed from the adfconfig.yml. To support this, the Target instances fetch the configuration value from parameter store.

When hundreds of targets are initialized, it will attempt to fetch this parameter way too often. Especially considering the value is not likely to change.

## What?

Apply caching on the fetch, put, delete operations in the Parameter Store class. Such that all ADF components that need to perform lookups frequently can benefit from this enhancement.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
