### PR TITLE
fix: AWS Organizations account State field over deprecated Status

### DIFF
--- a/src/lambda_codebase/account/main.py
+++ b/src/lambda_codebase/account/main.py
@@ -151,7 +151,11 @@ def _find_deployment_account_via_orgs_api() -> str:
             DEPLOYMENT_OU_PATH,
         )
         active_accounts = list(filter(
-            lambda account: account.get("Status") == "ACTIVE",
+            # Prefer `State`, fall back to the deprecated `Status` field
+            # (removed after September 2026) for backward compatibility.
+            lambda account: (
+                account.get("State", account.get("Status")) == "ACTIVE"
+            ),
             accounts_found,
         ))
         number_of_deployment_accounts = len(active_accounts)

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/retrieve_organization_accounts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/retrieve_organization_accounts.py
@@ -212,7 +212,12 @@ def _get_member_accounts(billing_account_id, options):
         accounts.extend(page["Accounts"])
 
     # Remove any account that is not actively part of this organization yet.
-    only_active_accounts = filter(lambda a: a["Status"] == "ACTIVE", accounts)
+    # Prefer the `State` field, falling back to the deprecated `Status` field
+    # (removed after September 2026) for backward compatibility.
+    only_active_accounts = filter(
+        lambda a: a.get("State", a.get("Status")) == "ACTIVE",
+        accounts,
+    )
 
     # Only return the key: value pairs that are defined in the --field option.
     only_certain_fields_of_active = list(

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/get_accounts.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/helpers/terraform/get_accounts.py
@@ -82,7 +82,11 @@ def get_accounts():
                 'Email': account['Email'],
             },
             filter(
-                lambda account: account['Status'] == 'ACTIVE',
+                # Prefer `State`, fall back to the deprecated `Status` field
+                # (removed after September 2026) for backward compatibility.
+                lambda account: (
+                    account.get('State', account.get('Status')) == 'ACTIVE'
+                ),
                 paginator(organizations.list_accounts)
             )
         )

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/organizations.py
@@ -266,11 +266,17 @@ class Organizations:  # pylint: disable=R0904
                     account_ou_id,
                 )
                 return False
-        if account.get("Status") != "ACTIVE":
+        # AWS Organizations is replacing the `Status` field with the more
+        # granular `State` field. The `Status` field is deprecated and will be
+        # removed after September 2026. Prefer `State` when present and fall
+        # back to `Status` for backward compatibility. See:
+        # https://aws.amazon.com/blogs/mt/updates-to-account-status-information-in-aws-organizations/
+        account_state = account.get("State", account.get("Status"))
+        if account_state != "ACTIVE":
             LOGGER.warning(
                 "Account %s is not an active AWS Account, state reported: %s",
                 account["Id"],
-                account.get("Status"),
+                account_state,
             )
             return False
         return True

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/target.py
@@ -171,7 +171,10 @@ class Target:
 
     @staticmethod
     def _account_is_active(account):
-        return bool(account.get("Status") == "ACTIVE")
+        # Prefer the `State` field, falling back to the deprecated `Status`
+        # field (removed after September 2026) for backward compatibility.
+        account_state = account.get("State", account.get("Status"))
+        return bool(account_state == "ACTIVE")
 
     def _create_target_info(self, name, account_id):
         return {

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_organizations.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_organizations.py
@@ -160,6 +160,69 @@ def test_get_accounts_with_suspended(paginator_mock, cls):
 
 
 @patch("organizations.paginator")
+def test_get_accounts_with_state_field(paginator_mock, cls):
+    # AWS Organizations is replacing `Status` with the more granular `State`
+    # field. Ensure ADF honors `State` and filters out non-active accounts.
+    all_account_ids = [
+        "111111111111",
+        "222222222222",
+        "333333333333",
+        "444444444444",
+    ]
+    non_active_account_ids = {
+        "222222222222": "PENDING_CLOSURE",
+        "444444444444": "SUSPENDED",
+    }
+    cls.client.list_parents.side_effect = lambda account_id: (
+        {
+            "Id": f"ou-{account_id}",
+            "Type": "ORGANIZATIONAL_UNIT",
+        }
+    )
+    paginator_mock.return_value = list(
+        map(
+            lambda account_id: (
+                {
+                    "Id": account_id,
+                    "State": non_active_account_ids.get(account_id, "ACTIVE"),
+                }
+            ),
+            all_account_ids,
+        )
+    )
+    assert set(
+        map(
+            lambda account: account["Id"],
+            cls.get_accounts(),
+        )
+    ) == (set(all_account_ids) - set(non_active_account_ids))
+
+
+@patch("organizations.paginator")
+def test_get_accounts_state_takes_precedence_over_status(paginator_mock, cls):
+    # When both fields are present, the newer `State` field wins over the
+    # deprecated `Status` field.
+    cls.client.list_parents.side_effect = lambda account_id: (
+        {
+            "Id": f"ou-{account_id}",
+            "Type": "ORGANIZATIONAL_UNIT",
+        }
+    )
+    paginator_mock.return_value = [
+        # State says SUSPENDED, legacy Status says ACTIVE -> excluded.
+        {"Id": "111111111111", "State": "SUSPENDED", "Status": "ACTIVE"},
+        # State says ACTIVE -> included.
+        {"Id": "222222222222", "State": "ACTIVE", "Status": "ACTIVE"},
+    ]
+    assert set(
+        map(
+            lambda account: account["Id"],
+            cls.get_accounts(),
+        )
+    ) == {"222222222222"}
+
+
+@patch("organizations.paginator")
 def test_get_accounts_ignore_root(paginator_mock, cls):
     all_account_ids = [
         "111111111111",


### PR DESCRIPTION
AWS Organizations is replacing the account 'Status' field with the more granular 'State' field (PENDING_ACTIVATION, ACTIVE, SUSPENDED, PENDING_CLOSURE, CLOSED). The legacy 'Status' field is deprecated and will be removed after September 2026. Once removed, ADF's account filtering (which checks Status == 'ACTIVE') would treat every account as inactive and skip it, breaking bootstrapping and account management.

This change makes ADF prefer the 'State' field and fall back to 'Status' for backward compatibility, across all account-filtering locations:
- adf-build/shared/python/organizations.py
- adf-build/shared/python/target.py
- adf-build/shared/helpers/retrieve_organization_accounts.py
- adf-build/shared/helpers/terraform/get_accounts.py
- lambda_codebase/account/main.py

Adds tests covering State-based filtering and State precedence over Status.

Ref: https://aws.amazon.com/blogs/mt/updates-to-account-status-information-in-aws-organizations/

