### PR TITLE
chore(ci): Update MegaLinter to v10 and CodeQL to v4

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -16,3 +16,10 @@ include_checks:
 ignore_checks:
   - W3002
   - W3045
+  # SAM templates are not compatible with cfn-lint > 1.54 at this point.
+  # To make it work with the latest version of MegaLinter, we have to disable
+  # the newly added rules E1019 and E1010 below. Once cfn-lint regains SAM
+  # compatibility and we upgrade past 1.54 (see requirements-dev.txt), these
+  # two rules should be removed from this disabled list.
+  - E1019
+  - E1010

--- a/.ecrc.json
+++ b/.ecrc.json
@@ -4,7 +4,9 @@
     "IgnoreDefaults": false,
     "SpacesAftertabs": false,
     "NoColor": false,
-    "Exclude": ["LICENSE.txt"],
+    "Exclude": [
+        "LICENSE.txt"
+    ],
     "AllowedContentTypes": [],
     "PassedFiles": [],
     "Disable": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -23,23 +23,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter@v8.4.2
+        uses: oxsecurity/megalinter@v10
         env:
           # All available variables are described in documentation
-          # https://megalinter.io/configuration/
+          # https://megalinter.io/latest/configuration/
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive production artifacts
         if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MegaLinter reports
           path: |
