### PR TITLE
chore(ci): Stop GitHub Workflows running twice per commit

### DIFF
--- a/.github/workflows/adf.yml
+++ b/.github/workflows/adf.yml
@@ -1,6 +1,14 @@
 name: ADF CI
 
-on: [push, pull_request]
+on:
+  # Only lint pushes to mainline; branch pushes are covered by the
+  # pull_request trigger below. This avoids MegaLinter running twice for
+  # the same commit when a branch has an open pull request.
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
 
 env:
   CI_BUILD: 1
@@ -10,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ['3.12']
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -3,7 +3,15 @@
 # More info at https://megalinter.io
 name: MegaLinter
 
-on: [push, pull_request]
+on:
+  # Only lint pushes to mainline; branch pushes are covered by the
+  # pull_request trigger below. This avoids MegaLinter running twice for
+  # the same commit when a branch has an open pull request.
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
 
 env:
   APPLY_FIXES: none


### PR DESCRIPTION
## Why?

The `push` trigger was unrestricted, so ADF and MegaLinter ran on every commit to every branch. When that branch also had an open pull request, the `pull_request` trigger fired for the same commit, producing two redundant runs.

## What?

Restrict the `push` trigger to the `main` and `master` branches for both CI workflows. Feature branch commits are now linted only via `pull_request`, while pushes to the mainline branches still run, eliminating the duplicate execution.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
