### PR TITLE
chore(ci): make lychee resilient to timeouts and exclude gnu.org

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -7,10 +7,9 @@
 #   - 300..=399: redirects. Combined with max_redirects = 0 below, lychee does
 #     not follow redirects and treats a 3xx response as a valid link, so
 #     harmless 301/302 redirects are not reported.
-#   - 429 (Too Many Requests): some external sites we link to, such as
-#     https://www.gnu.org/software/make/, are reachable but rate-limit this
-#     workflow because it queries them frequently. A 429 means the host is up,
-#     so we treat it as valid rather than failing the build.
+#   - 429 (Too Many Requests): some external sites we link to are reachable but
+#     rate-limit this workflow because it queries them frequently. A 429 means
+#     the host is up, so we treat it as valid rather than failing the build.
 accept = [
     "100..=103",
     "200..=299",
@@ -22,11 +21,20 @@ accept = [
 # lychee from reporting harmless 301/302 redirects.
 max_redirects = 0
 
+# Retry transient failures (e.g. request timeouts) before failing the build.
+max_retries = 3
+retry_wait_time = 2
+# Allow slower hosts more time to respond before treating it as a timeout.
+timeout = 30
+
 # URLs and mail addresses to skip. Values are regular expressions.
 exclude = [
     # Fake internal URL used only for demonstration in the sample testspec;
     # it is not a real endpoint and will never resolve.
     '^https?://integration-test-url\.internal',
+    # www.gnu.org rate-limits and times out this workflow (it queries the
+    # host frequently). The links are known-good, so skip checking them.
+    '^https?://www\.gnu\.org/',
 ]
 
 # Paths to skip. Values are regular expressions.


### PR DESCRIPTION
## Why?

The gnu.org URLs frequently lead to timeouts or rate-limited responses, thereby failing the workflow.

## What?

Add max_retries, retry_wait_time, and timeout so lychee retries transient failures (e.g. request timeouts) before failing the SPELL_LYCHEE step. Also exclude www.gnu.org/software/ links, which rate-limit and time out from the CI runner, and generalise the 429 accept comment accordingly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
