### PR TITLE
Linter upgrade and fixes

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter@v8.1.0
+        uses: oxsecurity/megalinter@v8.4.2
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -92,6 +92,7 @@ Please note that building on *Windows* is not supported, please use the
     This should return a table that is possibly empty.
   - Additionally, running `docker --version` should return version 19 or
     later.
+<!-- markdown-link-check-disable-next-line -->
 - [make](https://www.gnu.org/software/make/)
   - To test if it is available, run `make --version`.
     This should return 4.3 or later.
@@ -101,6 +102,7 @@ Please note that building on *Windows* is not supported, please use the
 - [jq](https://github.com/jqlang/jq)
   - To test if it is available, run `jq --version`.
     This version should be 1.6 or later.
+<!-- markdown-link-check-disable-next-line -->
 - [sed](https://www.gnu.org/software/sed/)
   - To test if it is available, run `sed --version`.
     This should return 4.3 or later.

--- a/samples/sample-service-catalog-product/productX/template.yml
+++ b/samples/sample-service-catalog-product/productX/template.yml
@@ -47,6 +47,11 @@ Parameters:
 Resources:
   Cloud9Instance:
     Type: AWS::Cloud9::EnvironmentEC2
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1152
     Properties:
       AutomaticStopTimeMinutes: !Ref AutomaticStopTimeInMinutes
       Description: !Ref InstanceDescription


### PR DESCRIPTION
# Why?

Recently our linters started failing to validate links to gnu.org. So I 

- Disabled the linkchecker for these domains
- Upgraded our linter
- Fix an issue with CFN lint expection and AMI ID, even though https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloud9-environmentec2.html#cfn-cloud9-environmentec2-imageid accepts an alias.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