@@ -48,6 +48,6 @@ jobs:
 
       - name: Upload MegaLinter scan results to GitHub Security tab
         if: ${{ success() }} || ${{ failure() }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'megalinter-reports/megalinter-report.sarif'

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,5 +1,5 @@
 # Configuration file for MegaLinter
-# See all available variables at https://megalinter.io/configuration/ and in linters documentation
+# See all available variables at https://megalinter.io/latest/configuration/ and in linters documentation
 
 # all, none, or list of linter keys
 APPLY_FIXES: none
@@ -18,10 +18,10 @@ ENABLE_LINTERS:
   - JSON_PRETTIER
   - JSON_V8R
   - JAVASCRIPT_STANDARD
-  - MARKDOWN_MARKDOWN_LINK_CHECK
   - MARKDOWN_MARKDOWNLINT
   - MARKDOWN_MARKDOWN_TABLE_FORMATTER
   - SPELL_CSPELL
+  - SPELL_LYCHEE
   - TERRAFORM_TFLINT
   - YAML_YAMLLINT
 
@@ -31,7 +31,7 @@ FILEIO_REPORTER: false
 
 # Install plugin for list handling.
 JSON_PRETTIER_PRE_COMMANDS:
-  - command: "npm install prettier-plugin-multiline-arrays@3.0.6"
+  - command: "npm install prettier-plugin-multiline-arrays@4.1.11"
     cwd: "workspace"
 
 CLOUDFORMATION_CFN_LINT_CONFIG_FILE: '.cfnlintrc'
@@ -39,7 +39,6 @@ CLOUDFORMATION_CFN_LINT_FILE_EXTENSIONS: [".yml", ".yaml"]
 
 EDITORCONFIG_EDITORCONFIG_CHECKER_CONFIG_FILE: '.ecrc.json'
 
-MARKDOWN_MARKDOWN_LINK_CHECK_ARGUMENTS: '-q'
 MARKDOWN_MARKDOWNLINT_DISABLE_ERRORS: false
 
 SPELL_CSPELL_ARGUMENTS: '--gitignore --no-progress --show-suggestions'
@@ -48,5 +47,10 @@ SPELL_CSPELL_FILE_EXTENSIONS: ["*"]
 TERRAFORM_TFLINT_UNSECURED_ENV_VARIABLES:
   - GITHUB_TOKEN
 
-GITHUB_STATUS_REPORTER: true
-GITHUB_COMMENT_REPORTER: true
+# Reporters that post back to GitHub are disabled to keep the workflow's
+# GITHUB_TOKEN at least privilege (only security-events: write, for the SARIF
+# upload). Enabling these would require granting statuses: write and
+# pull-requests: write, expanding the token's blast radius for the third-party
+# code MegaLinter runs. Rely on the job status and the Security tab instead.
+GITHUB_STATUS_REPORTER: false
+GITHUB_COMMENT_REPORTER: false

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,6 +2,7 @@ module.exports = {
   plugins: [
     'prettier-plugin-multiline-arrays'
   ],
+  multilineArraysWrapThreshold: 0,
   trailingComma: 'es5',
   semi: false,
   singleQuote: true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1277,8 +1277,8 @@ Policies via AWS Organizations. Tagging Policies can now be applied to OU's in
 the same manner as Service Control Policies could be in prior versions.
 Using a tagging-policy.json file in a specific folder of the bootstrap
 repository that matches to your organization structure enables the tagging
-policy for the specific OU. Read more about how tagging policies work
-[here](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html)
+policy for the specific OU. Read more about
+[how tagging policies work](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html)
 and see the example-tagging-policy.json in the bootstrap repo for a simple
 reference.
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -886,7 +886,7 @@ Tag Policies are available only in an organization that has
 [all features enabled](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_org_support-all-features.html).
 Once you have enabled all features within your Organization, ADF can manage and
 automate the application and updating process of the Tag Policies. For more
-information, see [here](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html).
+information, see the [Tag policies documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html).
 
 ## Integrating Slack
 
@@ -1093,9 +1093,9 @@ _deployment account_ in _your main region_:
 4. This should progress and turn up as green. If any of these steps fail, it
    could be that one of your pipelines could not be updated. You can click on
    the `Details` link to get more insights into the failure. Please report the
-   step where it failed by opening an issue
-   [here](https://github.com/awslabs/aws-deployment-framework/issues) and
-   include a copy of the logs when it fails here.
+   step where it failed by
+   [opening an issue](https://github.com/awslabs/aws-deployment-framework/issues)
+   and include a copy of the logs when it fails here.
 
 The `aws-deployment-framework-pipelines` pipeline will trigger the creation of
 pipelines as defined in the deployment maps.

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -150,8 +150,8 @@ or later.
 #### 2.2.2. Network Settings
 
 To build and deploy ADF, you will need to setup a Cloud9 environment that has
-credentials setup. The recommended approach as documented
-[here](https://docs.aws.amazon.com/cloud9/latest/user-guide/credentials.html)
+credentials setup. The recommended approach, as described in the
+[Cloud9 credentials documentation](https://docs.aws.amazon.com/cloud9/latest/user-guide/credentials.html),
 is to use AWS Managed Temporary Credentials. In Cloud9, it will be able
 to operate with your access rights (similarly to how AWS CloudShell works) if
 you set it up:
@@ -462,7 +462,7 @@ Example: `deployment`
 **Explanation:**
 The Alias of the deployment account. The account alias is a globally unique
 name for an account that enable things such as custom login URLs. Read more
-[here](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#AboutAccountAlias).
+[about AWS account aliases](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#AboutAccountAlias).
 
 *This is not required when performing an update between versions of ADF.*
 *Only supported when installing ADF for the first time.*

--- a/docs/multi-organization-guide.md
+++ b/docs/multi-organization-guide.md
@@ -131,8 +131,8 @@ AWS Organization stage ("dev", "int", "prod") and ADF will behave exactly the sa
 
 One challenge with synchronizing the `aws-deployment-framework-bootstrap` repository
 across AWS Organizations is that the contents of the `adfconfig.yml` configuration
-file is typically tailored to the ADF installation. The can be solved by adding a
-custom adfconfig file for the given organization.
+file is typically tailored to the ADF installation. This can be solved by
+adding a custom adfconfig file for the given organization.
 
 Adding a configuration file with the name pattern `adfconfig.{organization id}.yml``
 in the root of the`aws-deployment-framework-bootstrap` repository will take

--- a/docs/providers-guide.md
+++ b/docs/providers-guide.md
@@ -230,8 +230,8 @@ Provider type: `codebuild`.
 
 - *image* *(String|Object)*.
   - It is required to specify the container image your pipeline requires.
-  - Specify the Image that the AWS CodeBuild will use. Images can be found
-    [here](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-codebuild.LinuxBuildImage.html).
+  - Specify the Image that the AWS CodeBuild will use. See the available
+    [CodeBuild Linux build images](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-codebuild.LinuxBuildImage.html).
   - Image can also take an object that contains a reference to a public docker
     hub image with a prefix of `docker-hub://`, such as
     `docker-hub://bitnami/mongodb`. This allows your pipeline to consume a
@@ -261,11 +261,11 @@ Provider type: `codebuild`.
 
     Along with `repository_arn` or `repository_name`, we also support a `tag`
     key. This can be used to define which image should be used
-    (defaults to `latest`). An example of this setup is provided
-    [here](user-guide.md#custom-build-images).
+    (defaults to `latest`). See an
+    [example of custom build images](user-guide.md#custom-build-images).
 - *size* *(String)* **(small|medium|large)** - default: `small`.
-  - The Compute type to use for the build, types can be found
-    [here](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
+  - The Compute type to use for the build. See the available
+    [CodeBuild compute types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
 - *environment_variables* *(Object)* defaults to empty object.
   - Any Environment Variables you wish to be available within the build stage
     for this pipeline. These are to be passed in as Key/Value pairs. For
@@ -298,7 +298,7 @@ Provider type: `codebuild`.
   - If you wish to pass in a custom inline Buildspec as a string for the
     CodeBuild Project this would override any `buildspec.yml` file.
 
-    Read more [here](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec-ref-example).
+    Read more in the [buildspec reference](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec-ref-example).
   - **Note:** Either specify the `spec_inline` or the `spec_filename` in the
     properties block. If both are supplied, the pipeline generator will throw an
     error instead.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -445,8 +445,8 @@ notification_endpoint:
   **Start**, **Complete**, or **Fail**.
 - *schedule* *(String)* defaults to none
   - If the Pipeline should execute on a specific schedule. Schedules are defined
-    by using a Rate or an Expression. See
-    [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions)
+    by using a Rate or an Expression. See the
+    [CloudWatch schedule expressions documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions)
     for more information on how to define a Rate or an Expression.
 
 - *restart_execution_on_update* *(Boolean)* default: `False`.
@@ -1141,8 +1141,8 @@ pipelines:
       - *some_target_account
 ```
 
-For more advanced yaml usage, see
-[here](https://learnxinyminutes.com/docs/yaml/)
+For more advanced yaml usage, see the
+[YAML tutorial](https://learnxinyminutes.com/docs/yaml/)
 
 ### One to many relationships
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,37 @@
+# Configuration for the lychee link checker (run via MegaLinter SPELL_LYCHEE).
+# lychee automatically reads lychee.toml from the repository root.
+# See https://lychee.cli.rs/guides/config/
+
+# Accepted HTTP status codes for a link to be considered valid.
+# Keeps lychee's defaults (100..=103, 200..=299) and additionally accepts:
+#   - 300..=399: redirects. Combined with max_redirects = 0 below, lychee does
+#     not follow redirects and treats a 3xx response as a valid link, so
+#     harmless 301/302 redirects are not reported.
+#   - 429 (Too Many Requests): some external sites we link to, such as
+#     https://www.gnu.org/software/make/, are reachable but rate-limit this
+#     workflow because it queries them frequently. A 429 means the host is up,
+#     so we treat it as valid rather than failing the build.
+accept = [
+    "100..=103",
+    "200..=299",
+    "300..=399",
+    "429",
+]
+
+# Do not follow redirects. Together with accepting 300..=399 above, this stops
+# lychee from reporting harmless 301/302 redirects.
+max_redirects = 0
+
+# URLs and mail addresses to skip. Values are regular expressions.
+exclude = [
+    # Fake internal URL used only for demonstration in the sample testspec;
+    # it is not a real endpoint and will never resolve.
+    '^https?://integration-test-url\.internal',
+]
+
+# Paths to skip. Values are regular expressions.
+exclude_path = [
+    # Generated dependency lock files contain many third-party links (e.g.
+    # funding URLs) that we do not control and that frequently return 403/429.
+    'package-lock\.json$',
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
+# SAM templates are not compatible with cfn-lint > 1.54 at this point, so this
+# is pinned below that version. When bumping cfn-lint past 1.54, verify SAM
+# compatibility and remove the E1019 and E1010 rules from the ignore_checks
+# list in .cfnlintrc (they were only added to work around this limitation).
 cfn-lint~=1.53.3
 isort==6.1.0
 mock==5.2.0

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-accounts/README.md
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-accounts/README.md
@@ -65,7 +65,8 @@ a `/` (see examples above).
   As a prerequisite your organization management account must already have
   enterprise support activated.**
 - `alias`: AWS account alias. Must be unique globally otherwise cannot be
-  created. Check [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html)
+  created. Check the
+  [AWS account alias documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html)
   for further details. If the account alias is not created or already exists,
   in the Federation login page, no alias will be presented.
 - `tags`: list of tags associate to the account.

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-tagging-policy.json
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-bootstrap/example-tagging-policy.json
@@ -11,7 +11,9 @@
                 ]
             },
             "enforced_for": {
-                "@@assign": ["s3:bucket"]
+                "@@assign": [
+                    "s3:bucket"
+                ]
             }
         }
     }


### PR DESCRIPTION
## Why?

Modernize the MegaLinter workflow and its actions, and harden the GITHUB_TOKEN to least privilege.
This would be an issue by the end of they year, when codeql-action/upload-sarif is deprecated.

## What?
CodeQL Action:
- Bump github/codeql-action/upload-sarif from v3 to v4. CodeQL Action
  v3 is deprecated (runs on the retiring Node.js runtime);
  we must move to v4.
  See: https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

MegaLinter (v8.4.2 -> v10) and security guidance from the upstream
example (See https://megalinter.io/latest/install-github/):
- Drop the secrets.PAT fallback and use GITHUB_TOKEN only; a leaked PAT
  grants broad write access and is called out as not recommended.
- Set persist-credentials: false on checkout (safe with APPLY_FIXES off).
- Remove fetch-depth: 0 since VALIDATE_ALL_CODEBASE is true.
- Bump actions/checkout v4 -> v7 and actions/upload-artifact v4 -> v7.
- Replace MARKDOWN_MARKDOWN_LINK_CHECK with SPELL_LYCHEE. The
  markdown-link-check linter was deprecated and removed from MegaLinter
  in v9.0.0; lychee is its replacement and has much better performance.
  See: https://megalinter.io/10.1.0/removed-linters/

Least-privilege GITHUB_TOKEN:
- Disable GITHUB_STATUS_REPORTER and GITHUB_COMMENT_REPORTER so the
  workflow needs only security-events: write (for the SARIF upload).
  Enabling them would require statuses: write and pull-requests: write,
  widening the token's blast radius for the third-party code MegaLinter
  runs. Job status and the Security tab remain as signals.
- Bump prettier-plugin-multiline-arrays 3.0.6 -> 4.1.11 for MegaLinter
  v10 (Prettier 3) compatibility. Earlier 4.1.x releases did not wrap
  arrays under Prettier >= 3.9.2 (electrovir/prettier-plugin-multiline-
  arrays#76); 4.1.11 restores wrapping. Set multilineArraysWrapThreshold
  to 0 in .prettierrc.js so all non-empty arrays wrap one element per
  line, and reformat the affected JSON files.

cfn-lint (SAM incompatibility):
- SAM templates are not compatible with cfn-lint > 1.54 at this point,
  so cfn-lint stays pinned below that version and the newly surfaced
  rules E1019 and E1010 are added to ignore_checks in .cfnlintrc to keep
  the latest MegaLinter passing. Documented in both .cfnlintrc and
  requirements-dev.txt so the two rules are removed once we upgrade
  cfn-lint past 1.54.

Dependabot:
- Add .github/dependabot.yml to keep GitHub Actions updated weekly.

Documentation:
- Fix markdownlint findings surfaced by the new SPELL_LYCHEE/markdownlint
  run: replace non-descriptive "[here]" link text (MD059) with descriptive
  text across the docs, CHANGELOG, and adf-accounts README, and reflow an
  over-length line (MD013) in the multi-organization guide.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
