### PR TITLE
Removing 3.9 build support ahead of deprecation

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/requirements.txt
@@ -5,5 +5,4 @@ pyyaml~=6.0.2
 schema~=0.7.7
 tenacity==9.1.2
 typing-extensions~=4.14.1
-urllib3~=1.26.18 ; python_version < "3.10"
-urllib3~=2.5.0 ; python_version >= "3.10"
+urllib3~=2.5.0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/requirements.txt
@@ -8,5 +8,4 @@ pyyaml~=6.0.2
 schema~=0.7.7
 tenacity==9.1.2
 typing-extensions~=4.14.1
-urllib3~=1.26.18 ; python_version < "3.10"
-urllib3~=2.5.0 ; python_version >= "3.10"
+urllib3~=2.5.0


### PR DESCRIPTION
## Why?

Python 3.9 is no longer maintained by October 2025. ADF itself relies on Python 3.12.

The previous conditions were added to support developers running on Python 3.9. Given the deprecation notice, and urllib3's CVE-2025-50181 it is recommended to update urllib3 to `>= 2.5.0`. That version of urllib3 only supports Python 3.10+.

## What?

* Removed urllib3 requirements for Python versions below 3.9.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
