### PR TITLE
fix(deployment-map): Allow omitting CodeCommit account_id and build

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_generate.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/cdk/cdk_constructs/tests/test_adf_codepipeline_generate.py
@@ -4,6 +4,7 @@
 # pylint: skip-file
 
 from mock import patch
+from copy import deepcopy
 from cdk_constructs.adf_codepipeline import Action
 from adf_codepipeline_test_constants import BASE_MAP_PARAMS
 
@@ -40,3 +41,55 @@ def test_generates_without_input_and_output_artifacts(input_mock, output_mock, a
     )
     assert not 'input_artifacts' in action.config
     assert not 'output_artifacts' in action.config
+
+
+@patch('cdk_constructs.adf_codepipeline._codepipeline.CfnPipeline.ActionDeclarationProperty')
+def test_source_account_id_defaults_to_deployment_account_when_omitted(action_decl_mock):
+    action_decl_mock.side_effect = lambda **x: x
+    map_params = deepcopy(BASE_MAP_PARAMS)
+    del map_params['default_providers']['source']['properties']['account_id']
+    assert 'scm/default_scm_codecommit_account_id' not in map_params
+    action = Action(
+        map_params=map_params,
+        category='Source',
+        provider='CodeCommit',
+    )
+    # ACCOUNT_ID is set to '111111111111' (str) in tox.ini, which is used as
+    # the ADF_DEFAULT_SCM_CODECOMMIT_ACCOUNT_ID fallback.
+    assert action._get_role_account_id() == '111111111111'
+    assert action.config['role_arn'] == (
+        'arn:aws:iam::111111111111:role/adf-codecommit-role'
+    )
+
+
+@patch('cdk_constructs.adf_codepipeline._codepipeline.CfnPipeline.ActionDeclarationProperty')
+def test_source_account_id_uses_explicit_account_id_when_provided(action_decl_mock):
+    action_decl_mock.side_effect = lambda **x: x
+    map_params = deepcopy(BASE_MAP_PARAMS)
+    map_params['default_providers']['source']['properties']['account_id'] = '222222222222'
+    action = Action(
+        map_params=map_params,
+        category='Source',
+        provider='CodeCommit',
+    )
+    assert action._get_role_account_id() == '222222222222'
+    assert action.config['role_arn'] == (
+        'arn:aws:iam::222222222222:role/adf-codecommit-role'
+    )
+
+
+@patch('cdk_constructs.adf_codepipeline._codepipeline.CfnPipeline.ActionDeclarationProperty')
+def test_source_account_id_uses_default_scm_codecommit_account_id_override(action_decl_mock):
+    action_decl_mock.side_effect = lambda **x: x
+    map_params = deepcopy(BASE_MAP_PARAMS)
+    del map_params['default_providers']['source']['properties']['account_id']
+    map_params['scm/default_scm_codecommit_account_id'] = '333333333333'
+    action = Action(
+        map_params=map_params,
+        category='Source',
+        provider='CodeCommit',
+    )
+    assert action._get_role_account_id() == '333333333333'
+    assert action.config['role_arn'] == (
+        'arn:aws:iam::333333333333:role/adf-codecommit-role'
+    )

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/schema_validation.py
@@ -57,7 +57,7 @@ SOURCE_OUTPUT_ARTIFACT_FORMAT = Or(
 
 # CodeCommit Source
 CODECOMMIT_SOURCE_PROPS = {
-    "account_id": AWS_ACCOUNT_ID_SCHEMA,
+    Optional("account_id"): AWS_ACCOUNT_ID_SCHEMA,
     Optional("repository"): str,
     Optional("branch"): str,
     Optional("poll_for_changes"): bool,
@@ -308,7 +308,7 @@ PROVIDER_SCHEMA = {
             lambda x: PROVIDER_SOURCE_SCHEMAS[x['provider']].validate(x),
         ),
     ),
-    'build': Or(
+    Optional('build'): Or(
         And(
             {
                 Optional("provider"): 'codebuild',

--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_schema_validation.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/tests/test_schema_validation.py
@@ -7,7 +7,7 @@ Tests for schema validation
 
 import unittest
 import schema_validation
-from schema import Schema
+from schema import Schema, SchemaError
 
 
 class NotificationSchemaValidationHappyPaths(unittest.TestCase):
@@ -248,3 +248,109 @@ class TargetSchemaValidationHappyPaths(unittest.TestCase):
             Schema(schema_validation.TARGET_SCHEMA).validate(target_schema),
             target_schema,
         )
+
+
+class PipelineSchemaValidationHappyPaths(unittest.TestCase):
+    def test_codecommit_source_props_schema_without_account_id(self):
+        codecommit_props = {
+            "repository": "a_repo_name",
+            "branch": "mainline",
+        }
+        expected_result = {**codecommit_props, "output_artifact_format": None}
+        self.assertDictEqual(
+            Schema(schema_validation.CODECOMMIT_SOURCE_PROPS).validate(
+                codecommit_props
+            ),
+            expected_result,
+        )
+
+    def test_pipeline_with_codecommit_source_without_account_id(self):
+        map_input = {
+            "pipelines": [
+                {
+                    "name": "a_pipeline",
+                    "default_providers": {
+                        "source": {
+                            "provider": "codecommit",
+                            "properties": {
+                                "repository": "a_repo_name",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        validated = schema_validation.SchemaValidation(map_input).validated
+        self.assertEqual(
+            validated["pipelines"][0]["default_providers"]["source"][
+                "properties"
+            ],
+            {
+                "repository": "a_repo_name",
+            },
+        )
+
+    def test_pipeline_without_build_block(self):
+        map_input = {
+            "pipelines": [
+                {
+                    "name": "a_pipeline",
+                    "default_providers": {
+                        "source": {
+                            "provider": "codecommit",
+                            "properties": {
+                                "account_id": "111111111111",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        validated = schema_validation.SchemaValidation(map_input).validated
+        self.assertNotIn(
+            "build",
+            validated["pipelines"][0]["default_providers"],
+        )
+
+
+class PipelineSchemaValidationUnhappyPaths(unittest.TestCase):
+    def test_pipeline_with_malformed_codecommit_account_id(self):
+        map_input = {
+            "pipelines": [
+                {
+                    "name": "a_pipeline",
+                    "default_providers": {
+                        "source": {
+                            "provider": "codecommit",
+                            "properties": {
+                                "account_id": "not_an_account_id",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        with self.assertRaises(SchemaError):
+            schema_validation.SchemaValidation(map_input)
+
+    def test_pipeline_with_malformed_build_block(self):
+        map_input = {
+            "pipelines": [
+                {
+                    "name": "a_pipeline",
+                    "default_providers": {
+                        "source": {
+                            "provider": "codecommit",
+                            "properties": {
+                                "account_id": "111111111111",
+                            },
+                        },
+                        "build": {
+                            "provider": "not_a_valid_build_provider",
+                        },
+                    },
+                },
+            ],
+        }
+        with self.assertRaises(SchemaError):
+            schema_validation.SchemaValidation(map_input)


### PR DESCRIPTION
## Why

Resolves: #787.

At the moment, the deployment map schema requires an `account_id` on a `codecommit` source and requires a top-level `build` provider block on every pipeline. The runtime and the documentation, however, already treat both as optional: when the CodeCommit `account_id` is omitted it defaults to the deployment account id, and a pipeline without an explicit `build` block falls back to the default CodeBuild provider. The schema was simply stricter than the code and the docs, so valid deployment maps were rejected during validation before the runtime ever got a chance to apply its defaults.

This salvages the schema-only portion of upstream PR #787 by danxie1999. The default-`CODEBUILD_IMAGE` feature from that PR is deliberately not included here; only the two schema relaxations are.

## What

- In `CODECOMMIT_SOURCE_PROPS`, wrap `account_id` in `Optional(...)` so a `codecommit` source validates without it. The S3 source `account_id` stays required, as an S3 source cannot fall back to a default account.
- In `PROVIDER_SCHEMA`, make the top-level `build` key `Optional(...)` so a pipeline validates without an explicit build block.

No runtime or CDK wiring changes are needed; both defaults were already handled downstream. Tests are added that validate a `codecommit` source without an `account_id` and a pipeline without a `build` block through the public `SchemaValidation` interface, alongside negative cases ensuring a malformed account id and an invalid build provider still fail.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
